### PR TITLE
Fix selfservice-backend workflows triggering on Source/Shared folder

### DIFF
--- a/.github/workflows/deploy-selfservice-backend.yml
+++ b/.github/workflows/deploy-selfservice-backend.yml
@@ -29,7 +29,6 @@ jobs:
           filters: |
             src:
               - '${{ env.SOURCE_PATH }}/**'
-              - 'Source/Shared/**'
 
   deploy:
     needs: changes

--- a/.github/workflows/dev-selfservice-backend.yml
+++ b/.github/workflows/dev-selfservice-backend.yml
@@ -27,7 +27,6 @@ jobs:
           filters: |
             src:
               - '${{ env.SOURCE_PATH }}/**'
-              - 'Source/Shared/**'
 
   deploy:
     needs: changes


### PR DESCRIPTION
## Summary

Fix selfservice-backend workflows triggering on Source/Shared folder as the backend doesn't rely on any of the stuff from Source/Shared