### PR TITLE
Fix to only show the environments microservices in the overview

### DIFF
--- a/Source/SelfService/Web/microservice/overview.tsx
+++ b/Source/SelfService/Web/microservice/overview.tsx
@@ -70,7 +70,7 @@ export const MicroservicesOverviewScreen: React.FunctionComponent<Props> = (prop
             {hasMicroservices && (
                 <div className="serv">
                     <ul>
-                        {$microservices.map((ms) => {
+                        {filteredMicroservices.map((ms) => {
                             return <li key={`${environment}-${ms.id}`}><ViewCard
                                 microserviceId={ms.id}
                                 microserviceName={ms.name}


### PR DESCRIPTION
## Summary

Fixes that only the microservices that belong to the environment are showed in the microservices overview screen.