### PR TITLE
Default runtime images 7.1.0

### DIFF
--- a/Source/SelfService/Web/api/api.ts
+++ b/Source/SelfService/Web/api/api.ts
@@ -84,12 +84,20 @@ export type HttpInputApplicationEnvironment = {
     ingresses: Map<string, MicroserviceIngressPath>
 };
 
+export type LatestRuntimeInfo = {
+    image: string
+    changelog: string
+};
+
 export function getServerUrlPrefix(): string {
     return '/selfservice/api';
 }
 
-export function getLatestRuntimeImage(): string {
-    return 'dolittle/runtime:7.1.0';
+export function getLatestRuntimeInfo(): LatestRuntimeInfo {
+    return {
+        image: 'dolittle/runtime:7.1.0',
+        changelog: 'https://github.com/dolittle/Runtime/releases/tag/v7.1.0',
+    };
 }
 
 export async function getLiveApplications(): Promise<any> {

--- a/Source/SelfService/Web/api/api.ts
+++ b/Source/SelfService/Web/api/api.ts
@@ -88,6 +88,10 @@ export function getServerUrlPrefix(): string {
     return '/selfservice/api';
 }
 
+export function getLatestRuntimeImage(): string {
+    return 'dolittle/runtime:7.1.0';
+}
+
 export async function getLiveApplications(): Promise<any> {
     const url = `${getServerUrlPrefix()}/live/applications`;
     const result = await fetch(

--- a/Source/SelfService/Web/microservice/base/create.tsx
+++ b/Source/SelfService/Web/microservice/base/create.tsx
@@ -11,7 +11,7 @@ import { Guid } from '@dolittle/rudiments';
 
 import { getFirstIngressFromApplication, saveSimpleMicroservice } from '../../stores/microservice';
 import { MicroserviceSimple } from '../../api/index';
-import { HttpResponseApplications2 } from '../../api/api';
+import { HttpResponseApplications2, getLatestRuntimeImage } from '../../api/api';
 
 const stackTokens = { childrenGap: 15 };
 
@@ -29,6 +29,8 @@ export const Create: React.FunctionComponent<Props> = (props) => {
     // TODO do something with
     const microserviceId = Guid.create().toString();
 
+    const latestRuntimeImage = getLatestRuntimeImage();
+
     const ms = {
         dolittle: {
             applicationId: application.id,
@@ -41,7 +43,7 @@ export const Create: React.FunctionComponent<Props> = (props) => {
         extra: {
             // nginxdemos/hello:latest
             headImage: 'nginxdemos/hello:latest', //'dolittle/spinner:0.0.0', // Doesnt work
-            runtimeImage: 'dolittle/runtime:5.6.0',
+            runtimeImage: latestRuntimeImage,
             ingress: {
                 path: '/',
                 pathType: 'Prefix',

--- a/Source/SelfService/Web/microservice/base/create.tsx
+++ b/Source/SelfService/Web/microservice/base/create.tsx
@@ -11,7 +11,7 @@ import { Guid } from '@dolittle/rudiments';
 
 import { getFirstIngressFromApplication, saveSimpleMicroservice } from '../../stores/microservice';
 import { MicroserviceSimple } from '../../api/index';
-import { HttpResponseApplications2, getLatestRuntimeImage } from '../../api/api';
+import { HttpResponseApplications2, getLatestRuntimeInfo } from '../../api/api';
 
 const stackTokens = { childrenGap: 15 };
 
@@ -29,7 +29,7 @@ export const Create: React.FunctionComponent<Props> = (props) => {
     // TODO do something with
     const microserviceId = Guid.create().toString();
 
-    const latestRuntimeImage = getLatestRuntimeImage();
+    const runtimeInfo = getLatestRuntimeInfo();
 
     const ms = {
         dolittle: {
@@ -43,7 +43,7 @@ export const Create: React.FunctionComponent<Props> = (props) => {
         extra: {
             // nginxdemos/hello:latest
             headImage: 'nginxdemos/hello:latest', //'dolittle/spinner:0.0.0', // Doesnt work
-            runtimeImage: latestRuntimeImage,
+            runtimeImage: runtimeInfo.image,
             ingress: {
                 path: '/',
                 pathType: 'Prefix',

--- a/Source/SelfService/Web/microservice/businessMomentsAdaptor/create.tsx
+++ b/Source/SelfService/Web/microservice/businessMomentsAdaptor/create.tsx
@@ -18,7 +18,7 @@ import { Config as RestConfig } from './configuration/RestConfiguration';
 import { getFirstIngressFromApplication, saveBusinessMomentsAdaptorMicroservice } from '../../stores/microservice';
 import { MicroserviceBusinessMomentAdaptor } from '../../api/index';
 
-import { HttpResponseApplications2 } from '../../api/api';
+import { getLatestRuntimeInfo, HttpResponseApplications2 } from '../../api/api';
 import { Guid } from '@dolittle/rudiments';
 
 const stackTokens = { childrenGap: 15 };
@@ -37,13 +37,14 @@ export const Create: React.FunctionComponent<Props> = (props) => {
 
     // TODO do something with
     const microserviceId = Guid.create().toString();
+    const runtimeInfo = getLatestRuntimeInfo();
 
     const fromStore = {
         businessmomentsadaptor: {
             image: '453e04a74f9d42f2b36cd51fa2c83fa3.azurecr.io/businessmomentsadaptor:latest',
         },
         runtime: {
-            image: 'dolittle/runtime:5.6.0'
+            image: runtimeInfo.image,
         }
     };
 

--- a/Source/SelfService/Web/microservice/purchaseOrder/create.tsx
+++ b/Source/SelfService/Web/microservice/purchaseOrder/create.tsx
@@ -13,7 +13,7 @@ import { useSnackbar } from 'notistack';
 
 import { savePurchaseOrderMicroservice, getFirstIngressFromApplication } from '../../stores/microservice';
 import { MicroservicePurchaseOrder } from '../../api/index';
-import { HttpResponseApplications2, getLatestRuntimeImage } from '../../api/api';
+import { HttpResponseApplications2, getLatestRuntimeInfo } from '../../api/api';
 import { useGlobalContext } from '../../stores/notifications';
 import { Configuration } from './configuration';
 import { Tab, Tabs } from '../../theme/tabs';
@@ -36,7 +36,7 @@ export const Create: React.FunctionComponent<Props> = (props) => {
 
     const microserviceId = Guid.create().toString();
     const headImage = 'dolittle/integrations-m3-purchaseorders:latest';
-    const latestRuntimeImage = getLatestRuntimeImage();
+    const runtimeInfo = getLatestRuntimeInfo();
     const ingressInfo = getFirstIngressFromApplication(_props.application, environment);
 
     const ms: MicroservicePurchaseOrder = {
@@ -56,7 +56,7 @@ export const Create: React.FunctionComponent<Props> = (props) => {
                 domainPrefix: ingressInfo.domainPrefix
             },
             headImage,
-            runtimeImage: latestRuntimeImage,
+            runtimeImage: runtimeInfo.image,
             webhooks: [],
             rawDataLogName: 'raw-data-log-v1',
         },

--- a/Source/SelfService/Web/microservice/purchaseOrder/create.tsx
+++ b/Source/SelfService/Web/microservice/purchaseOrder/create.tsx
@@ -13,7 +13,7 @@ import { useSnackbar } from 'notistack';
 
 import { savePurchaseOrderMicroservice, getFirstIngressFromApplication } from '../../stores/microservice';
 import { MicroservicePurchaseOrder } from '../../api/index';
-import { HttpResponseApplications2 } from '../../api/api';
+import { HttpResponseApplications2, getLatestRuntimeImage } from '../../api/api';
 import { useGlobalContext } from '../../stores/notifications';
 import { Configuration } from './configuration';
 import { Tab, Tabs } from '../../theme/tabs';
@@ -36,7 +36,7 @@ export const Create: React.FunctionComponent<Props> = (props) => {
 
     const microserviceId = Guid.create().toString();
     const headImage = 'dolittle/integrations-m3-purchaseorders:latest';
-    const runtimeImage = 'dolittle/runtime:6.1.0';
+    const latestRuntimeImage = getLatestRuntimeImage();
     const ingressInfo = getFirstIngressFromApplication(_props.application, environment);
 
     const ms: MicroservicePurchaseOrder = {
@@ -56,7 +56,7 @@ export const Create: React.FunctionComponent<Props> = (props) => {
                 domainPrefix: ingressInfo.domainPrefix
             },
             headImage,
-            runtimeImage,
+            runtimeImage: latestRuntimeImage,
             webhooks: [],
             rawDataLogName: 'raw-data-log-v1',
         },


### PR DESCRIPTION
## Summary

- getLatestRuntimeInfo() returns the latest image and the link to the changelog
- Creating base microservice uses getLatestRuntimeInfo() to get the runtime to use by default.
- Creating purchaseOrderApi microservice uses getLatestRuntimeInfo() to get the runtime to use by default.
- Creating businessMomentsAdaptor microservice uses getLatestRuntimeInfo() to get the runtime to use by default.
