### PR TITLE
Add snackbar when copying POapi webhook urls.

### DIFF
--- a/Source/SelfService/Web/App.tsx
+++ b/Source/SelfService/Web/App.tsx
@@ -18,12 +18,13 @@ import CssBaseline from '@material-ui/core/CssBaseline';
 import { RouteNotFound } from './components/notfound';
 import { EnvironmentScreen } from './screens/environmentScreen';
 
-import {
-    createTheme,
-    ThemeProvider,
-} from '@material-ui/core/styles';
+import { createTheme, makeStyles, Theme, ThemeProvider } from '@material-ui/core/styles';
 import { DieAndRestart } from './components/dieAndRestart';
 import { LayoutWithSidebar } from './layout/layoutWithSidebar';
+
+import { SnackbarProvider } from 'notistack';
+import Grow from '@material-ui/core/Grow';
+import { TransitionProps } from '@material-ui/core/transitions';
 
 const themeDark = createTheme({
     palette: {
@@ -34,6 +35,13 @@ const themeDark = createTheme({
         text: {
             primary: '#E9EAEC'
         }
+    }
+});
+
+const useStyles = makeStyles({
+    snackbar: {
+        backgroundColor: '#2C2B33',
+        color: '#FAFAFA',
     }
 });
 
@@ -50,55 +58,64 @@ export const App = () => {
         return null;
     }
 
+    const classes = useStyles();
+
     return (
         <>
             <ThemeProvider theme={themeDark}>
                 <CssBaseline />
                 <GlobalContextProvider>
-                    <BrowserRouter basename={uriWithAppPrefix('')}>
-                        <Switch>
-                            <Route exact path="/login">
-                                <LoginScreen />
-                            </Route>
+                    <SnackbarProvider
+                        maxSnack={1}
+                        anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+                        className={classes.snackbar}
+                        TransitionComponent={Grow as React.ComponentType<TransitionProps>}
+                    >
+                        <BrowserRouter basename={uriWithAppPrefix('')}>
+                            <Switch>
+                                <Route exact path="/login">
+                                    <LoginScreen />
+                                </Route>
 
-                            <Route path="/backups/application/:applicationId">
-                                <BackupsScreen />
-                            </Route>
+                                <Route path="/backups/application/:applicationId">
+                                    <BackupsScreen />
+                                </Route>
 
-                            <Route exact path="/applications">
-                                <ApplicationsScreen />
-                            </Route>
+                                <Route exact path="/applications">
+                                    <ApplicationsScreen />
+                                </Route>
 
-                            <Route path="/environment/application/:applicationId">
-                                <EnvironmentScreen />
-                            </Route>
+                                <Route path="/environment/application/:applicationId">
+                                    <EnvironmentScreen />
+                                </Route>
 
-                            <Route path="/microservices/application/:applicationId/:environment">
-                                <MicroservicesScreen />
-                            </Route>
+                                <Route path="/microservices/application/:applicationId/:environment">
+                                    <MicroservicesScreen />
+                                </Route>
 
-                            <Route path="/business-moments/application/:applicationId/:environment">
-                                <BusinessMomentsScreen />
-                            </Route>
+                                <Route path="/business-moments/application/:applicationId/:environment">
+                                    <BusinessMomentsScreen />
+                                </Route>
 
-                            <Route path="/documentation/application/:applicationId/:environment">
-                                <DocumentationScreen />
-                            </Route>
+                                <Route path="/documentation/application/:applicationId/:environment">
+                                    <DocumentationScreen />
+                                </Route>
 
-                            <Route path="/insights/application/:applicationId/:environment">
-                                <InsightsScreen />
-                            </Route>
+                                <Route path="/insights/application/:applicationId/:environment">
+                                    <InsightsScreen />
+                                </Route>
 
-                            <Route exact path="/problem">
-                                <LayoutWithSidebar navigation={[]}>
-                                    <DieAndRestart />
-                                </LayoutWithSidebar>
+                                <Route exact path="/problem">
+                                    <LayoutWithSidebar navigation={[]}>
+                                        <DieAndRestart />
+                                    </LayoutWithSidebar>
 
-                            </Route>
+                                </Route>
 
-                            <RouteNotFound redirectUrl="/applications" auto={true} />
-                        </Switch>
-                    </BrowserRouter>
+                                <RouteNotFound redirectUrl="/applications" auto={true} />
+                            </Switch>
+                        </BrowserRouter>
+                    </SnackbarProvider>
                 </GlobalContextProvider>
             </ThemeProvider>
         </>

--- a/Source/SelfService/Web/App.tsx
+++ b/Source/SelfService/Web/App.tsx
@@ -22,7 +22,7 @@ import { createTheme, makeStyles, Theme, ThemeProvider } from '@material-ui/core
 import { DieAndRestart } from './components/dieAndRestart';
 import { LayoutWithSidebar } from './layout/layoutWithSidebar';
 
-import { SnackbarProvider } from 'notistack';
+import { ClassNameMap, CombinedClassKey, SnackbarProvider } from 'notistack';
 import Grow from '@material-ui/core/Grow';
 import { TransitionProps } from '@material-ui/core/transitions';
 
@@ -38,10 +38,13 @@ const themeDark = createTheme({
     }
 });
 
-const useStyles = makeStyles({
-    snackbar: {
+const useSnackbarStyles = makeStyles({
+    contentRoot: {
         backgroundColor: '#2C2B33',
         color: '#FAFAFA',
+    },
+    variantError: {
+        backgroundColor: '#F44040',
     }
 });
 
@@ -58,7 +61,7 @@ export const App = () => {
         return null;
     }
 
-    const classes = useStyles();
+    const snackbarClasses = useSnackbarStyles();
 
     return (
         <>
@@ -68,7 +71,7 @@ export const App = () => {
                     <SnackbarProvider
                         maxSnack={1}
                         anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
-                        className={classes.snackbar}
+                        classes={snackbarClasses as Partial<ClassNameMap<CombinedClassKey>>}
                         TransitionComponent={Grow as React.ComponentType<TransitionProps>}
                     >
                         <BrowserRouter basename={uriWithAppPrefix('')}>

--- a/Source/SelfService/Web/microservice/purchaseOrder/overview.tsx
+++ b/Source/SelfService/Web/microservice/purchaseOrder/overview.tsx
@@ -85,14 +85,22 @@ export const Overview: React.FunctionComponent<Props> = (props) => {
     const webhookPoHead = 'm3/pohead';
     const webhookPoLine = 'm3/poline';
 
-    const copyPOHeadUrl = () => {
-        navigator.clipboard.writeText(`${webhookPrefix}/${webhookPoHead}`);
-        enqueueSnackbar('POHEAD URL copied to clipboard.');
+    const copyPOHeadUrl = async () => {
+        try {
+            await navigator.clipboard.writeText(`${webhookPrefix}/${webhookPoHead}`);
+            enqueueSnackbar('POHEAD URL copied to clipboard.');
+        } catch {
+            enqueueSnackbar('Failed to copy POHEAD URL to clipboard.', { variant: 'error' });
+        }
     };
 
-    const copyPOLineUrl = () => {
-        navigator.clipboard.writeText(`${webhookPrefix}/${webhookPoLine}`);
-        enqueueSnackbar('POLINE URL copied to clipboard.');
+    const copyPOLineUrl = async () => {
+        try {
+            await navigator.clipboard.writeText(`${webhookPrefix}/${webhookPoLine}`);
+            enqueueSnackbar('POLINE URL copied to clipboard.');
+        } catch {
+            enqueueSnackbar('Failed to copy POLINE URL to clipboard.', { variant: 'error' });
+        }
     };
 
     const stepsContent = [

--- a/Source/SelfService/Web/microservice/purchaseOrder/overview.tsx
+++ b/Source/SelfService/Web/microservice/purchaseOrder/overview.tsx
@@ -10,6 +10,7 @@ import StepContent from '@material-ui/core/StepContent';
 import Button from '@material-ui/core/Button';
 import Paper from '@material-ui/core/Paper';
 import Typography from '@material-ui/core/Typography';
+import { useSnackbar } from 'notistack';
 
 import { useGlobalContext } from '../../stores/notifications';
 import logoInfor from '../../images/infor.png'; // with import
@@ -58,6 +59,7 @@ const useStyles = makeStyles((theme: Theme) =>
 // TODO ask Liz about bearer token
 export const Overview: React.FunctionComponent<Props> = (props) => {
     const { setNotification } = useGlobalContext();
+    const { enqueueSnackbar } = useSnackbar();
 
     const _props = props!;
     const onSave = _props.onSave;
@@ -85,10 +87,12 @@ export const Overview: React.FunctionComponent<Props> = (props) => {
 
     const copyPOHeadUrl = () => {
         navigator.clipboard.writeText(`${webhookPrefix}/${webhookPoHead}`);
+        enqueueSnackbar('POHEAD URL copied to clipboard.');
     };
 
     const copyPOLineUrl = () => {
         navigator.clipboard.writeText(`${webhookPrefix}/${webhookPoLine}`);
+        enqueueSnackbar('POLINE URL copied to clipboard.');
     };
 
     const stepsContent = [

--- a/Source/SelfService/Web/package.json
+++ b/Source/SelfService/Web/package.json
@@ -22,6 +22,7 @@
         "@material-ui/styles": "4.11.4",
         "@monaco-editor/react": "4.1.3",
         "@shared/web": "1.0.0",
+        "notistack": "1.0.10",
         "react-markdown": "6.0.2",
         "remark-gfm": "1.0.0",
         "url-loader": "^4.1.1",


### PR DESCRIPTION
## Summary

Adds a Snackbar when user copies PurchaseOrderAPI URLs to clipboard, with an error if it fails. I found a library that seemed nice https://iamhosseindhv.com/notistack, that simplifies handling multiple snackbars (which is not allowed by Material Design). The library required a bit of hacking with types to get the animation and styling to work, but I think that might be down to something with typescript and dependencies and versions. I think we can clean that up later.

The styling corresponds to the Figma designs for notifications to the best of my ability.

### Added

- A global provider to display Snackbars from anywhere easily (notistack)
- Snackbars when copying URLs during the creation of PurchaseOrderAPI