### PR TITLE
Make the reset-local-k3d script more secure

### DIFF
--- a/Environment/k3d/reset-local-k3d
+++ b/Environment/k3d/reset-local-k3d
@@ -27,13 +27,22 @@ k3d cluster create dolittle-dev \
 
 CREATE_EXIT_CODE=$?
 if [ $CREATE_EXIT_CODE -ne 0 ]; then
-    echo "Error creating cluster"
+    cat <<_EOF_
+
+Error switching to the k3d context
+You might need to clean up docker
+
+docker network rm k3d-dolittle-dev
+docker rm k3d-dolittle-dev-registry
+_EOF_
+
     exit $CREATE_EXIT_CODE
 fi
 
 kubectl config use-context k3d-dolittle-dev
 CONTEXT_EXIT_CODE=$?
 if [ $CONTEXT_EXIT_CODE -ne 0 ]; then
+
     echo "Error switching to the k3d context"
     exit $CONTEXT_EXIT_CODE
 fi

--- a/Environment/k3d/reset-local-k3d
+++ b/Environment/k3d/reset-local-k3d
@@ -28,12 +28,14 @@ k3d cluster create dolittle-dev \
 CREATE_EXIT_CODE=$?
 if [ $CREATE_EXIT_CODE -ne 0 ]; then
     echo "Error creating cluster"
+    exit $CREATE_EXIT_CODE
 fi
 
 kubectl config use-context k3d-dolittle-dev
 CONTEXT_EXIT_CODE=$?
 if [ $CONTEXT_EXIT_CODE -ne 0 ]; then
     echo "Error switching to the k3d context"
+    exit $CONTEXT_EXIT_CODE
 fi
 
 cp -r Environment/k3d/git/* /tmp/dolittle-local-dev

--- a/Environment/k3d/reset-local-k3d
+++ b/Environment/k3d/reset-local-k3d
@@ -1,9 +1,12 @@
 #!/bin/bash
 
+echo "Resetting local k3d cluster"
 ROOT_PWD=$(git rev-parse --show-toplevel)
 cd $ROOT_PWD
 
 k3d cluster delete dolittle-dev
+
+echo "Deleted dolittle-dev k3d cluster"
 
 rm -rf /tmp/dolittle-local-dev
 mkdir -p /tmp/dolittle-local-dev
@@ -11,6 +14,7 @@ cd /tmp/dolittle-local-dev
 git init
 cd -
 
+echo "Creating dolittle-dev k3d cluster"
 k3d cluster create dolittle-dev \
     --servers 1 \
     --agents 1 \
@@ -20,6 +24,17 @@ k3d cluster create dolittle-dev \
     --registry-create \
     --kubeconfig-switch-context \
     -v /tmp/k3dvolume:/tmp/k3dvolume
+
+CREATE_EXIT_CODE=$?
+if [ $CREATE_EXIT_CODE -ne 0 ]; then
+    echo "Error creating cluster"
+fi
+
+kubectl config use-context k3d-dolittle-dev
+CONTEXT_EXIT_CODE=$?
+if [ $CONTEXT_EXIT_CODE -ne 0 ]; then
+    echo "Error switching to the k3d context"
+fi
 
 cp -r Environment/k3d/git/* /tmp/dolittle-local-dev
 


### PR DESCRIPTION
## Summary

Makes the `reset-local-k3d` script check that the cluster creation actually worked and that it's in the correct context. This is so that we don't have any accidents in the future again when the context switching fails.