### PR TITLE
Hide rawdatalog delete

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,3 +12,11 @@ develop-backend:
 	DEVELOPMENT_TENANT_ID="453e04a7-4f9d-42f2-b36c-d51fa2c83fa3" \
 	DEVELOPMENT_USER_ID="local-dev" \
 	go run main.go
+
+clean-local-dev:
+	kubectl delete all --all -n application-11b6cf47-5d9f-438f-8116-0d9828654657
+	rm -r /tmp/dolittle-local-dev || true
+	mkdir -p /tmp/dolittle-local-dev
+	cd /tmp/dolittle-local-dev && git init && cd -
+	cp -r Environment/k3d/git/* /tmp/dolittle-local-dev
+	cd Environment/k3d/k8s && kubectl apply -f namespace.yml -f rbac.yml -f tenants.yml -f mongo.yml && cd -

--- a/Source/SelfService/Web/layout/layoutWithSidebar.tsx
+++ b/Source/SelfService/Web/layout/layoutWithSidebar.tsx
@@ -92,7 +92,6 @@ export const getDefaultMenu = (history: History<LocationState>, applicationId: s
                                 event.preventDefault();
                                 const href = link.href;
                                 history.push(href);
-                                window.location.reload();
                             }}>
                                 {link.name}
                             </a>

--- a/Source/SelfService/Web/layout/layoutWithSidebar.tsx
+++ b/Source/SelfService/Web/layout/layoutWithSidebar.tsx
@@ -92,6 +92,7 @@ export const getDefaultMenu = (history: History<LocationState>, applicationId: s
                                 event.preventDefault();
                                 const href = link.href;
                                 history.push(href);
+                                window.location.reload();
                             }}>
                                 {link.name}
                             </a>

--- a/Source/SelfService/Web/microservice/microservice.scss
+++ b/Source/SelfService/Web/microservice/microservice.scss
@@ -19,6 +19,7 @@
 
   .left, .right {
     flex-basis: 50%;
+    flex: 1;
   }
 
   .right {

--- a/Source/SelfService/Web/microservice/overview.tsx
+++ b/Source/SelfService/Web/microservice/overview.tsx
@@ -78,6 +78,7 @@ export const MicroservicesOverviewScreen: React.FunctionComponent<Props> = (prop
                                 applicationId={applicationId}
                                 environment={environment}
                                 canEdit={canEdit}
+                                canDelete={ms.kind !== 'raw-data-log-ingestor'}
                                 onAfterDelete={(microserviceId: string, environment: string) => {
                                     console.log('I wonder if this store does this now');
                                     console.log('worth noting below filters based on environment');

--- a/Source/SelfService/Web/microservice/viewCard.tsx
+++ b/Source/SelfService/Web/microservice/viewCard.tsx
@@ -146,6 +146,7 @@ function createDeleteButton(canEdit: boolean, onClickDelete, onClickStopPropagat
             </a>
         );
 }
+
 function createStatus() {
     return (
         <div className="right">STATUS:TODO</div>

--- a/Source/SelfService/Web/microservice/viewCard.tsx
+++ b/Source/SelfService/Web/microservice/viewCard.tsx
@@ -19,6 +19,7 @@ type Props = {
     applicationId: string
     environment: string
     canEdit: boolean
+    canDelete: boolean
     onAfterDelete: (microserviceId: string, environment: string) => void;
 };
 
@@ -66,6 +67,7 @@ export const ViewCard: React.FunctionComponent<Props> = (props) => {
     const applicationId = _props.applicationId;
     const environment = _props.environment;
     const canEdit = _props.canEdit;
+    const canDelete = _props.canDelete;
 
     // Today we do not store the microservice type in the cluster, making it hard to say what it is
     const subTitle = kindTitles[microserviceKind] ? kindTitles[microserviceKind].subTitle : '';
@@ -107,13 +109,13 @@ export const ViewCard: React.FunctionComponent<Props> = (props) => {
 
                 <h1>{microserviceName}</h1>
                 <h2>{subTitle}</h2>
-
                 <div className="bottomBar">
                     {canEdit ?
                         (
                             <a href="#"
                                 onClick={onClickDelete}
                                 className="left"
+                                hidden={!canDelete}
                             >
                                 Delete
                             </a>
@@ -123,16 +125,15 @@ export const ViewCard: React.FunctionComponent<Props> = (props) => {
                             <a href="#"
                                 className="left"
                                 onClick={onClickStopPropagation}
+                                hidden={!canDelete}
                             >
                                 Delete
                             </a>
                         )
                     }
-
                     <div className="right">STATUS:TODO</div>
                 </div>
             </div>
         </DocumentCard >
     );
 };
-

--- a/Source/SelfService/Web/microservice/viewCard.tsx
+++ b/Source/SelfService/Web/microservice/viewCard.tsx
@@ -109,31 +109,45 @@ export const ViewCard: React.FunctionComponent<Props> = (props) => {
 
                 <h1>{microserviceName}</h1>
                 <h2>{subTitle}</h2>
-                <div className="bottomBar">
-                    {canEdit ?
-                        (
-                            <a href="#"
-                                onClick={onClickDelete}
-                                className="left"
-                                hidden={!canDelete}
-                            >
-                                Delete
-                            </a>
-                        ) :
-
-                        (
-                            <a href="#"
-                                className="left"
-                                onClick={onClickStopPropagation}
-                                hidden={!canDelete}
-                            >
-                                Delete
-                            </a>
-                        )
-                    }
-                    <div className="right">STATUS:TODO</div>
-                </div>
+                {createBottomBar(canEdit, canDelete, onClickDelete, onClickStopPropagation)}
             </div>
         </DocumentCard >
     );
 };
+
+function createBottomBar(canEdit: boolean, canDelete: boolean, onClickDelete, onClickStopPropagation) {
+    return (
+        <div className="bottomBar">
+            {canDelete ?
+                createDeleteButton(canEdit, onClickDelete, onClickStopPropagation)
+                : (null)
+            }
+            {createStatus()}
+        </div>
+    );
+}
+
+function createDeleteButton(canEdit: boolean, onClickDelete, onClickStopPropagation) {
+    return canEdit ?
+        (
+            <a href="#"
+                onClick={onClickDelete}
+                className="left"
+            >
+                Delete
+            </a>
+        ) :
+        (
+            <a href="#"
+                className="left"
+                onClick={onClickStopPropagation}
+            >
+                Delete
+            </a>
+        );
+}
+function createStatus() {
+    return (
+        <div className="right">STATUS:TODO</div>
+    );
+}

--- a/Source/SelfService/Web/stores/microservice.ts
+++ b/Source/SelfService/Web/stores/microservice.ts
@@ -160,8 +160,9 @@ const saveMicroservice = async (kind: string, input: any): Promise<boolean> => {
 
     // Add to store
     // Hairy stuff trying to keep track of the edit and the live
-    mergeMicroservicesFromGit([input]);
     const applicationId = input.dolittle.applicationId;
+    const application = await getApplication(applicationId);
+    mergeMicroservicesFromGit(application.microservices);
     const environment = input.environment;
     const liveMicroservices = await getMicroservices(applicationId);
     //const filteredMicroservices = liveMicroservices.microservices.filter(microservice => microservice.environment === environment);


### PR DESCRIPTION
## Summary

Hides the delete button for the raw data log view card


#### How to test
- Start with a clean cluster (or without raw-data-log and purchase-order)
- Click Microservices
- Click Create new microservice
- Click Create within the Purchase order api card
- Select Infor graphic
- Enter name
- Click next
- Enter username
- Enter password
- Click Next
- Click Microservices
- See that there is no delete button on the raw-data-log-v1 webhook microservice 

### Added

- canDelete property to microservice view card

### Changed

- Uses HTML5 hidden to hide delete button from raw data log microservice view card 

