### PR TITLE
Add mongo to the local dev setup

### DIFF
--- a/Documentation/k3d.md
+++ b/Documentation/k3d.md
@@ -44,13 +44,12 @@ Do the following command and verify that current context is `k3d-dolittle-env`
 kubectl config current-context
 ```
 
-Execute the following commands in the `k3d-dolittle-dev` context:
+We need to bootstrap some k8s things before we can continue. This is to mimick our setup in the platform. We also setup a hardcoded mongodb with the correct setup (labels, annotations, resources.json) for the example microservices in Studio.
+Execute the following commands in Studio repo while in the `k3d-dolittle-dev` k8s context (the pods might take a while to start):
 
  ```sh
 cd Environment/k3d/k8s
-kubectl apply -f namespace.yml
-kubectl apply -f rbac.yml
-kubectl apply -f tenants.yml
+kubectl apply -f namespace.yml -f rbac.yml -f tenants.yml -f mongo.yml
 ```
 
 # Run self-service web

--- a/Environment/k3d/k8s/mongo.yml
+++ b/Environment/k3d/k8s/mongo.yml
@@ -1,0 +1,73 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    dolittle.io/tenant-id: 453e04a7-4f9d-42f2-b36c-d51fa2c83fa3
+    dolittle.io/application-id: 11b6cf47-5d9f-438f-8116-0d9828654657
+  labels:
+    tenant: Customer-Chris
+    application: Taco
+    environment: Dev
+    infrastructure: Mongo
+  name: dev-mongo
+  namespace: application-11b6cf47-5d9f-438f-8116-0d9828654657
+spec:
+  selector:
+    tenant: Customer-Chris
+    application: Taco
+    environment: Dev
+    infrastructure: Mongo
+  clusterIP: None
+  ports:
+    - port: 27017
+      targetPort: mongo
+
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  annotations:
+    dolittle.io/tenant-id: 453e04a7-4f9d-42f2-b36c-d51fa2c83fa3
+    dolittle.io/application-id: 11b6cf47-5d9f-438f-8116-0d9828654657
+  labels:
+    tenant: Customer-Chris
+    application: Taco
+    environment: Dev
+    infrastructure: Mongo
+  name: dev-mongo
+  namespace: application-11b6cf47-5d9f-438f-8116-0d9828654657
+spec:
+  selector:
+    matchLabels:
+      tenant: Customer-Chris
+      application: Taco
+      environment: Dev
+      infrastructure: Mongo
+
+  serviceName: dev-mongo
+  replicas: 1
+  podManagementPolicy: OrderedReady
+  updateStrategy:
+    type: RollingUpdate
+
+  template:
+    metadata:
+      annotations:
+        dolittle.io/tenant-id: 453e04a7-4f9d-42f2-b36c-d51fa2c83fa3
+        dolittle.io/application-id: 11b6cf47-5d9f-438f-8116-0d9828654657
+      labels:
+        tenant: Customer-Chris
+        application: Taco
+        environment: Dev
+        infrastructure: Mongo
+    spec:
+      containers:
+        - name: mongo
+          image: dolittle/mongodb:4.2.2
+          ports:
+            - name: mongo
+              containerPort: 27017
+          # volumeMounts:
+          #   - name: dev-mongo-storage
+          #     mountPath: /data/db

--- a/Environment/k3d/k8s/mongo.yml
+++ b/Environment/k3d/k8s/mongo.yml
@@ -68,6 +68,3 @@ spec:
           ports:
             - name: mongo
               containerPort: 27017
-          # volumeMounts:
-          #   - name: dev-mongo-storage
-          #     mountPath: /data/db


### PR DESCRIPTION
## Summary
Adds a hardcoded mongo deployment & service to the local dev setup. As Studio doesn't yet dynamically create the required mongodb this is required to get the local dev setup bootstrapped.

Remember to remove sections that you don't need or use.

### Added

- New `mongo.yml` to be applied during the bootstrapping phase
- Docs on how to apply it & why we do bootstrapping
