### PR TITLE
Studio v3 friendly

### DIFF
--- a/.github/workflows/dev-applications-deploy.yml
+++ b/.github/workflows/dev-applications-deploy.yml
@@ -2,7 +2,7 @@ name: Dev - Applications - Deploy
 
 env:
   SOURCE_PATH: 'Source/Applications'
-  DEPLOYMENT_NAME: 'studio-dev-applications'
+  DEPLOYMENT_NAME: 'dev-applications'
   DOCKER_IMAGE_TAG: 'dolittle/studio/applications'
   DOCKER_FILE: 'Source/Applications/Backend/Dockerfile'
 

--- a/.github/workflows/dev-data-deploy.yml
+++ b/.github/workflows/dev-data-deploy.yml
@@ -2,7 +2,7 @@ name: Dev - Data - Deploy
 
 env:
   SOURCE_PATH: "Source/Data"
-  DEPLOYMENT_NAME: "studio-dev-data"
+  DEPLOYMENT_NAME: "dev-data"
   DOCKER_IMAGE_TAG: "dolittle/studio/data"
   DOCKER_FILE: "Source/Data/Backend/Dockerfile"
 

--- a/.github/workflows/dev-events-deploy.yml
+++ b/.github/workflows/dev-events-deploy.yml
@@ -2,7 +2,7 @@ name: Dev - Events - Deploy
 
 env:
   SOURCE_PATH: 'Source/Events'
-  DEPLOYMENT_NAME: 'studio-dev-events'
+  DEPLOYMENT_NAME: 'dev-events'
   DOCKER_IMAGE_TAG: 'dolittle/studio/events'
   DOCKER_FILE: 'Source/Events/Backend/Dockerfile'
 

--- a/.github/workflows/dev-portal-deploy.yml
+++ b/.github/workflows/dev-portal-deploy.yml
@@ -2,7 +2,7 @@ name: Dev - Portal - Deploy
 
 env:
   SOURCE_PATH: 'Source/Portal'
-  DEPLOYMENT_NAME: 'studio-dev-portal'
+  DEPLOYMENT_NAME: 'dev-portal'
   DOCKER_IMAGE_TAG: 'dolittle/studio/portal'
   DOCKER_FILE: 'Source/Portal/Backend/Dockerfile'
 

--- a/.github/workflows/prod-applications-deploy.yml
+++ b/.github/workflows/prod-applications-deploy.yml
@@ -2,7 +2,7 @@ name: Prod - Applications - Deploy
 
 env:
   SOURCE_PATH: 'Source/Applications'
-  DEPLOYMENT_NAME: 'studio-prod-applications'
+  DEPLOYMENT_NAME: 'prod-applications'
   DOCKER_IMAGE_TAG: 'dolittle/studio/applications'
   DOCKER_FILE: 'Source/Applications/Backend/Dockerfile'
 

--- a/.github/workflows/prod-data-deploy.yml
+++ b/.github/workflows/prod-data-deploy.yml
@@ -2,7 +2,7 @@ name: Prod - Data - Deploy
 
 env:
   SOURCE_PATH: "Source/Data"
-  DEPLOYMENT_NAME: "studio-prod-data"
+  DEPLOYMENT_NAME: "prod-data"
   DOCKER_IMAGE_TAG: "dolittle/studio/data"
   DOCKER_FILE: "Source/Data/Backend/Dockerfile"
 

--- a/.github/workflows/prod-events-deploy.yml
+++ b/.github/workflows/prod-events-deploy.yml
@@ -2,7 +2,7 @@ name: Prod - Events - Deploy
 
 env:
   SOURCE_PATH: 'Source/Events'
-  DEPLOYMENT_NAME: 'studio-prod-events'
+  DEPLOYMENT_NAME: 'prod-events'
   DOCKER_IMAGE_TAG: 'dolittle/studio/events'
   DOCKER_FILE: 'Source/Events/Backend/Dockerfile'
 

--- a/.github/workflows/prod-portal-deploy.yml
+++ b/.github/workflows/prod-portal-deploy.yml
@@ -2,7 +2,7 @@ name: Prod - Portal - Deploy
 
 env:
   SOURCE_PATH: 'Source/Portal'
-  DEPLOYMENT_NAME: 'studio-prod-portal'
+  DEPLOYMENT_NAME: 'prod-portal'
   DOCKER_IMAGE_TAG: 'dolittle/studio/portal'
   DOCKER_FILE: 'Source/Portal/Backend/Dockerfile'
 

--- a/Documentation/cloud-environment.md
+++ b/Documentation/cloud-environment.md
@@ -37,36 +37,36 @@ For more details on how to update configuration and work with this in the Dolitt
 | Type | Environment | Value |
 | ---- | ----------- | ----- |
 | Image repository | All | 508c17455f2a4b4cb7a52fbb1484346d.azurecr.io/dolittle/studio/harvest |
-| Deployment name  | Dev | studio-dev-portal |
-| ConfigMap name   | Dev | studio-dev-portal-config-files |
-| Env. Variables name | Dev | studio-dev-portal-env-variables |
-| Deployment name  | Prod | studio-prod-portal |
-| ConfigMap name   | Prod | studio-prod-portal-config-files |
-| Env. Variables name | Prod | studio-prod-portal-env-variables |
+| Deployment name  | Dev | dev-portal |
+| ConfigMap name   | Dev | dev-portal-config-files |
+| Env. Variables name | Dev | dev-portal-env-variables |
+| Deployment name  | Prod | prod-portal |
+| ConfigMap name   | Prod | prod-portal-config-files |
+| Env. Variables name | Prod | prod-portal-env-variables |
 
 ### Applications
 
 | Type | Environment | Value |
 | ---- | ----------- | ----- |
 | Image repository | All | 508c17455f2a4b4cb7a52fbb1484346d.azurecr.io/dolittle/studio/harvest |
-| Deployment name  | Dev | studio-dev-applications |
-| ConfigMap name   | Dev | studio-dev-applications-config-files |
-| Env. Variables name | Dev | studio-dev-applications-env-variables |
-| Deployment name  | Prod | studio-prod-applications |
-| ConfigMap name   | Prod | studio-prod-applications-config-files |
-| Env. Variables name | Prod | studio-prod-applications-env-variables |
+| Deployment name  | Dev | dev-applications |
+| ConfigMap name   | Dev | dev-applications-config-files |
+| Env. Variables name | Dev | dev-applications-env-variables |
+| Deployment name  | Prod | prod-applications |
+| ConfigMap name   | Prod | prod-applications-config-files |
+| Env. Variables name | Prod | prod-applications-env-variables |
 
 ### Events
 
 | Type | Environment | Value |
 | ---- | ----------- | ----- |
 | Image repository | All | 508c17455f2a4b4cb7a52fbb1484346d.azurecr.io/dolittle/studio/harvest |
-| Deployment name  | Dev | studio-dev-events |
-| ConfigMap name   | Dev | studio-dev-events-config-files |
-| Env. Variables name | Dev | studio-dev-events-env-variables |
-| Deployment name  | Prod | studio-prod-events |
-| ConfigMap name   | Prod | studio-prod-events-config-files |
-| Env. Variables name | Prod | studio-prod-events-env-variables |
+| Deployment name  | Dev | dev-events |
+| ConfigMap name   | Dev | dev-events-config-files |
+| Env. Variables name | Dev | dev-events-env-variables |
+| Deployment name  | Prod | prod-events |
+| ConfigMap name   | Prod | prod-events-config-files |
+| Env. Variables name | Prod | prod-events-env-variables |
 
 ## Kubernetes
 
