### PR TITLE
Add resources configuration to Data under .dolittle so that docker-compose works

### DIFF
--- a/.dolittle/Data/resources.json
+++ b/.dolittle/Data/resources.json
@@ -1,0 +1,10 @@
+{
+    "508c1745-5f2a-4b4c-b7a5-2fbb1484346d": {
+        "eventStore": {
+            "servers": [
+                "studio-mongo"
+            ],
+            "database": "event_store_data"
+        }
+    }
+}


### PR DESCRIPTION
The Data microservice was missing the resources configuration  so the docker-compose would not run.

So either the resources.json was missing or the docker-compose was not supposed to spin up the runtime for the Data microservice yet.