### PR TITLE
Bug fix around environment variable + odd behaviour on saving environment variables a second time

### DIFF
--- a/Source/SelfService/Web/api/api.ts
+++ b/Source/SelfService/Web/api/api.ts
@@ -268,7 +268,7 @@ export async function restartMicroservice(applicationId: string, environment: st
 
 
 export async function getEnvironmentVariables(applicationId: string, environment: string, microserviceId: string): Promise<HttpResponseEnvironmentVariables> {
-    const url = `${getServerUrlPrefix()}/live/application/${applicationId}/environment/${environment.toLowerCase()}/microservice/${microserviceId}/environment-variables`;
+    const url = `${getServerUrlPrefix()}/live/application/${applicationId}/environment/${environment}/microservice/${microserviceId}/environment-variables`;
 
     const response = await fetch(url, {
         method: 'GET',
@@ -280,7 +280,7 @@ export async function getEnvironmentVariables(applicationId: string, environment
 }
 
 export async function updateEnvironmentVariables(applicationId: string, environment: string, microserviceId: string, input: InputEnvironmentVariable[]): Promise<boolean> {
-    const url = `${getServerUrlPrefix()}/live/application/${applicationId}/environment/${environment.toLowerCase()}/microservice/${microserviceId}/environment-variables`;
+    const url = `${getServerUrlPrefix()}/live/application/${applicationId}/environment/${environment}/microservice/${microserviceId}/environment-variables`;
 
     const data = {
         data: input

--- a/Source/SelfService/Web/microservice/environmentVariables/view.tsx
+++ b/Source/SelfService/Web/microservice/environmentVariables/view.tsx
@@ -166,6 +166,8 @@ export const View: React.FunctionComponent<Props> = (props) => {
                             enqueueSnackbar('Environment variables are saved', { variant: 'error' });
                             return;
                         }
+
+                        setOriginalData(JSON.parse(JSON.stringify(currentData)));
                         // TODO make it clear to trigger a restart
                         enqueueSnackbar('Environment variables are saved, you need to manually trigger a restart for them to take effect', { variant: 'info' });
                     }}


### PR DESCRIPTION
## Summary

- Pass in the extact name of the Environment
- On success from the server update original data