@@ -96,11 +96,11 @@ By using the `kubectl logs` command you can get logs for a container within a po
 For instance if we want to look at the runtime logs for the applications microservice using the pod identifier from the `get pods` command:
 
 ```shell
-$ kubectl logs studio-dev-applications-5c59ff4c4-mjtgb -c runtime
+$ kubectl logs dev-applications-5c59ff4c4-mjtgb -c runtime
 ```
 
 For the head, which is the backend code of the microservice:
 
 ```shell
-$ kubectl logs studio-dev-applications-5c59ff4c4-mjtgb -c head
+$ kubectl logs dev-applications-5c59ff4c4-mjtgb -c head
 ```

--- a/Source/Applications/Backend/listing/ApplicationForListingQueries.ts
+++ b/Source/Applications/Backend/listing/ApplicationForListingQueries.ts
@@ -29,11 +29,11 @@ export class ApplicationForListingQueries {
                 return { namespace, deployments };
             })))
             .map(async ({ namespace, deployments }) => {
-                const guid = namespace.metadata?.name?.replace('application-', '');
+                const guid = namespace.metadata!.annotations['dolittle.io/application-id'];
 
                 const application = new ApplicationForListing();
                 application._id = guid;
-                application.name = namespace.metadata?.labels?.application ?? '[Not Set]';
+                application.name = namespace.metadata!.labels!.application;
 
                 application.microservices = deployments
                     .filter(_ => _.metadata?.labels?.microservice)

--- a/Source/Applications/Backend/listing/ApplicationForListingQueries.ts
+++ b/Source/Applications/Backend/listing/ApplicationForListingQueries.ts
@@ -29,8 +29,7 @@ export class ApplicationForListingQueries {
                 return { namespace, deployments };
             })))
             .map(async ({ namespace, deployments }) => {
-                // What is going on
-                const guid = namespace?.metadata?.annotations['dolittle.io/application-id'];
+                const guid = namespace.metadata!.annotations!['dolittle.io/application-id'];
 
                 const application = new ApplicationForListing();
                 application._id = guid;

--- a/Source/Applications/Backend/listing/ApplicationForListingQueries.ts
+++ b/Source/Applications/Backend/listing/ApplicationForListingQueries.ts
@@ -29,7 +29,7 @@ export class ApplicationForListingQueries {
                 return { namespace, deployments };
             })))
             .map(async ({ namespace, deployments }) => {
-                const guid = namespace.metadata?.annotations['dolittle.io/application-id'];
+                const guid = namespace!.metadata?.annotations['dolittle.io/application-id'];
 
                 const application = new ApplicationForListing();
                 application._id = guid;

--- a/Source/Applications/Backend/listing/ApplicationForListingQueries.ts
+++ b/Source/Applications/Backend/listing/ApplicationForListingQueries.ts
@@ -29,7 +29,8 @@ export class ApplicationForListingQueries {
                 return { namespace, deployments };
             })))
             .map(async ({ namespace, deployments }) => {
-                const guid = namespace!.metadata?.annotations['dolittle.io/application-id'];
+                // What is going on
+                const guid = namespace?.metadata?.annotations['dolittle.io/application-id'];
 
                 const application = new ApplicationForListing();
                 application._id = guid;

--- a/Source/Applications/Backend/listing/ApplicationForListingQueries.ts
+++ b/Source/Applications/Backend/listing/ApplicationForListingQueries.ts
@@ -29,7 +29,7 @@ export class ApplicationForListingQueries {
                 return { namespace, deployments };
             })))
             .map(async ({ namespace, deployments }) => {
-                const guid = namespace.metadata!.annotations['dolittle.io/application-id'];
+                const guid = namespace.metadata?.annotations['dolittle.io/application-id'];
 
                 const application = new ApplicationForListing();
                 application._id = guid;

--- a/Source/Applications/k8s/Development/configmap.yml
+++ b/Source/Applications/k8s/Development/configmap.yml
@@ -15,9 +15,9 @@ metadata:
   namespace: application-fe7736bb-57fc-4166-bb91-6954f4dd4eb7
 data:
   NODE_ENV: "production"
-  DATABASE_HOST: "studio-dev-mongo.application-fe7736bb-57fc-4166-bb91-6954f4dd4eb7.svc.cluster.local"
+  DATABASE_HOST: "dev-mongo.application-fe7736bb-57fc-4166-bb91-6954f4dd4eb7.svc.cluster.local"
   DATABASE_NAME: "studio_dev_applications_readmodels"
-  EVENTSTORE_HOST: "studio-dev-mongo.application-fe7736bb-57fc-4166-bb91-6954f4dd4eb7.svc.cluster.local"
+  EVENTSTORE_HOST: "dev-mongo.application-fe7736bb-57fc-4166-bb91-6954f4dd4eb7.svc.cluster.local"
   EVENTSTORE_NAME: "studio_dev_applications_eventstore"
   PORT: "80"
   DOLITTLE_RUNTIME_PORT: "50053"

--- a/Source/Applications/k8s/Development/configmap.yml
+++ b/Source/Applications/k8s/Development/configmap.yml
@@ -2,12 +2,17 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  namespace: application-fe7736bb-57fc-4166-bb91-6954f4dd4eb7
-  name: studio-dev-applications-env-variables
+  annotations:
+    dolittle.io/tenant-id: 508c1745-5f2a-4b4c-b7a5-2fbb1484346d
+    dolittle.io/application-id: fe7736bb-57fc-4166-bb91-6954f4dd4eb7
+    dolittle.io/microservice-id: 05a823dd-0f0d-4157-bc46-14834cca3cd2
   labels:
     tenant: Dolittle
-    application: Studio-Dev
+    application: Studio
+    environment: Dev
     microservice: Applications
+  name: dev-applications-env-variables
+  namespace: application-fe7736bb-57fc-4166-bb91-6954f4dd4eb7
 data:
   NODE_ENV: "production"
   DATABASE_HOST: "studio-dev-mongo.application-fe7736bb-57fc-4166-bb91-6954f4dd4eb7.svc.cluster.local"
@@ -21,11 +26,16 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  namespace: application-fe7736bb-57fc-4166-bb91-6954f4dd4eb7
-  name: studio-dev-applications-config-files
+  annotations:
+    dolittle.io/tenant-id: 508c1745-5f2a-4b4c-b7a5-2fbb1484346d
+    dolittle.io/application-id: fe7736bb-57fc-4166-bb91-6954f4dd4eb7
+    dolittle.io/microservice-id: 05a823dd-0f0d-4157-bc46-14834cca3cd2
   labels:
     tenant: Dolittle
-    application: Studio-Dev
+    application: Studio
+    environment: Dev
     microservice: Applications
+  name: dev-applications-config-files
+  namespace: application-fe7736bb-57fc-4166-bb91-6954f4dd4eb7
 data:
 

--- a/Source/Applications/k8s/Development/patch.sh
+++ b/Source/Applications/k8s/Development/patch.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-kubectl patch --namespace application-fe7736bb-57fc-4166-bb91-6954f4dd4eb7 deployment studio-dev-applications -p '{"spec": { "template": {"metadata": { "labels": { "date": "'`date +'%s'`'" } }}}}'
+kubectl patch --namespace application-fe7736bb-57fc-4166-bb91-6954f4dd4eb7 deployment dev-applications -p '{"spec": { "template": {"metadata": { "labels": { "date": "'`date +'%s'`'" } }}}}'

--- a/Source/Applications/k8s/Production/configmap.yml
+++ b/Source/Applications/k8s/Production/configmap.yml
@@ -2,17 +2,22 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  namespace: application-fe7736bb-57fc-4166-bb91-6954f4dd4eb7
-  name: studio-prod-applications-env-variables
+  annotations:
+    dolittle.io/tenant-id: 508c1745-5f2a-4b4c-b7a5-2fbb1484346d
+    dolittle.io/application-id: fe7736bb-57fc-4166-bb91-6954f4dd4eb7
+    dolittle.io/microservice-id: 05a823dd-0f0d-4157-bc46-14834cca3cd2
   labels:
     tenant: Dolittle
-    application: Studio-Prod
+    application: Studio
+    environment: Prod
     microservice: Applications
+  name: prod-applications-env-variables
+  namespace: application-fe7736bb-57fc-4166-bb91-6954f4dd4eb7
 data:
   NODE_ENV: "production"
-  DATABASE_HOST: "studio-prod-mongo.application-fe7736bb-57fc-4166-bb91-6954f4dd4eb7.svc.cluster.local"
+  DATABASE_HOST: "prod-mongo.application-fe7736bb-57fc-4166-bb91-6954f4dd4eb7.svc.cluster.local"
   DATABASE_NAME: "studio_prod_applications_readmodels"
-  EVENTSTORE_HOST: "studio-prod-mongo.application-fe7736bb-57fc-4166-bb91-6954f4dd4eb7.svc.cluster.local"
+  EVENTSTORE_HOST: "prod-mongo.application-fe7736bb-57fc-4166-bb91-6954f4dd4eb7.svc.cluster.local"
   EVENTSTORE_NAME: "studio_prod_applications_eventstore"
   PORT: "80"
   DOLITTLE_RUNTIME_PORT: "50053"
@@ -21,8 +26,17 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
+  annotations:
+    dolittle.io/tenant-id: 508c1745-5f2a-4b4c-b7a5-2fbb1484346d
+    dolittle.io/application-id: fe7736bb-57fc-4166-bb91-6954f4dd4eb7
+    dolittle.io/microservice-id: 05a823dd-0f0d-4157-bc46-14834cca3cd2
+  labels:
+    tenant: Dolittle
+    application: Studio
+    environment: Prod
+    microservice: Applications
+  name: prod-applications-config-files
   namespace: application-fe7736bb-57fc-4166-bb91-6954f4dd4eb7
-  name: studio-prod-applications-config-files
   labels:
     tenant: Dolittle
     application: Studio-Prod

--- a/Source/Applications/k8s/Production/configmap.yml
+++ b/Source/Applications/k8s/Production/configmap.yml
@@ -39,7 +39,7 @@ metadata:
   namespace: application-fe7736bb-57fc-4166-bb91-6954f4dd4eb7
   labels:
     tenant: Dolittle
-    application: Studio-Prod
+    application: Studio
     microservice: Applications
 data:
 

--- a/Source/Applications/k8s/Production/patch.sh
+++ b/Source/Applications/k8s/Production/patch.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-kubectl patch --namespace application-fe7736bb-57fc-4166-bb91-6954f4dd4eb7 deployment studio-prod-applications -p '{"spec": { "template": {"metadata": { "labels": { "date": "'`date +'%s'`'" } }}}}'
+kubectl patch --namespace application-fe7736bb-57fc-4166-bb91-6954f4dd4eb7 deployment prod-applications -p '{"spec": { "template": {"metadata": { "labels": { "date": "'`date +'%s'`'" } }}}}'

--- a/Source/Data/Backend/backups/BackupForListingQueries.ts
+++ b/Source/Data/Backend/backups/BackupForListingQueries.ts
@@ -28,7 +28,7 @@ export class BackupForListingQueries {
             {
                 id: Guid.parse('4221cedd-8d25-4a7c-8745-d55cebeccbfb'),
                 applicationId: Guid.parse('853ebea1-1e6b-4fee-9855-10d1df5cad1e'),
-                microservice: 'studio-dev-applications',
+                microservice: 'dev-applications',
                 tenantId: Guid.parse('84d94e56-948f-4734-9b4a-b48386a6109d'),
                 name: 'Applications dev backup',
                 date: new Date(2021, 1, 21, 11, 37)
@@ -36,7 +36,7 @@ export class BackupForListingQueries {
             {
                 id: Guid.parse('982f3f26-2e49-472c-9442-4d11b373060e'),
                 applicationId: Guid.parse('853ebea1-1e6b-4fee-9855-10d1df5cad1e'),
-                microservice: 'studio-dev-applications',
+                microservice: 'dev-applications',
                 tenantId: Guid.parse('ff5948e6-dc81-4132-918f-50b42d5fe6b6'),
                 name: 'Applications dev backup',
                 date: new Date(2021, 1, 21, 11, 39)
@@ -44,7 +44,7 @@ export class BackupForListingQueries {
             {
                 id: Guid.parse('58151228-a2fb-4ba2-aabc-5e50f35e0ffd'),
                 applicationId: Guid.parse('853ebea1-1e6b-4fee-9855-10d1df5cad1e'),
-                microservice: 'studio-dev-events',
+                microservice: 'dev-events',
                 tenantId: Guid.parse('84d94e56-948f-4734-9b4a-b48386a6109d'),
                 name: 'Ultimate backup',
                 date: new Date(2021, 1, 23, 13, 37)
@@ -52,7 +52,7 @@ export class BackupForListingQueries {
             {
                 id: Guid.parse('213ff215-3395-4142-8a3a-aebdb26de8fd'),
                 applicationId: Guid.parse('853ebea1-1e6b-4fee-9855-10d1df5cad1e'),
-                microservice: 'studio-dev-events',
+                microservice: 'dev-events',
                 tenantId: Guid.parse('84d94e56-948f-4734-9b4a-b48386a6109d'),
                 name: 'Ultimate backup',
                 date: new Date(2021, 1, 23, 12, 37)
@@ -60,7 +60,7 @@ export class BackupForListingQueries {
             {
                 id: Guid.parse('3324d5e5-e2cc-4654-9b12-f8aaa156f2f7'),
                 applicationId: Guid.parse('853ebea1-1e6b-4fee-9855-10d1df5cad1e'),
-                microservice: 'studio-dev-events',
+                microservice: 'dev-events',
                 tenantId: Guid.parse('ff5948e6-dc81-4132-918f-50b42d5fe6b6'),
                 name: 'Ultimate backup',
                 date: new Date(2021, 1, 23, 12, 39)
@@ -68,7 +68,7 @@ export class BackupForListingQueries {
             {
                 id: Guid.parse('45309fb6-2e0f-43d1-9665-325099a6aaf6'),
                 applicationId: Guid.parse('853ebea1-1e6b-4fee-9855-10d1df5cad1e'),
-                microservice: 'studio-dev-portal',
+                microservice: 'dev-portal',
                 tenantId: Guid.parse('84d94e56-948f-4734-9b4a-b48386a6109d'),
                 name: 'All the events and then some',
                 date: new Date(2021, 1, 21, 12, 37)
@@ -76,7 +76,7 @@ export class BackupForListingQueries {
             {
                 id: Guid.parse('61376499-a307-4f17-b528-5afba2f952d2'),
                 applicationId: Guid.parse('853ebea1-1e6b-4fee-9855-10d1df5cad1e'),
-                microservice: 'studio-dev-portal',
+                microservice: 'dev-portal',
                 tenantId: Guid.parse('84d94e56-948f-4734-9b4a-b48386a6109d'),
                 name: 'All the events and then some',
                 date: new Date(2021, 1, 21, 12, 37)
@@ -84,7 +84,7 @@ export class BackupForListingQueries {
             {
                 id: Guid.parse('25e85230-7cf2-4ac6-ab4c-48b31875d855'),
                 applicationId: Guid.parse('853ebea1-1e6b-4fee-9855-10d1df5cad1e'),
-                microservice: 'studio-dev-portal',
+                microservice: 'dev-portal',
                 tenantId: Guid.parse('d3472df7-0720-4d53-b2c8-9289dccd4e98'),
                 name: 'All the events and then some',
                 date: new Date(2021, 1, 21, 11, 35)

--- a/Source/Data/Backend/listing/ApplicationForListingQueries.ts
+++ b/Source/Data/Backend/listing/ApplicationForListingQueries.ts
@@ -29,11 +29,11 @@ export class ApplicationForListingQueries {
                 return { namespace, deployments };
             })))
             .map(async ({ namespace, deployments }) => {
-                const guid = namespace.metadata?.name?.replace('application-', '');
+                const guid = namespace.metadata!.annotations['dolittle.io/application-id'];
 
                 const application = new ApplicationForListing();
                 application._id = guid;
-                application.name = namespace.metadata?.labels?.application ?? '[Not Set]';
+                application.name = namespace.metadata!.labels!.application;
 
                 application.microservices = deployments
                     .filter(_ => _.metadata?.labels?.microservice)

--- a/Source/Data/Backend/listing/ApplicationForListingQueries.ts
+++ b/Source/Data/Backend/listing/ApplicationForListingQueries.ts
@@ -29,7 +29,7 @@ export class ApplicationForListingQueries {
                 return { namespace, deployments };
             })))
             .map(async ({ namespace, deployments }) => {
-                const guid = namespace.metadata?.annotations?['dolittle.io/application-id'];
+                const guid = namespace.metadata?.annotations['dolittle.io/application-id'];
 
                 const application = new ApplicationForListing();
                 application._id = guid;

--- a/Source/Data/Backend/listing/ApplicationForListingQueries.ts
+++ b/Source/Data/Backend/listing/ApplicationForListingQueries.ts
@@ -29,7 +29,7 @@ export class ApplicationForListingQueries {
                 return { namespace, deployments };
             })))
             .map(async ({ namespace, deployments }) => {
-                const guid = namespace!.metadata?.annotations['dolittle.io/application-id'];
+                const guid = namespace.metadata!.annotations!['dolittle.io/application-id'];
 
                 const application = new ApplicationForListing();
                 application._id = guid;

--- a/Source/Data/Backend/listing/ApplicationForListingQueries.ts
+++ b/Source/Data/Backend/listing/ApplicationForListingQueries.ts
@@ -29,7 +29,7 @@ export class ApplicationForListingQueries {
                 return { namespace, deployments };
             })))
             .map(async ({ namespace, deployments }) => {
-                const guid = namespace.metadata?.annotations['dolittle.io/application-id'];
+                const guid = namespace!.metadata?.annotations['dolittle.io/application-id'];
 
                 const application = new ApplicationForListing();
                 application._id = guid;

--- a/Source/Data/Backend/listing/ApplicationForListingQueries.ts
+++ b/Source/Data/Backend/listing/ApplicationForListingQueries.ts
@@ -29,7 +29,7 @@ export class ApplicationForListingQueries {
                 return { namespace, deployments };
             })))
             .map(async ({ namespace, deployments }) => {
-                const guid = namespace.metadata?.annotations['dolittle.io/application-id'];
+                const guid = namespace.metadata?.annotations?['dolittle.io/application-id'];
 
                 const application = new ApplicationForListing();
                 application._id = guid;

--- a/Source/Data/Backend/listing/ApplicationForListingQueries.ts
+++ b/Source/Data/Backend/listing/ApplicationForListingQueries.ts
@@ -29,7 +29,7 @@ export class ApplicationForListingQueries {
                 return { namespace, deployments };
             })))
             .map(async ({ namespace, deployments }) => {
-                const guid = namespace.metadata!.annotations['dolittle.io/application-id'];
+                const guid = namespace.metadata?.annotations['dolittle.io/application-id'];
 
                 const application = new ApplicationForListing();
                 application._id = guid;

--- a/Source/Data/k8s/Development/configmap.yml
+++ b/Source/Data/k8s/Development/configmap.yml
@@ -2,13 +2,17 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  namespace: application-fe7736bb-57fc-4166-bb91-6954f4dd4eb7
-  name: studio-dev-data-env-variables
+  annotations:
+    dolittle.io/tenant-id: 508c1745-5f2a-4b4c-b7a5-2fbb1484346d
+    dolittle.io/application-id: fe7736bb-57fc-4166-bb91-6954f4dd4eb7
+    dolittle.io/microservice-id: 05a823dd-0f0d-4157-bc46-14834cca3cd2
   labels:
     tenant: Dolittle
-    application: Studio-Dev
-    microservice: Data
+    application: Studio
     environment: Dev
+    microservice: Data
+  name: dev-data-env-variables
+  namespace: application-fe7736bb-57fc-4166-bb91-6954f4dd4eb7
 data:
   NODE_ENV: "production"
   DATABASE_HOST: "studio-dev-mongo.application-fe7736bb-57fc-4166-bb91-6954f4dd4eb7.svc.cluster.local"
@@ -23,11 +27,15 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  namespace: application-fe7736bb-57fc-4166-bb91-6954f4dd4eb7
-  name: studio-dev-data-config-files
+  annotations:
+    dolittle.io/tenant-id: 508c1745-5f2a-4b4c-b7a5-2fbb1484346d
+    dolittle.io/application-id: fe7736bb-57fc-4166-bb91-6954f4dd4eb7
+    dolittle.io/microservice-id: 05a823dd-0f0d-4157-bc46-14834cca3cd2
   labels:
     tenant: Dolittle
-    application: Studio-Dev
-    microservice: Data
+    application: Studio
     environment: Dev
+    microservice: Data
+  name: dev-data-config-files
+  namespace: application-fe7736bb-57fc-4166-bb91-6954f4dd4eb7
 data:

--- a/Source/Data/k8s/Development/configmap.yml
+++ b/Source/Data/k8s/Development/configmap.yml
@@ -15,9 +15,9 @@ metadata:
   namespace: application-fe7736bb-57fc-4166-bb91-6954f4dd4eb7
 data:
   NODE_ENV: "production"
-  DATABASE_HOST: "studio-dev-mongo.application-fe7736bb-57fc-4166-bb91-6954f4dd4eb7.svc.cluster.local"
+  DATABASE_HOST: "dev-mongo.application-fe7736bb-57fc-4166-bb91-6954f4dd4eb7.svc.cluster.local"
   DATABASE_NAME: "read_models_data"
-  EVENTSTORE_HOST: "studio-dev-mongo.application-fe7736bb-57fc-4166-bb91-6954f4dd4eb7.svc.cluster.local"
+  EVENTSTORE_HOST: "dev-mongo.application-fe7736bb-57fc-4166-bb91-6954f4dd4eb7.svc.cluster.local"
   EVENTSTORE_NAME: "event_store_data"
   DOLITTLE_RUNTIME_HOST: "localhost"
   DOLITTLE_RUNTIME_PORT: "50053"

--- a/Source/Data/k8s/Development/patch.sh
+++ b/Source/Data/k8s/Development/patch.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-kubectl patch --namespace application-fe7736bb-57fc-4166-bb91-6954f4dd4eb7 deployment studio-dev-data -p '{"spec": { "template": {"metadata": { "labels": { "date": "'`date +'%s'`'" } }}}}'
+kubectl patch --namespace application-fe7736bb-57fc-4166-bb91-6954f4dd4eb7 deployment dev-data -p '{"spec": { "template": {"metadata": { "labels": { "date": "'`date +'%s'`'" } }}}}'

--- a/Source/Data/k8s/Production/configmap.yml
+++ b/Source/Data/k8s/Production/configmap.yml
@@ -2,12 +2,17 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  namespace: application-fe7736bb-57fc-4166-bb91-6954f4dd4eb7
-  name: studio-prod-data-env-variables
+  annotations:
+    dolittle.io/tenant-id: 508c1745-5f2a-4b4c-b7a5-2fbb1484346d
+    dolittle.io/application-id: fe7736bb-57fc-4166-bb91-6954f4dd4eb7
+    dolittle.io/microservice-id: 7d2433e2-84a1-b84b-a098-5bf52f985e5a
   labels:
     tenant: Dolittle
-    application: Studio-Prod
+    application: Studio
+    environment: Prod
     microservice: Data
+  name: prod-data-env-variables
+  namespace: application-fe7736bb-57fc-4166-bb91-6954f4dd4eb7
 data:
   NODE_ENV: "production"
   DATABASE_HOST: "studio-prod-mongo.application-fe7736bb-57fc-4166-bb91-6954f4dd4eb7.svc.cluster.local"
@@ -22,10 +27,15 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  namespace: application-fe7736bb-57fc-4166-bb91-6954f4dd4eb7
-  name: studio-prod-data-config-files
+  annotations:
+    dolittle.io/tenant-id: 508c1745-5f2a-4b4c-b7a5-2fbb1484346d
+    dolittle.io/application-id: fe7736bb-57fc-4166-bb91-6954f4dd4eb7
+    dolittle.io/microservice-id: 7d2433e2-84a1-b84b-a098-5bf52f985e5a
   labels:
     tenant: Dolittle
-    application: Studio-Prod
+    application: Studio
+    environment: Prod
     microservice: Data
+  name: prod-data-config-files
+  namespace: application-fe7736bb-57fc-4166-bb91-6954f4dd4eb7
 data:

--- a/Source/Data/k8s/Production/configmap.yml
+++ b/Source/Data/k8s/Production/configmap.yml
@@ -15,9 +15,9 @@ metadata:
   namespace: application-fe7736bb-57fc-4166-bb91-6954f4dd4eb7
 data:
   NODE_ENV: "production"
-  DATABASE_HOST: "studio-prod-mongo.application-fe7736bb-57fc-4166-bb91-6954f4dd4eb7.svc.cluster.local"
+  DATABASE_HOST: "prod-mongo.application-fe7736bb-57fc-4166-bb91-6954f4dd4eb7.svc.cluster.local"
   DATABASE_NAME: "read_models_data"
-  EVENTSTORE_HOST: "studio-prod-mongo.application-fe7736bb-57fc-4166-bb91-6954f4dd4eb7.svc.cluster.local"
+  EVENTSTORE_HOST: "prod-mongo.application-fe7736bb-57fc-4166-bb91-6954f4dd4eb7.svc.cluster.local"
   EVENTSTORE_NAME: "event_store_data"
   DOLITTLE_RUNTIME_HOST: "localhost"
   DOLITTLE_RUNTIME_PORT: "50053"

--- a/Source/Data/k8s/Production/patch.sh
+++ b/Source/Data/k8s/Production/patch.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-kubectl patch --namespace application-fe7736bb-57fc-4166-bb91-6954f4dd4eb7 deployment studio-prod-data
+kubectl patch --namespace application-fe7736bb-57fc-4166-bb91-6954f4dd4eb7 deployment prod-data

--- a/Source/Events/k8s/Development/configmap.yml
+++ b/Source/Events/k8s/Development/configmap.yml
@@ -2,12 +2,17 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  namespace: application-fe7736bb-57fc-4166-bb91-6954f4dd4eb7
-  name: studio-dev-events-env-variables
+  annotations:
+    dolittle.io/tenant-id: 508c1745-5f2a-4b4c-b7a5-2fbb1484346d
+    dolittle.io/application-id: fe7736bb-57fc-4166-bb91-6954f4dd4eb7
+    dolittle.io/microservice-id: 81cad113-a001-45dc-86cb-7b1e725ae25e
   labels:
     tenant: Dolittle
-    application: Studio-Dev
+    application: Studio
+    environment: Dev
     microservice: Events
+  name: dev-events-env-variables
+  namespace: application-fe7736bb-57fc-4166-bb91-6954f4dd4eb7
 data:
   NODE_ENV: "production"
   DATABASE_HOST: "studio-dev-mongo.application-fe7736bb-57fc-4166-bb91-6954f4dd4eb7.svc.cluster.local"
@@ -21,11 +26,16 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  namespace: application-fe7736bb-57fc-4166-bb91-6954f4dd4eb7
-  name: studio-dev-events-config-files
+  annotations:
+    dolittle.io/tenant-id: 508c1745-5f2a-4b4c-b7a5-2fbb1484346d
+    dolittle.io/application-id: fe7736bb-57fc-4166-bb91-6954f4dd4eb7
+    dolittle.io/microservice-id: 81cad113-a001-45dc-86cb-7b1e725ae25e
   labels:
     tenant: Dolittle
-    application: Studio-Dev
+    application: Studio
+    environment: Dev
     microservice: Events
+  name: dev-events-config-files
+  namespace: application-fe7736bb-57fc-4166-bb91-6954f4dd4eb7
 data:
 

--- a/Source/Events/k8s/Development/configmap.yml
+++ b/Source/Events/k8s/Development/configmap.yml
@@ -15,9 +15,9 @@ metadata:
   namespace: application-fe7736bb-57fc-4166-bb91-6954f4dd4eb7
 data:
   NODE_ENV: "production"
-  DATABASE_HOST: "studio-dev-mongo.application-fe7736bb-57fc-4166-bb91-6954f4dd4eb7.svc.cluster.local"
+  DATABASE_HOST: "dev-mongo.application-fe7736bb-57fc-4166-bb91-6954f4dd4eb7.svc.cluster.local"
   DATABASE_NAME: "studio_dev_events_readmodels"
-  EVENTSTORE_HOST: "studio-dev-mongo.application-fe7736bb-57fc-4166-bb91-6954f4dd4eb7.svc.cluster.local"
+  EVENTSTORE_HOST: "dev-mongo.application-fe7736bb-57fc-4166-bb91-6954f4dd4eb7.svc.cluster.local"
   EVENTSTORE_NAME: "studio_dev_events_eventstore"
   PORT: "80"
   DOLITTLE_RUNTIME_PORT: "50053"

--- a/Source/Events/k8s/Development/patch.sh
+++ b/Source/Events/k8s/Development/patch.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-kubectl patch --namespace application-fe7736bb-57fc-4166-bb91-6954f4dd4eb7 deployment studio-dev-events -p '{"spec": { "template": {"metadata": { "labels": { "date": "'`date +'%s'`'" } }}}}'
+kubectl patch --namespace application-fe7736bb-57fc-4166-bb91-6954f4dd4eb7 deployment dev-events -p '{"spec": { "template": {"metadata": { "labels": { "date": "'`date +'%s'`'" } }}}}'

--- a/Source/Events/k8s/Production/configmap.yml
+++ b/Source/Events/k8s/Production/configmap.yml
@@ -15,9 +15,9 @@ metadata:
   namespace: application-fe7736bb-57fc-4166-bb91-6954f4dd4eb7
 data:
   NODE_ENV: "production"
-  DATABASE_HOST: "studio-prod-mongo.application-fe7736bb-57fc-4166-bb91-6954f4dd4eb7.svc.cluster.local"
+  DATABASE_HOST: "prod-mongo.application-fe7736bb-57fc-4166-bb91-6954f4dd4eb7.svc.cluster.local"
   DATABASE_NAME: "studio_prod_events_readmodels"
-  EVENTSTORE_HOST: "studio-prod-mongo.application-fe7736bb-57fc-4166-bb91-6954f4dd4eb7.svc.cluster.local"
+  EVENTSTORE_HOST: "prod-mongo.application-fe7736bb-57fc-4166-bb91-6954f4dd4eb7.svc.cluster.local"
   EVENTSTORE_NAME: "studio_prod_events_eventstore"
   PORT: "80"
   DOLITTLE_RUNTIME_PORT: "50053"

--- a/Source/Events/k8s/Production/configmap.yml
+++ b/Source/Events/k8s/Production/configmap.yml
@@ -2,12 +2,17 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  namespace: application-fe7736bb-57fc-4166-bb91-6954f4dd4eb7
-  name: studio-prod-events-env-variables
+  annotations:
+    dolittle.io/tenant-id: 508c1745-5f2a-4b4c-b7a5-2fbb1484346d
+    dolittle.io/application-id: fe7736bb-57fc-4166-bb91-6954f4dd4eb7
+    dolittle.io/microservice-id: 81cad113-a001-45dc-86cb-7b1e725ae25e
   labels:
     tenant: Dolittle
-    application: Studio-Prod
+    application: Studio
+    environment: Prod
     microservice: Events
+  name: prod-events-env-variables
+  namespace: application-fe7736bb-57fc-4166-bb91-6954f4dd4eb7
 data:
   NODE_ENV: "production"
   DATABASE_HOST: "studio-prod-mongo.application-fe7736bb-57fc-4166-bb91-6954f4dd4eb7.svc.cluster.local"
@@ -21,11 +26,16 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  namespace: application-fe7736bb-57fc-4166-bb91-6954f4dd4eb7
-  name: studio-prod-events-config-files
+  annotations:
+    dolittle.io/tenant-id: 508c1745-5f2a-4b4c-b7a5-2fbb1484346d
+    dolittle.io/application-id: fe7736bb-57fc-4166-bb91-6954f4dd4eb7
+    dolittle.io/microservice-id: 81cad113-a001-45dc-86cb-7b1e725ae25e
   labels:
     tenant: Dolittle
-    application: Studio-Prod
+    application: Studio
+    environment: Prod
     microservice: Events
+  name: prod-events-config-files
+  namespace: application-fe7736bb-57fc-4166-bb91-6954f4dd4eb7
 data:
 

--- a/Source/Events/k8s/Production/patch.sh
+++ b/Source/Events/k8s/Production/patch.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-kubectl patch --namespace application-fe7736bb-57fc-4166-bb91-6954f4dd4eb7 deployment studio-prod-events -p '{"spec": { "template": {"metadata": { "labels": { "date": "'`date +'%s'`'" } }}}}'
+kubectl patch --namespace application-fe7736bb-57fc-4166-bb91-6954f4dd4eb7 deployment prod-events -p '{"spec": { "template": {"metadata": { "labels": { "date": "'`date +'%s'`'" } }}}}'

--- a/Source/K8sMock/Backend/configmaps/ConfigmapsController.ts
+++ b/Source/K8sMock/Backend/configmaps/ConfigmapsController.ts
@@ -18,7 +18,7 @@ export class ConfigmapsController extends Controller {
             {
                 {
                     this._configmaps.push(this.createConfigMap(
-                        'studio-dev-applications-env-variables',
+                        'dev-applications-env-variables',
                         'application-853ebea1-1e6b-4fee-9855-10d1df5cad1e',
                         {
                             tenant: 'Dolittle',
@@ -30,7 +30,7 @@ export class ConfigmapsController extends Controller {
                         }
                         ));
                     this._configmaps.push(this.createConfigMap(
-                        'studio-dev-applications-config-files',
+                        'dev-applications-config-files',
                         'application-853ebea1-1e6b-4fee-9855-10d1df5cad1e',
                         {
                             tenant: 'Dolittle',
@@ -44,7 +44,7 @@ export class ConfigmapsController extends Controller {
                 }
                 {
                     this._configmaps.push(this.createConfigMap(
-                        'studio-dev-events-env-variables',
+                        'dev-events-env-variables',
                         'application-853ebea1-1e6b-4fee-9855-10d1df5cad1e',
                         {
                             tenant: 'Dolittle',
@@ -56,7 +56,7 @@ export class ConfigmapsController extends Controller {
                         }
                         ));
                     this._configmaps.push(this.createConfigMap(
-                        'studio-dev-events-config-files',
+                        'dev-events-config-files',
                         'application-853ebea1-1e6b-4fee-9855-10d1df5cad1e',
                         {
                             tenant: 'Dolittle',
@@ -70,7 +70,7 @@ export class ConfigmapsController extends Controller {
                 }
                 {
                     this._configmaps.push(this.createConfigMap(
-                        'studio-dev-portal-env-variables',
+                        'dev-portal-env-variables',
                         'application-853ebea1-1e6b-4fee-9855-10d1df5cad1e',
                         {
                             tenant: 'Dolittle',
@@ -82,7 +82,7 @@ export class ConfigmapsController extends Controller {
                         }
                         ));
                     this._configmaps.push(this.createConfigMap(
-                        'studio-dev-portal-config-files',
+                        'dev-portal-config-files',
                         'application-853ebea1-1e6b-4fee-9855-10d1df5cad1e',
                         {
                             tenant: 'Dolittle',
@@ -98,7 +98,7 @@ export class ConfigmapsController extends Controller {
             {
                 {
                     this._configmaps.push(this.createConfigMap(
-                        'studio-prod-applications-env-variables',
+                        'prod-applications-env-variables',
                         'application-853ebea1-1e6b-4fee-9855-10d1df5cad1e',
                         {
                             tenant: 'Dolittle',
@@ -110,7 +110,7 @@ export class ConfigmapsController extends Controller {
                         }
                         ));
                     this._configmaps.push(this.createConfigMap(
-                        'studio-prod-applications-config-files',
+                        'prod-applications-config-files',
                         'application-853ebea1-1e6b-4fee-9855-10d1df5cad1e',
                         {
                             tenant: 'Dolittle',
@@ -124,7 +124,7 @@ export class ConfigmapsController extends Controller {
                 }
                 {
                     this._configmaps.push(this.createConfigMap(
-                        'studio-prod-events-env-variables',
+                        'prod-events-env-variables',
                         'application-853ebea1-1e6b-4fee-9855-10d1df5cad1e',
                         {
                             tenant: 'Dolittle',
@@ -136,7 +136,7 @@ export class ConfigmapsController extends Controller {
                         }
                         ));
                     this._configmaps.push(this.createConfigMap(
-                        'studio-prod-events-config-files',
+                        'prod-events-config-files',
                         'application-853ebea1-1e6b-4fee-9855-10d1df5cad1e',
                         {
                             tenant: 'Dolittle',
@@ -150,7 +150,7 @@ export class ConfigmapsController extends Controller {
                 }
                 {
                     this._configmaps.push(this.createConfigMap(
-                        'studio-prod-portal-env-variables',
+                        'prod-portal-env-variables',
                         'application-853ebea1-1e6b-4fee-9855-10d1df5cad1e',
                         {
                             tenant: 'Dolittle',
@@ -162,7 +162,7 @@ export class ConfigmapsController extends Controller {
                         }
                         ));
                     this._configmaps.push(this.createConfigMap(
-                        'studio-prod-portal-config-files',
+                        'prod-portal-config-files',
                         'application-853ebea1-1e6b-4fee-9855-10d1df5cad1e',
                         {
                             tenant: 'Dolittle',

--- a/Source/K8sMock/Backend/deployments/DeploymentsController.ts
+++ b/Source/K8sMock/Backend/deployments/DeploymentsController.ts
@@ -17,7 +17,7 @@ export class DeploymentsController extends Controller {
         {
             {
                 this._deployments.push(this.createDeployment(
-                    'studio-dev-applications',
+                    'dev-applications',
                     'application-853ebea1-1e6b-4fee-9855-10d1df5cad1e',
                     {
                         tenant: 'Dolittle',
@@ -29,7 +29,7 @@ export class DeploymentsController extends Controller {
                     'dolittle/runtime:5.1.2'
                     ));
                 this._deployments.push(this.createDeployment(
-                    'studio-dev-events',
+                    'dev-events',
                     'application-853ebea1-1e6b-4fee-9855-10d1df5cad1e',
                     {
                         tenant: 'Dolittle',
@@ -41,7 +41,7 @@ export class DeploymentsController extends Controller {
                     'dolittle/runtime:5.1.4'
                     ));
                 this._deployments.push(this.createDeployment(
-                    'studio-dev-portal',
+                    'dev-portal',
                     'application-853ebea1-1e6b-4fee-9855-10d1df5cad1e',
                     {
                         tenant: 'Dolittle',
@@ -55,7 +55,7 @@ export class DeploymentsController extends Controller {
             }
             {
                 this._deployments.push(this.createDeployment(
-                    'studio-prod-applications',
+                    'prod-applications',
                     'application-853ebea1-1e6b-4fee-9855-10d1df5cad1e',
                     {
                         tenant: 'Dolittle',
@@ -67,7 +67,7 @@ export class DeploymentsController extends Controller {
                     'dolittle/runtime:5.1.2'
                     ));
                 this._deployments.push(this.createDeployment(
-                    'studio-prod-events',
+                    'prod-events',
                     'application-853ebea1-1e6b-4fee-9855-10d1df5cad1e',
                     {
                         tenant: 'Dolittle',
@@ -79,7 +79,7 @@ export class DeploymentsController extends Controller {
                     'dolittle/runtime:5.1.2'
                     ));
                 this._deployments.push(this.createDeployment(
-                    'studio-prod-portal',
+                    'prod-portal',
                     'application-853ebea1-1e6b-4fee-9855-10d1df5cad1e',
                     {
                         tenant: 'Dolittle',

--- a/Source/K8sMock/Backend/pods/PodsController.ts
+++ b/Source/K8sMock/Backend/pods/PodsController.ts
@@ -14,7 +14,7 @@ export class PodsController extends Controller {
     private static readonly _pods: V1Pod[] =
     [
         PodsController.createPod(
-            'studio-dev-applications',
+            'dev-applications',
             'application-853ebea1-1e6b-4fee-9855-10d1df5cad1e',
             {
                 tenant: 'Dolittle',
@@ -26,7 +26,7 @@ export class PodsController extends Controller {
             'dolittle/runtime:5.1.2'
             ),
         PodsController.createPod(
-            'studio-dev-events',
+            'dev-events',
             'application-853ebea1-1e6b-4fee-9855-10d1df5cad1e',
             {
                 tenant: 'Dolittle',
@@ -38,7 +38,7 @@ export class PodsController extends Controller {
             'dolittle/runtime:5.1.4'
             ),
         PodsController.createPod(
-            'studio-dev-portal',
+            'dev-portal',
             'application-853ebea1-1e6b-4fee-9855-10d1df5cad1e',
             {
                 tenant: 'Dolittle',
@@ -51,7 +51,7 @@ export class PodsController extends Controller {
             ),
 
         PodsController.createPod(
-            'studio-prod-applications',
+            'prod-applications',
             'application-853ebea1-1e6b-4fee-9855-10d1df5cad1e',
             {
                 tenant: 'Dolittle',
@@ -63,7 +63,7 @@ export class PodsController extends Controller {
             'dolittle/runtime:5.1.2'
             ),
         PodsController.createPod(
-            'studio-prod-events',
+            'prod-events',
             'application-853ebea1-1e6b-4fee-9855-10d1df5cad1e',
             {
                 tenant: 'Dolittle',
@@ -75,7 +75,7 @@ export class PodsController extends Controller {
             'dolittle/runtime:5.1.2'
             ),
         PodsController.createPod(
-            'studio-prod-portal',
+            'prod-portal',
             'application-853ebea1-1e6b-4fee-9855-10d1df5cad1e',
             {
                 tenant: 'Dolittle',

--- a/Source/Portal/k8s/Development/configmap.yml
+++ b/Source/Portal/k8s/Development/configmap.yml
@@ -15,9 +15,9 @@ metadata:
   namespace: application-fe7736bb-57fc-4166-bb91-6954f4dd4eb7
 data:
   NODE_ENV: "production"
-  DATABASE_HOST: "studio-dev-mongo.application-fe7736bb-57fc-4166-bb91-6954f4dd4eb7.svc.cluster.local"
+  DATABASE_HOST: "dev-mongo.application-fe7736bb-57fc-4166-bb91-6954f4dd4eb7.svc.cluster.local"
   DATABASE_NAME: "studio_dev_portal_readmodels"
-  EVENTSTORE_HOST: "studio-dev-mongo.application-fe7736bb-57fc-4166-bb91-6954f4dd4eb7.svc.cluster.local"
+  EVENTSTORE_HOST: "dev-mongo.application-fe7736bb-57fc-4166-bb91-6954f4dd4eb7.svc.cluster.local"
   EVENTSTORE_NAME: "studio_dev_portal_eventstore"
   PORT: "80"
   DOLITTLE_RUNTIME_PORT: "50053"

--- a/Source/Portal/k8s/Development/configmap.yml
+++ b/Source/Portal/k8s/Development/configmap.yml
@@ -2,12 +2,17 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  namespace: application-fe7736bb-57fc-4166-bb91-6954f4dd4eb7
-  name: studio-dev-portal-env-variables
+  annotations:
+    dolittle.io/tenant-id: 508c1745-5f2a-4b4c-b7a5-2fbb1484346d
+    dolittle.io/application-id: fe7736bb-57fc-4166-bb91-6954f4dd4eb7
+    dolittle.io/microservice-id: 590696bc-1c4e-4a14-b621-c2125713a974
   labels:
     tenant: Dolittle
-    application: Studio-Dev
+    application: Studio
+    environment: Dev
     microservice: Portal
+  name: dev-portal-env-variables
+  namespace: application-fe7736bb-57fc-4166-bb91-6954f4dd4eb7
 data:
   NODE_ENV: "production"
   DATABASE_HOST: "studio-dev-mongo.application-fe7736bb-57fc-4166-bb91-6954f4dd4eb7.svc.cluster.local"
@@ -21,11 +26,16 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  namespace: application-fe7736bb-57fc-4166-bb91-6954f4dd4eb7
-  name: studio-dev-portal-config-files
+  annotations:
+    dolittle.io/tenant-id: 508c1745-5f2a-4b4c-b7a5-2fbb1484346d
+    dolittle.io/application-id: fe7736bb-57fc-4166-bb91-6954f4dd4eb7
+    dolittle.io/microservice-id: 590696bc-1c4e-4a14-b621-c2125713a974
   labels:
     tenant: Dolittle
-    application: Studio-Dev
+    application: Studio
+    environment: Dev
     microservice: Portal
+  name: dev-portal-config-files
+  namespace: application-fe7736bb-57fc-4166-bb91-6954f4dd4eb7
 data:
 

--- a/Source/Portal/k8s/Development/patch.sh
+++ b/Source/Portal/k8s/Development/patch.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-kubectl patch --namespace application-fe7736bb-57fc-4166-bb91-6954f4dd4eb7 deployment studio-dev-portal -p '{"spec": { "template": {"metadata": { "labels": { "date": "'`date +'%s'`'" } }}}}'
+kubectl patch --namespace application-fe7736bb-57fc-4166-bb91-6954f4dd4eb7 deployment dev-portal -p '{"spec": { "template": {"metadata": { "labels": { "date": "'`date +'%s'`'" } }}}}'

--- a/Source/Portal/k8s/Production/configmap.yml
+++ b/Source/Portal/k8s/Production/configmap.yml
@@ -15,9 +15,9 @@ metadata:
   namespace: application-fe7736bb-57fc-4166-bb91-6954f4dd4eb7
 data:
   NODE_ENV: "production"
-  DATABASE_HOST: "studio-prod-mongo.application-fe7736bb-57fc-4166-bb91-6954f4dd4eb7.svc.cluster.local"
+  DATABASE_HOST: "prod-mongo.application-fe7736bb-57fc-4166-bb91-6954f4dd4eb7.svc.cluster.local"
   DATABASE_NAME: "studio_prod_portal_readmodels"
-  EVENTSTORE_HOST: "studio-prod-mongo.application-fe7736bb-57fc-4166-bb91-6954f4dd4eb7.svc.cluster.local"
+  EVENTSTORE_HOST: "prod-mongo.application-fe7736bb-57fc-4166-bb91-6954f4dd4eb7.svc.cluster.local"
   EVENTSTORE_NAME: "studio_prod_portal_eventstore"
   PORT: "80"
   DOLITTLE_RUNTIME_PORT: "50053"

--- a/Source/Portal/k8s/Production/configmap.yml
+++ b/Source/Portal/k8s/Production/configmap.yml
@@ -2,12 +2,17 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  namespace: application-fe7736bb-57fc-4166-bb91-6954f4dd4eb7
-  name: studio-prod-portal-env-variables
+  annotations:
+    dolittle.io/tenant-id: 508c1745-5f2a-4b4c-b7a5-2fbb1484346d
+    dolittle.io/application-id: fe7736bb-57fc-4166-bb91-6954f4dd4eb7
+    dolittle.io/microservice-id: 590696bc-1c4e-4a14-b621-c2125713a974
   labels:
     tenant: Dolittle
-    application: Studio-Prod
+    application: Studio
+    environment: Prod
     microservice: Portal
+  name: prod-portal-env-variables
+  namespace: application-fe7736bb-57fc-4166-bb91-6954f4dd4eb7
 data:
   NODE_ENV: "production"
   DATABASE_HOST: "studio-prod-mongo.application-fe7736bb-57fc-4166-bb91-6954f4dd4eb7.svc.cluster.local"
@@ -21,11 +26,16 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  namespace: application-fe7736bb-57fc-4166-bb91-6954f4dd4eb7
-  name: studio-prod-portal-config-files
+  annotations:
+    dolittle.io/tenant-id: 508c1745-5f2a-4b4c-b7a5-2fbb1484346d
+    dolittle.io/application-id: fe7736bb-57fc-4166-bb91-6954f4dd4eb7
+    dolittle.io/microservice-id: 590696bc-1c4e-4a14-b621-c2125713a974
   labels:
     tenant: Dolittle
-    application: Studio-Prod
+    application: Studio
+    environment: Prod
     microservice: Portal
+  name: prod-portal-config-files
+  namespace: application-fe7736bb-57fc-4166-bb91-6954f4dd4eb7
 data:
 

--- a/Source/Portal/k8s/Production/patch.sh
+++ b/Source/Portal/k8s/Production/patch.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-kubectl patch --namespace application-fe7736bb-57fc-4166-bb91-6954f4dd4eb7 deployment studio-prod-portal -p '{"spec": { "template": {"metadata": { "labels": { "date": "'`date +'%s'`'" } }}}}'
+kubectl patch --namespace application-fe7736bb-57fc-4166-bb91-6954f4dd4eb7 deployment prod-portal -p '{"spec": { "template": {"metadata": { "labels": { "date": "'`date +'%s'`'" } }}}}'

--- a/Source/Shared/k8s/ApplicationNamespaces.ts
+++ b/Source/Shared/k8s/ApplicationNamespaces.ts
@@ -21,7 +21,7 @@ export class ApplicationNamespaces extends IApplicationNamespaces {
 
     getNamespacesForTenant = (tenantId: string) => {
         if (!this.namespaces) return [];
-        return this.namespaces.list().filter(_ => _.metadata?.labels !== undefined && _.metadata?.annotations['dolittle.io/tenant-id'] === tenantId);
+        return this.namespaces.list().filter(_ => _.metadata?.annotations !== undefined && _.metadata?.annotations['dolittle.io/tenant-id'] === tenantId);
     };
 
     private async startListWatcherLoop() {

--- a/Source/Shared/k8s/ApplicationNamespaces.ts
+++ b/Source/Shared/k8s/ApplicationNamespaces.ts
@@ -21,7 +21,7 @@ export class ApplicationNamespaces extends IApplicationNamespaces {
 
     getNamespacesForTenant = (tenantId: string) => {
         if (!this.namespaces) return [];
-        return this.namespaces.list().filter(_ => _.metadata?.labels !== undefined && _.metadata?.labels['tenant-id'] === tenantId);
+        return this.namespaces.list().filter(_ => _.metadata?.labels !== undefined && _.metadata?.annotations['dolittle.io/tenant-id'] === tenantId);
     };
 
     private async startListWatcherLoop() {


### PR DESCRIPTION
Making Studio cluster V3 friendly.
Important part was gettings applications via the new tenant-id path.

A little bit of boilerplate replacing

# Todo
- [ ] Do we need to update vanir?
- [ ] The read_models db name is not the same as in the cluster
- [ ] The event_store name is not the same as in the cluster