### PR TITLE
WIP: Start your engines

### DIFF
--- a/Source/Shared/Components/toolbar/ToolbarItem.tsx
+++ b/Source/Shared/Components/toolbar/ToolbarItem.tsx
@@ -5,5 +5,5 @@ import React from 'react';
 import { ToolbarItemProps } from './ToolbarItemProps';
 
 export const ToolbarItem = (props: ToolbarItemProps) => {
-    return (<></>)
+    return (<></>);
 };

--- a/Source/Shared/Components/toolbar/ToolbarViewModel.ts
+++ b/Source/Shared/Components/toolbar/ToolbarViewModel.ts
@@ -28,7 +28,7 @@ export class ToolbarViewModel {
                 props.icon,
                 props.onClick
             );
-        })
+        });
 
         this._toolbarItems.setItems(toolbarItems);
     }

--- a/Source/Shared/Platform/AssignMicroserviceToApplicationResult.ts
+++ b/Source/Shared/Platform/AssignMicroserviceToApplicationResult.ts
@@ -1,4 +1,5 @@
-
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 export class AssignMicroserviceToApplicationResult {
     message!: string;
 }

--- a/Source/Shared/Platform/IMicroservices.ts
+++ b/Source/Shared/Platform/IMicroservices.ts
@@ -1,9 +1,9 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-import { Microservice } from "./Microservice";
-import { MicroserviceCreationResult } from "./MicroserviceCreationResult";
+import { Microservice } from './Microservice';
+import { MicroserviceCreationResult } from './MicroserviceCreationResult';
 
 export abstract class IMicroservices {
-    abstract create(microservice: Microservice) : Promise<MicroserviceCreationResult>;
+    abstract create(microservice: Microservice): Promise<MicroserviceCreationResult>;
 }

--- a/start-all.sh
+++ b/start-all.sh
@@ -12,6 +12,7 @@ done
 ps aux | grep 'Studio/node_modules' | awk  '{print $2}' | xargs kill -9 >/dev/null 2>&1
 ps aux | grep 'yarn start:dev' | awk  '{print $2}' | xargs kill -9 >/dev/null 2>&1
 ps aux | grep 'webpack' | awk  '{print $2}' | xargs kill -9 >/dev/null 2>&1
+exit
 
 for app in Portal Applications Events Data; do
     cd $ROOT_PWD

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,24 @@
+CWD="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+ROOT_PWD="$CWD"
+WORKSPACE="${ROOT_PWD}/.dolittle/workspace.json"
+LINES=$(cat $WORKSPACE | jq -rc '.ports[]')
+for line in $LINES; do
+    backendPort=$(echo $line | jq -r '.backend')
+    webPort=$(echo $line | jq -r '.web')
+    kill -9 $(lsof -ti tcp:$webPort) >/dev/null 2>&1
+    kill -9 $(lsof -ti tcp:$backendPort) >/dev/null 2>&1
+done
+
+ps aux | grep 'yarn start:dev' | awk  '{print $2}' | xargs kill -9 >/dev/null 2>&1
+ps aux | grep 'nodemon' | awk  '{print $2}' | xargs kill -9 >/dev/null 2>&1
+ps aux | grep 'Studio/node_modules' | awk  '{print $2}' | xargs kill -9 >/dev/null 2>&1
+
+for app in Portal Applications Events Data; do
+    cd $ROOT_PWD
+    cd  "Source/$app/Backend"
+    yarn start:dev &
+
+    cd $ROOT_PWD
+    cd  "Source/$app/Web"
+    yarn start:dev &
+done

--- a/start.sh
+++ b/start.sh
@@ -9,9 +9,9 @@ for line in $LINES; do
     kill -9 $(lsof -ti tcp:$backendPort) >/dev/null 2>&1
 done
 
-ps aux | grep 'yarn start:dev' | awk  '{print $2}' | xargs kill -9 >/dev/null 2>&1
-ps aux | grep 'nodemon' | awk  '{print $2}' | xargs kill -9 >/dev/null 2>&1
 ps aux | grep 'Studio/node_modules' | awk  '{print $2}' | xargs kill -9 >/dev/null 2>&1
+ps aux | grep 'yarn start:dev' | awk  '{print $2}' | xargs kill -9 >/dev/null 2>&1
+ps aux | grep 'webpack' | awk  '{print $2}' | xargs kill -9 >/dev/null 2>&1
 
 for app in Portal Applications Events Data; do
     cd $ROOT_PWD


### PR DESCRIPTION
An over engineered way of starting Studio. I bet there is an easier way

# Quesitons
- Did I miss a simpler way?

# How
```
cd .dolittle
docker-compose up -d
cd ..
sh start.sh
```

# Thoughts
- workspace.json, if the application was added, we could then have more fine grained control of the ports we are killing.
- the approach in this PR, are aggressive when it comes to stopping node and killing ports, there almost certainly will be a cleaner way.