### PR TITLE
Fix the COPY TO CLIPBOARD button to actually work in POAPI creation view

### DIFF
--- a/Source/SelfService/Web/microservice/purchaseOrder/overview.tsx
+++ b/Source/SelfService/Web/microservice/purchaseOrder/overview.tsx
@@ -83,6 +83,14 @@ export const Overview: React.FunctionComponent<Props> = (props) => {
     const webhookPoHead = 'm3/pohead';
     const webhookPoLine = 'm3/poline';
 
+    const copyPOHeadUrl = () => {
+        navigator.clipboard.writeText(`${webhookPrefix}/${webhookPoHead}`);
+    }
+
+    const copyPOLineUrl = () => {
+        navigator.clipboard.writeText(`${webhookPrefix}/${webhookPoLine}`);
+    }
+
     const stepsContent = [
         <>
             <Typography component={'span'}>
@@ -140,13 +148,13 @@ export const Overview: React.FunctionComponent<Props> = (props) => {
                 <span className={classes.inactiveText}>
                     {webhookPrefix} / m3/pohead
                 </span >
-                <Button color='primary'>COPY TO CLIPBOARD</Button>
+                <Button color='primary' onClick={copyPOHeadUrl}>COPY TO CLIPBOARD</Button>
 
                 <p>Webhook for purchase order line (POLINE)</p>
                 <span className={classes.inactiveText}>
                     {webhookPrefix} / m3/poline
                 </span >
-                <Button color='primary'>COPY TO CLIPBOARD</Button>
+                <Button color='primary' onClick={copyPOLineUrl}>COPY TO CLIPBOARD</Button>
 
                 <p>Create username</p>
                 <TextField

--- a/Source/SelfService/Web/microservice/purchaseOrder/overview.tsx
+++ b/Source/SelfService/Web/microservice/purchaseOrder/overview.tsx
@@ -85,11 +85,11 @@ export const Overview: React.FunctionComponent<Props> = (props) => {
 
     const copyPOHeadUrl = () => {
         navigator.clipboard.writeText(`${webhookPrefix}/${webhookPoHead}`);
-    }
+    };
 
     const copyPOLineUrl = () => {
         navigator.clipboard.writeText(`${webhookPrefix}/${webhookPoLine}`);
-    }
+    };
 
     const stepsContent = [
         <>


### PR DESCRIPTION
## Summary

Fixes the "COPY TO CLIPBOARD" button in the PurchaseOrderAPI microservice creation view to actually work.

### Fixed

- The "COPY TO CLIPBOARD" button actually works now