### PR TITLE
Fix direct links with environment not working

### DIFF
--- a/Source/SelfService/Web/businessMoments/container.tsx
+++ b/Source/SelfService/Web/businessMoments/container.tsx
@@ -17,7 +17,7 @@ import '../application/applicationScreen.scss';
 import { useReadable } from 'use-svelte-store';
 import { businessmoments, load, isLoaded } from '../stores/businessmoment';
 import { microservices } from '../stores/microservice';
-import { useRouteApplicationProps } from '../utils/route';
+import { useRouteApplicationParams } from '../utils/route';
 
 
 type Props = {
@@ -28,7 +28,7 @@ type Props = {
 export const BusinessMomentsContainerScreen: React.FunctionComponent<Props> = (props) => {
     const _props = props!;
     const application = _props.application;
-    const routeApplicationProps = useRouteApplicationProps();
+    const routeApplicationProps = useRouteApplicationParams();
     const applicationId = routeApplicationProps.applicationId;
     const environment = _props.environment;
 

--- a/Source/SelfService/Web/businessMoments/container.tsx
+++ b/Source/SelfService/Web/businessMoments/container.tsx
@@ -17,7 +17,7 @@ import '../application/applicationScreen.scss';
 import { useReadable } from 'use-svelte-store';
 import { businessmoments, load, isLoaded } from '../stores/businessmoment';
 import { microservices } from '../stores/microservice';
-import { withRouteApplicationProps } from '../utils/route';
+import { useRouteApplicationProps } from '../utils/route';
 
 
 type Props = {
@@ -28,7 +28,7 @@ type Props = {
 export const BusinessMomentsContainerScreen: React.FunctionComponent<Props> = (props) => {
     const _props = props!;
     const application = _props.application;
-    const routeApplicationProps = withRouteApplicationProps('business-moments');
+    const routeApplicationProps = useRouteApplicationProps();
     const applicationId = routeApplicationProps.applicationId;
     const environment = _props.environment;
 

--- a/Source/SelfService/Web/businessMoments/overview.tsx
+++ b/Source/SelfService/Web/businessMoments/overview.tsx
@@ -13,7 +13,7 @@ import { Modal, DefaultButton } from '@fluentui/react';
 import { ViewCard } from './viewCard';
 import { HttpResponseApplication } from '../api/application';
 import { MicroserviceBusinessMomentAdaptor, HttpResponseBusinessMoments } from '../api/index';
-import { useRouteApplicationProps } from '../utils/route';
+import { useRouteApplicationParams } from '../utils/route';
 import { canEditMicroservices } from '../stores/microservice';
 
 type Props = {
@@ -27,7 +27,7 @@ export const BusinessMomentsOverview: React.FunctionComponent<Props> = (props) =
     const { enqueueSnackbar } = useSnackbar();
     const _props = props!;
     const application = _props.application;
-    const routeApplicationProps = useRouteApplicationProps();
+    const routeApplicationProps = useRouteApplicationParams();
     const applicationId = routeApplicationProps.applicationId;
     const environment = _props.environment;
 

--- a/Source/SelfService/Web/businessMoments/overview.tsx
+++ b/Source/SelfService/Web/businessMoments/overview.tsx
@@ -13,7 +13,7 @@ import { Modal, DefaultButton } from '@fluentui/react';
 import { ViewCard } from './viewCard';
 import { HttpResponseApplication } from '../api/application';
 import { MicroserviceBusinessMomentAdaptor, HttpResponseBusinessMoments } from '../api/index';
-import { withRouteApplicationProps } from '../utils/route';
+import { useRouteApplicationProps } from '../utils/route';
 import { canEditMicroservices } from '../stores/microservice';
 
 type Props = {
@@ -27,7 +27,7 @@ export const BusinessMomentsOverview: React.FunctionComponent<Props> = (props) =
     const { enqueueSnackbar } = useSnackbar();
     const _props = props!;
     const application = _props.application;
-    const routeApplicationProps = withRouteApplicationProps('business-moments');
+    const routeApplicationProps = useRouteApplicationProps();
     const applicationId = routeApplicationProps.applicationId;
     const environment = _props.environment;
 

--- a/Source/SelfService/Web/components/pickEnvironment.tsx
+++ b/Source/SelfService/Web/components/pickEnvironment.tsx
@@ -12,7 +12,7 @@ import { useGlobalContext } from '../stores/notifications';
 import {
     Link,
 } from '@fluentui/react';
-import { RouteApplicationProps } from '../utils/route';
+import { RouteApplicationParams } from '../utils/route';
 
 function rand() {
     return Math.round(Math.random() * 20) - 10;
@@ -49,7 +49,7 @@ type Props = {
     openModal: boolean
 };
 
-export const isEnvironmentValidFromUri = (routeProps: RouteApplicationProps, applications: ShortInfoWithEnvironment[], currentApplicationId: string, currentEnvironment: string): boolean => {
+export const isEnvironmentValidFromUri = (routeProps: RouteApplicationParams, applications: ShortInfoWithEnvironment[], currentApplicationId: string, currentEnvironment: string): boolean => {
     // Give priority to this fist
     // We want the second one for the uri change
     let exists = applications.some((info) => {

--- a/Source/SelfService/Web/components/pickEnvironment.tsx
+++ b/Source/SelfService/Web/components/pickEnvironment.tsx
@@ -49,22 +49,10 @@ type Props = {
     openModal: boolean
 };
 
-export const isEnvironmentValidFromUri = (routeProps: RouteApplicationParams, applications: ShortInfoWithEnvironment[], currentApplicationId: string, currentEnvironment: string): boolean => {
-    // Give priority to this fist
-    // We want the second one for the uri change
-    let exists = applications.some((info) => {
+export const isEnvironmentValidFromUri = (applications: ShortInfoWithEnvironment[], currentApplicationId: string, currentEnvironment: string): boolean => {
+    return applications.some((info) => {
         return currentApplicationId === info.id && currentEnvironment === info.environment;
     });
-
-    if (exists) {
-        return exists;
-    }
-
-    exists = applications.some((info) => {
-        return routeProps.applicationId === info.id && routeProps.environment === info.environment;
-    });
-
-    return exists;
 };
 
 export const PickEnvironment: React.FunctionComponent<Props> = (props) => {

--- a/Source/SelfService/Web/screens/backupsScreen.tsx
+++ b/Source/SelfService/Web/screens/backupsScreen.tsx
@@ -13,7 +13,7 @@ import { getApplication, HttpResponseApplication } from '../api/application';
 import { ViewCard } from '../backup/viewCard';
 import { getDefaultMenu, LayoutWithSidebar } from '../layout/layoutWithSidebar';
 import { BreadCrumbContainer } from '../layout/breadcrumbs';
-import { useRouteApplicationProps } from '../utils/route';
+import { useRouteApplicationParams } from '../utils/route';
 import { ListView } from '../backup/listView';
 import { useGlobalContext } from '../stores/notifications';
 
@@ -25,7 +25,7 @@ export const BackupsScreen: React.FunctionComponent<Props> = (props) => {
     const history = useHistory();
     const { currentEnvironment } = useGlobalContext();
 
-    const routeApplicationProps = useRouteApplicationProps();
+    const routeApplicationProps = useRouteApplicationParams();
     const applicationId = routeApplicationProps.applicationId;
     const [application, setApplication] = useState({} as HttpResponseApplication);
     const [loaded, setLoaded] = useState(false);

--- a/Source/SelfService/Web/screens/backupsScreen.tsx
+++ b/Source/SelfService/Web/screens/backupsScreen.tsx
@@ -13,7 +13,7 @@ import { getApplication, HttpResponseApplication } from '../api/application';
 import { ViewCard } from '../backup/viewCard';
 import { getDefaultMenu, LayoutWithSidebar } from '../layout/layoutWithSidebar';
 import { BreadCrumbContainer } from '../layout/breadcrumbs';
-import { withRouteApplicationProps } from '../utils/route';
+import { useRouteApplicationProps } from '../utils/route';
 import { ListView } from '../backup/listView';
 import { useGlobalContext } from '../stores/notifications';
 
@@ -25,7 +25,7 @@ export const BackupsScreen: React.FunctionComponent<Props> = (props) => {
     const history = useHistory();
     const { currentEnvironment } = useGlobalContext();
 
-    const routeApplicationProps = withRouteApplicationProps('backups');
+    const routeApplicationProps = useRouteApplicationProps();
     const applicationId = routeApplicationProps.applicationId;
     const [application, setApplication] = useState({} as HttpResponseApplication);
     const [loaded, setLoaded] = useState(false);

--- a/Source/SelfService/Web/screens/businessMomentsScreen.tsx
+++ b/Source/SelfService/Web/screens/businessMomentsScreen.tsx
@@ -30,7 +30,6 @@ import { withRouteApplicationState } from './withRouteApplicationState';
 export const BusinessMomentsScreen: React.FunctionComponent = withRouteApplicationState(({routeApplicationParams: routeApplicationProps}) => {
     const history = useHistory();
     const { currentEnvironment, currentApplicationId } = useGlobalContext();
-    const applicationId = routeApplicationProps.applicationId;
     const [application, setApplication] = useState({} as HttpResponseApplication);
     const [applications, setApplications] = useState([] as ShortInfoWithEnvironment[]);
     const [loaded, setLoaded] = useState(false);
@@ -38,8 +37,8 @@ export const BusinessMomentsScreen: React.FunctionComponent = withRouteApplicati
     useEffect(() => {
         Promise.all([
             getApplications(),
-            getApplication(applicationId),
-            getMicroservices(applicationId),
+            getApplication(currentApplicationId),
+            getMicroservices(currentApplicationId),
         ]).then(values => {
             const applicationsData = values[0] as HttpResponseApplications;
             const applicationData = values[1];
@@ -111,14 +110,14 @@ export const BusinessMomentsScreen: React.FunctionComponent = withRouteApplicati
 
 
     const redirectUrl = generatePath('/business-moments/application/:applicationId/:environment/overview', {
-        applicationId,
+        applicationId: currentApplicationId,
         environment: currentEnvironment,
     });
 
 
     return (
         <LayoutWithSidebar navigation={nav}>
-            <TopNavBar routes={routes} applications={applications} applicationId={applicationId} environment={currentEnvironment} />
+            <TopNavBar routes={routes} applications={applications} applicationId={currentApplicationId} environment={currentEnvironment} />
 
 
             <Switch>

--- a/Source/SelfService/Web/screens/businessMomentsScreen.tsx
+++ b/Source/SelfService/Web/screens/businessMomentsScreen.tsx
@@ -35,6 +35,9 @@ export const BusinessMomentsScreen: React.FunctionComponent = withRouteApplicati
     const [loaded, setLoaded] = useState(false);
 
     useEffect(() => {
+        if (!currentEnvironment || !currentApplicationId) {
+            return;
+        }
         Promise.all([
             getApplications(),
             getApplication(currentApplicationId),
@@ -58,7 +61,7 @@ export const BusinessMomentsScreen: React.FunctionComponent = withRouteApplicati
             mergeMicroservicesFromK8s(microservices);
             setLoaded(true);
         });
-    }, []);
+    }, [currentApplicationId, currentEnvironment]);
 
     if (!loaded) {
         return null;

--- a/Source/SelfService/Web/screens/businessMomentsScreen.tsx
+++ b/Source/SelfService/Web/screens/businessMomentsScreen.tsx
@@ -20,7 +20,7 @@ import '../application/applicationScreen.scss';
 import { mergeMicroservicesFromGit, mergeMicroservicesFromK8s } from '../stores/microservice';
 import { BusinessMomentsContainerScreen } from '../businessMoments/container';
 import { isEnvironmentValidFromUri, PickEnvironment } from '../components/pickEnvironment';
-import { withRouteApplicationProps } from '../utils/route';
+import { useRouteApplicationProps } from '../utils/route';
 import { RouteNotFound } from '../components/notfound';
 import { useGlobalContext } from '../stores/notifications';
 import { TopNavBar } from '../components/topNavBar';
@@ -30,7 +30,7 @@ import { HttpResponseApplication, getApplications, getApplication, HttpResponseA
 export const BusinessMomentsScreen: React.FunctionComponent = () => {
     const history = useHistory();
     const { currentEnvironment, currentApplicationId } = useGlobalContext();
-    const routeApplicationProps = withRouteApplicationProps('business-moments');
+    const routeApplicationProps = useRouteApplicationProps();
     const applicationId = routeApplicationProps.applicationId;
     const [application, setApplication] = useState({} as HttpResponseApplication);
     const [applications, setApplications] = useState([] as ShortInfoWithEnvironment[]);

--- a/Source/SelfService/Web/screens/businessMomentsScreen.tsx
+++ b/Source/SelfService/Web/screens/businessMomentsScreen.tsx
@@ -20,17 +20,16 @@ import '../application/applicationScreen.scss';
 import { mergeMicroservicesFromGit, mergeMicroservicesFromK8s } from '../stores/microservice';
 import { BusinessMomentsContainerScreen } from '../businessMoments/container';
 import { isEnvironmentValidFromUri, PickEnvironment } from '../components/pickEnvironment';
-import { useRouteApplicationProps } from '../utils/route';
 import { RouteNotFound } from '../components/notfound';
 import { useGlobalContext } from '../stores/notifications';
 import { TopNavBar } from '../components/topNavBar';
 import { ShortInfoWithEnvironment, getMicroservices, HttpResponseMicroservices } from '../api/api';
 import { HttpResponseApplication, getApplications, getApplication, HttpResponseApplications } from '../api/application';
+import { withRouteApplicationState } from './withRouteApplicationState';
 
-export const BusinessMomentsScreen: React.FunctionComponent = () => {
+export const BusinessMomentsScreen: React.FunctionComponent = withRouteApplicationState(({routeApplicationParams: routeApplicationProps}) => {
     const history = useHistory();
     const { currentEnvironment, currentApplicationId } = useGlobalContext();
-    const routeApplicationProps = useRouteApplicationProps();
     const applicationId = routeApplicationProps.applicationId;
     const [application, setApplication] = useState({} as HttpResponseApplication);
     const [applications, setApplications] = useState([] as ShortInfoWithEnvironment[]);
@@ -131,4 +130,4 @@ export const BusinessMomentsScreen: React.FunctionComponent = () => {
             </Switch>
         </LayoutWithSidebar >
     );
-};
+});

--- a/Source/SelfService/Web/screens/businessMomentsScreen.tsx
+++ b/Source/SelfService/Web/screens/businessMomentsScreen.tsx
@@ -27,9 +27,12 @@ import { ShortInfoWithEnvironment, getMicroservices, HttpResponseMicroservices }
 import { HttpResponseApplication, getApplications, getApplication, HttpResponseApplications } from '../api/application';
 import { withRouteApplicationState } from './withRouteApplicationState';
 
-export const BusinessMomentsScreen: React.FunctionComponent = withRouteApplicationState(() => {
+
+export const BusinessMomentsScreen: React.FunctionComponent = withRouteApplicationState(({ routeApplicationParams }) => {
     const history = useHistory();
-    const { currentEnvironment, currentApplicationId } = useGlobalContext();
+    const currentEnvironment = routeApplicationParams.environment;
+    const currentApplicationId = routeApplicationParams.applicationId;
+
     const [application, setApplication] = useState({} as HttpResponseApplication);
     const [applications, setApplications] = useState([] as ShortInfoWithEnvironment[]);
     const [loaded, setLoaded] = useState(false);

--- a/Source/SelfService/Web/screens/businessMomentsScreen.tsx
+++ b/Source/SelfService/Web/screens/businessMomentsScreen.tsx
@@ -27,7 +27,7 @@ import { ShortInfoWithEnvironment, getMicroservices, HttpResponseMicroservices }
 import { HttpResponseApplication, getApplications, getApplication, HttpResponseApplications } from '../api/application';
 import { withRouteApplicationState } from './withRouteApplicationState';
 
-export const BusinessMomentsScreen: React.FunctionComponent = withRouteApplicationState(({routeApplicationParams: routeApplicationProps}) => {
+export const BusinessMomentsScreen: React.FunctionComponent = withRouteApplicationState(() => {
     const history = useHistory();
     const { currentEnvironment, currentApplicationId } = useGlobalContext();
     const [application, setApplication] = useState({} as HttpResponseApplication);
@@ -72,7 +72,7 @@ export const BusinessMomentsScreen: React.FunctionComponent = withRouteApplicati
         );
     }
 
-    if (!isEnvironmentValidFromUri(routeApplicationProps, applications, currentApplicationId, currentEnvironment)) {
+    if (!isEnvironmentValidFromUri(applications, currentApplicationId, currentEnvironment)) {
         return (
             <PickEnvironment
                 applications={applications}

--- a/Source/SelfService/Web/screens/documentationScreen.tsx
+++ b/Source/SelfService/Web/screens/documentationScreen.tsx
@@ -29,15 +29,13 @@ import {
     getApplication,
     HttpResponseApplications,
 } from '../api/application';
+import { withRouteApplicationState } from './withRouteApplicationState';
 
 
 
-export const DocumentationScreen: React.FunctionComponent = () => {
+export const DocumentationScreen: React.FunctionComponent = withRouteApplicationState(() => {
     const history = useHistory();
     const { setNotification, currentEnvironment, currentApplicationId } = useGlobalContext();
-
-    const routeApplicationParams = useRouteApplicationParams();
-    const applicationId = routeApplicationParams.applicationId;
 
     const [application, setApplication] = useState({} as HttpResponseApplication);
     const [applications, setApplications] = useState([] as ShortInfoWithEnvironment[]);
@@ -46,7 +44,7 @@ export const DocumentationScreen: React.FunctionComponent = () => {
     useEffect(() => {
         Promise.all([
             getApplications(),
-            getApplication(applicationId),
+            getApplication(currentApplicationId),
         ]).then(values => {
             const applicationsData = values[0] as HttpResponseApplications;
             const applicationData = values[1];
@@ -127,13 +125,13 @@ export const DocumentationScreen: React.FunctionComponent = () => {
     ];
 
     const redirectUrl = generatePath('/documentation/application/:applicationId/:environment/overview', {
-        applicationId,
+        applicationId: currentApplicationId,
         environment: currentEnvironment,
     });
 
     return (
         <LayoutWithSidebar navigation={nav}>
-            <TopNavBar routes={routes} applications={applications} applicationId={applicationId} environment={currentEnvironment} />
+            <TopNavBar routes={routes} applications={applications} applicationId={currentApplicationId} environment={currentEnvironment} />
 
             <Switch>
                 <Route path="/documentation/application/:applicationId/:environment">
@@ -143,4 +141,4 @@ export const DocumentationScreen: React.FunctionComponent = () => {
             </Switch>
         </LayoutWithSidebar >
     );
-};
+});

--- a/Source/SelfService/Web/screens/documentationScreen.tsx
+++ b/Source/SelfService/Web/screens/documentationScreen.tsx
@@ -42,6 +42,10 @@ export const DocumentationScreen: React.FunctionComponent = withRouteApplication
     const [loaded, setLoaded] = useState(false);
 
     useEffect(() => {
+        if (!currentEnvironment || !currentApplicationId) {
+            return;
+        }
+
         Promise.all([
             getApplications(),
             getApplication(currentApplicationId),
@@ -63,7 +67,7 @@ export const DocumentationScreen: React.FunctionComponent = withRouteApplication
             console.log(error);
             setNotification('Failed getting data from the server', 'error');
         });
-    }, []);
+    }, [currentApplicationId, currentEnvironment]);
 
     if (!loaded) {
         return null;

--- a/Source/SelfService/Web/screens/documentationScreen.tsx
+++ b/Source/SelfService/Web/screens/documentationScreen.tsx
@@ -33,9 +33,11 @@ import { withRouteApplicationState } from './withRouteApplicationState';
 
 
 
-export const DocumentationScreen: React.FunctionComponent = withRouteApplicationState(() => {
+export const DocumentationScreen: React.FunctionComponent = withRouteApplicationState(({ routeApplicationParams }) => {
     const history = useHistory();
-    const { setNotification, currentEnvironment, currentApplicationId } = useGlobalContext();
+    const { setNotification } = useGlobalContext();
+    const currentEnvironment = routeApplicationParams.environment;
+    const currentApplicationId = routeApplicationParams.applicationId;
 
     const [application, setApplication] = useState({} as HttpResponseApplication);
     const [applications, setApplications] = useState([] as ShortInfoWithEnvironment[]);

--- a/Source/SelfService/Web/screens/documentationScreen.tsx
+++ b/Source/SelfService/Web/screens/documentationScreen.tsx
@@ -18,7 +18,7 @@ import { getDefaultMenu, LayoutWithSidebar } from '../layout/layoutWithSidebar';
 import '../application/applicationScreen.scss';
 
 import { DocumentationContainerScreen } from '../documentation/container';
-import { useRouteApplicationProps } from '../utils/route';
+import { useRouteApplicationParams } from '../utils/route';
 import { RouteNotFound } from '../components/notfound';
 import { PickEnvironment, isEnvironmentValidFromUri } from '../components/pickEnvironment';
 import { useGlobalContext } from '../stores/notifications';
@@ -36,8 +36,8 @@ export const DocumentationScreen: React.FunctionComponent = () => {
     const history = useHistory();
     const { setNotification, currentEnvironment, currentApplicationId } = useGlobalContext();
 
-    const routeApplicationProps = useRouteApplicationProps();
-    const applicationId = routeApplicationProps.applicationId;
+    const routeApplicationParams = useRouteApplicationParams();
+    const applicationId = routeApplicationParams.applicationId;
 
     const [application, setApplication] = useState({} as HttpResponseApplication);
     const [applications, setApplications] = useState([] as ShortInfoWithEnvironment[]);
@@ -79,7 +79,7 @@ export const DocumentationScreen: React.FunctionComponent = () => {
         );
     }
 
-    if (!isEnvironmentValidFromUri(routeApplicationProps, applications, currentApplicationId, currentEnvironment)) {
+    if (!isEnvironmentValidFromUri(routeApplicationParams, applications, currentApplicationId, currentEnvironment)) {
         return (
             <PickEnvironment
                 applications={applications}

--- a/Source/SelfService/Web/screens/documentationScreen.tsx
+++ b/Source/SelfService/Web/screens/documentationScreen.tsx
@@ -18,7 +18,7 @@ import { getDefaultMenu, LayoutWithSidebar } from '../layout/layoutWithSidebar';
 import '../application/applicationScreen.scss';
 
 import { DocumentationContainerScreen } from '../documentation/container';
-import { withRouteApplicationProps } from '../utils/route';
+import { useRouteApplicationProps } from '../utils/route';
 import { RouteNotFound } from '../components/notfound';
 import { PickEnvironment, isEnvironmentValidFromUri } from '../components/pickEnvironment';
 import { useGlobalContext } from '../stores/notifications';
@@ -36,7 +36,7 @@ export const DocumentationScreen: React.FunctionComponent = () => {
     const history = useHistory();
     const { setNotification, currentEnvironment, currentApplicationId } = useGlobalContext();
 
-    const routeApplicationProps = withRouteApplicationProps('documentation');
+    const routeApplicationProps = useRouteApplicationProps();
     const applicationId = routeApplicationProps.applicationId;
 
     const [application, setApplication] = useState({} as HttpResponseApplication);

--- a/Source/SelfService/Web/screens/documentationScreen.tsx
+++ b/Source/SelfService/Web/screens/documentationScreen.tsx
@@ -77,7 +77,7 @@ export const DocumentationScreen: React.FunctionComponent = withRouteApplication
         );
     }
 
-    if (!isEnvironmentValidFromUri(routeApplicationParams, applications, currentApplicationId, currentEnvironment)) {
+    if (!isEnvironmentValidFromUri(applications, currentApplicationId, currentEnvironment)) {
         return (
             <PickEnvironment
                 applications={applications}

--- a/Source/SelfService/Web/screens/insightsScreen.tsx
+++ b/Source/SelfService/Web/screens/insightsScreen.tsx
@@ -11,7 +11,7 @@ import { getDefaultMenu, LayoutWithSidebar } from '../layout/layoutWithSidebar';
 import '../application/applicationScreen.scss';
 import { PickEnvironment } from '../components/pickEnvironment';
 import { InsightsContainerScreen } from '../insights/container';
-import { useRouteApplicationProps } from '../utils/route';
+import { useRouteApplicationParams } from '../utils/route';
 import { RouteNotFound } from '../components/notfound';
 import { useGlobalContext } from '../stores/notifications';
 import { TopNavBar } from '../components/topNavBar';
@@ -26,7 +26,7 @@ export const InsightsScreen: React.FunctionComponent = () => {
     const history = useHistory();
     const { setError, currentEnvironment } = useGlobalContext();
 
-    const routeApplicationProps = useRouteApplicationProps();
+    const routeApplicationProps = useRouteApplicationParams();
     const applicationId = routeApplicationProps.applicationId;
     const environment = currentEnvironment;
 

--- a/Source/SelfService/Web/screens/insightsScreen.tsx
+++ b/Source/SelfService/Web/screens/insightsScreen.tsx
@@ -33,7 +33,9 @@ export const InsightsScreen: React.FunctionComponent = withRouteApplicationState
     const [loaded, setLoaded] = useState(false);
 
     useEffect(() => {
-
+        if (!currentEnvironment || !currentApplicationId) {
+            return;
+        }
         Promise.all([
             getApplications(),
             getApplication(currentApplicationId),
@@ -57,7 +59,7 @@ export const InsightsScreen: React.FunctionComponent = withRouteApplicationState
             history.push(href);
             return;
         });
-    }, []);
+    }, [currentApplicationId, currentEnvironment]);
 
     if (!loaded) {
         return null;

--- a/Source/SelfService/Web/screens/insightsScreen.tsx
+++ b/Source/SelfService/Web/screens/insightsScreen.tsx
@@ -11,7 +11,6 @@ import { getDefaultMenu, LayoutWithSidebar } from '../layout/layoutWithSidebar';
 import '../application/applicationScreen.scss';
 import { PickEnvironment } from '../components/pickEnvironment';
 import { InsightsContainerScreen } from '../insights/container';
-import { useRouteApplicationParams } from '../utils/route';
 import { RouteNotFound } from '../components/notfound';
 import { useGlobalContext } from '../stores/notifications';
 import { TopNavBar } from '../components/topNavBar';
@@ -21,13 +20,12 @@ import {
     getApplication,
     HttpResponseApplications,
 } from '../api/application';
+import { withRouteApplicationState } from './withRouteApplicationState';
 
-export const InsightsScreen: React.FunctionComponent = () => {
+export const InsightsScreen: React.FunctionComponent = withRouteApplicationState(() => {
     const history = useHistory();
-    const { setError, currentEnvironment } = useGlobalContext();
+    const { setError, currentEnvironment, currentApplicationId } = useGlobalContext();
 
-    const routeApplicationProps = useRouteApplicationParams();
-    const applicationId = routeApplicationProps.applicationId;
     const environment = currentEnvironment;
 
     const [application, setApplication] = useState({} as HttpResponseApplication);
@@ -38,7 +36,7 @@ export const InsightsScreen: React.FunctionComponent = () => {
 
         Promise.all([
             getApplications(),
-            getApplication(applicationId),
+            getApplication(currentApplicationId),
         ]).then(values => {
             const applicationsData = values[0] as HttpResponseApplications;
             const applicationData = values[1];
@@ -114,13 +112,13 @@ export const InsightsScreen: React.FunctionComponent = () => {
     ];
 
     const redirectUrl = generatePath('/insights/application/:applicationId/:environment/overview', {
-        applicationId,
+        applicationId: currentApplicationId,
         environment,
     });
 
     return (
         <LayoutWithSidebar navigation={nav}>
-            <TopNavBar routes={routes} applications={applications} applicationId={applicationId} environment={currentEnvironment} />
+            <TopNavBar routes={routes} applications={applications} applicationId={currentApplicationId} environment={currentEnvironment} />
 
             <Switch>
                 <Route path="/insights/application/:applicationId/:environment">
@@ -130,4 +128,4 @@ export const InsightsScreen: React.FunctionComponent = () => {
             </Switch>
         </LayoutWithSidebar >
     );
-};
+});

--- a/Source/SelfService/Web/screens/insightsScreen.tsx
+++ b/Source/SelfService/Web/screens/insightsScreen.tsx
@@ -22,9 +22,11 @@ import {
 } from '../api/application';
 import { withRouteApplicationState } from './withRouteApplicationState';
 
-export const InsightsScreen: React.FunctionComponent = withRouteApplicationState(() => {
+export const InsightsScreen: React.FunctionComponent = withRouteApplicationState(({ routeApplicationParams }) => {
     const history = useHistory();
-    const { setError, currentEnvironment, currentApplicationId } = useGlobalContext();
+    const { setError } = useGlobalContext();
+    const currentEnvironment = routeApplicationParams.environment;
+    const currentApplicationId = routeApplicationParams.applicationId;
 
     const environment = currentEnvironment;
 

--- a/Source/SelfService/Web/screens/insightsScreen.tsx
+++ b/Source/SelfService/Web/screens/insightsScreen.tsx
@@ -11,7 +11,7 @@ import { getDefaultMenu, LayoutWithSidebar } from '../layout/layoutWithSidebar';
 import '../application/applicationScreen.scss';
 import { PickEnvironment } from '../components/pickEnvironment';
 import { InsightsContainerScreen } from '../insights/container';
-import { withRouteApplicationProps } from '../utils/route';
+import { useRouteApplicationProps } from '../utils/route';
 import { RouteNotFound } from '../components/notfound';
 import { useGlobalContext } from '../stores/notifications';
 import { TopNavBar } from '../components/topNavBar';
@@ -26,7 +26,7 @@ export const InsightsScreen: React.FunctionComponent = () => {
     const history = useHistory();
     const { setError, currentEnvironment } = useGlobalContext();
 
-    const routeApplicationProps = withRouteApplicationProps('insights');
+    const routeApplicationProps = useRouteApplicationProps();
     const applicationId = routeApplicationProps.applicationId;
     const environment = currentEnvironment;
 

--- a/Source/SelfService/Web/screens/microservicesScreen.tsx
+++ b/Source/SelfService/Web/screens/microservicesScreen.tsx
@@ -176,24 +176,31 @@ export const MicroservicesScreen: React.FunctionComponent = withRouteApplication
                 <Route exact path="/microservices/application/:applicationId/:environment/overview">
                     <MicroservicesOverviewScreen application={application} environment={currentEnvironment} />
                 </Route>
+
                 <Route exact path="/microservices/application/:applicationId/:environment/create">
                     <MicroserviceNewScreen application={application} environment={currentEnvironment} />
                 </Route>
+
                 <Route exact path="/microservices/application/:applicationId/:environment/edit/:microserviceId">
                     <MicroserviceEditScreen application={application} environment={currentEnvironment} />
                 </Route>
+
                 <Route exact path="/microservices/application/:applicationId/:environment/view/:microserviceId/delete">
                     <DeleteView application={application} environment={currentEnvironment} />
                 </Route>
+
                 <Route exact path="/microservices/application/:applicationId/:environment/view/:microserviceId">
                     <MicroserviceViewScreen application={application} environment={currentEnvironment} />
                 </Route>
+
                 <Route exact path="/microservices/application/:applicationId/:environment/view/:microserviceId/environment-variables">
                     <MicroserviceEnvironmentVariablesView application={application} environment={currentEnvironment} />
                 </Route>
+
                 <Route exact path="/microservices/application/:applicationId/:environment/pod/view/:podName/logs">
                     <PodLogScreen />
                 </Route>
+
                 <RouteNotFound redirectUrl={redirectUrl} />
             </Switch>
         </LayoutWithSidebar >

--- a/Source/SelfService/Web/screens/microservicesScreen.tsx
+++ b/Source/SelfService/Web/screens/microservicesScreen.tsx
@@ -48,12 +48,12 @@ import {
 import { RouteNotFound } from '../components/notfound';
 import { TopNavBar } from '../components/topNavBar';
 import { HttpResponseApplication, getApplications, getApplication, HttpResponseApplications } from '../api/application';
+import { withRouteApplicationState } from './withRouteApplicationState';
 
-export const MicroservicesScreen: React.FunctionComponent = () => {
+export const MicroservicesScreen: React.FunctionComponent = withRouteApplicationState((routeApplicationProps) => {
     const history = useHistory();
     const { setNotification, currentEnvironment, currentApplicationId } = useGlobalContext();
 
-    const routeApplicationProps = useRouteApplicationProps();
     const applicationId = routeApplicationProps.applicationId;
 
     const [application, setApplication] = useState({} as HttpResponseApplication);
@@ -194,10 +194,8 @@ export const MicroservicesScreen: React.FunctionComponent = () => {
                 <Route exact path="/microservices/application/:applicationId/:environment/pod/view/:podName/logs">
                     <PodLogScreen />
                 </Route>
-
                 <RouteNotFound redirectUrl={redirectUrl} />
             </Switch>
-
         </LayoutWithSidebar >
     );
-};
+});

--- a/Source/SelfService/Web/screens/microservicesScreen.tsx
+++ b/Source/SelfService/Web/screens/microservicesScreen.tsx
@@ -38,8 +38,6 @@ import {
     mergeMicroservicesFromK8s
 } from '../stores/microservice';
 
-import { useRouteApplicationProps } from '../utils/route';
-
 import { useGlobalContext } from '../stores/notifications';
 import {
     isEnvironmentValidFromUri,
@@ -50,7 +48,7 @@ import { TopNavBar } from '../components/topNavBar';
 import { HttpResponseApplication, getApplications, getApplication, HttpResponseApplications } from '../api/application';
 import { withRouteApplicationState } from './withRouteApplicationState';
 
-export const MicroservicesScreen: React.FunctionComponent = withRouteApplicationState((routeApplicationProps) => {
+export const MicroservicesScreen: React.FunctionComponent = withRouteApplicationState(({routeApplicationProps}) => {
     const history = useHistory();
     const { setNotification, currentEnvironment, currentApplicationId } = useGlobalContext();
 

--- a/Source/SelfService/Web/screens/microservicesScreen.tsx
+++ b/Source/SelfService/Web/screens/microservicesScreen.tsx
@@ -38,7 +38,7 @@ import {
     mergeMicroservicesFromK8s
 } from '../stores/microservice';
 
-import { withRouteApplicationProps } from '../utils/route';
+import { useRouteApplicationProps } from '../utils/route';
 
 import { useGlobalContext } from '../stores/notifications';
 import {
@@ -53,7 +53,7 @@ export const MicroservicesScreen: React.FunctionComponent = () => {
     const history = useHistory();
     const { setNotification, currentEnvironment, currentApplicationId } = useGlobalContext();
 
-    const routeApplicationProps = withRouteApplicationProps('microservices');
+    const routeApplicationProps = useRouteApplicationProps();
     const applicationId = routeApplicationProps.applicationId;
 
     const [application, setApplication] = useState({} as HttpResponseApplication);
@@ -172,32 +172,25 @@ export const MicroservicesScreen: React.FunctionComponent = () => {
     return (
         <LayoutWithSidebar navigation={nav}>
             <TopNavBar routes={routes} applications={applications} applicationId={applicationId} environment={currentEnvironment} />
-
             <Switch>
                 <Route exact path="/microservices/application/:applicationId/:environment/overview">
                     <MicroservicesOverviewScreen application={application} environment={currentEnvironment} />
                 </Route>
-
                 <Route exact path="/microservices/application/:applicationId/:environment/create">
                     <MicroserviceNewScreen application={application} environment={currentEnvironment} />
                 </Route>
-
                 <Route exact path="/microservices/application/:applicationId/:environment/edit/:microserviceId">
                     <MicroserviceEditScreen application={application} environment={currentEnvironment} />
                 </Route>
-
                 <Route exact path="/microservices/application/:applicationId/:environment/view/:microserviceId/delete">
                     <DeleteView application={application} environment={currentEnvironment} />
                 </Route>
-
                 <Route exact path="/microservices/application/:applicationId/:environment/view/:microserviceId">
                     <MicroserviceViewScreen application={application} environment={currentEnvironment} />
                 </Route>
-
                 <Route exact path="/microservices/application/:applicationId/:environment/view/:microserviceId/environment-variables">
                     <MicroserviceEnvironmentVariablesView application={application} environment={currentEnvironment} />
                 </Route>
-
                 <Route exact path="/microservices/application/:applicationId/:environment/pod/view/:podName/logs">
                     <PodLogScreen />
                 </Route>

--- a/Source/SelfService/Web/screens/microservicesScreen.tsx
+++ b/Source/SelfService/Web/screens/microservicesScreen.tsx
@@ -48,7 +48,7 @@ import { TopNavBar } from '../components/topNavBar';
 import { HttpResponseApplication, getApplications, getApplication, HttpResponseApplications } from '../api/application';
 import { withRouteApplicationState } from './withRouteApplicationState';
 
-export const MicroservicesScreen: React.FunctionComponent = withRouteApplicationState(({routeApplicationProps}) => {
+export const MicroservicesScreen: React.FunctionComponent = withRouteApplicationState(({routeApplicationParams: routeApplicationProps}) => {
     const history = useHistory();
     const { setNotification, currentEnvironment, currentApplicationId } = useGlobalContext();
 

--- a/Source/SelfService/Web/screens/microservicesScreen.tsx
+++ b/Source/SelfService/Web/screens/microservicesScreen.tsx
@@ -48,9 +48,11 @@ import { TopNavBar } from '../components/topNavBar';
 import { HttpResponseApplication, getApplications, getApplication, HttpResponseApplications } from '../api/application';
 import { withRouteApplicationState } from './withRouteApplicationState';
 
-export const MicroservicesScreen: React.FunctionComponent = withRouteApplicationState(() => {
+export const MicroservicesScreen: React.FunctionComponent = withRouteApplicationState(({ routeApplicationParams }) => {
     const history = useHistory();
-    const { setNotification, currentEnvironment, currentApplicationId } = useGlobalContext();
+    const { setNotification } = useGlobalContext();
+    const currentEnvironment = routeApplicationParams.environment;
+    const currentApplicationId = routeApplicationParams.applicationId;
 
     const [application, setApplication] = useState({} as HttpResponseApplication);
     const [applications, setApplications] = useState({} as ShortInfoWithEnvironment[]);

--- a/Source/SelfService/Web/screens/microservicesScreen.tsx
+++ b/Source/SelfService/Web/screens/microservicesScreen.tsx
@@ -52,8 +52,6 @@ export const MicroservicesScreen: React.FunctionComponent = withRouteApplication
     const history = useHistory();
     const { setNotification, currentEnvironment, currentApplicationId } = useGlobalContext();
 
-    const applicationId = routeApplicationProps.applicationId;
-
     const [application, setApplication] = useState({} as HttpResponseApplication);
     const [applications, setApplications] = useState({} as ShortInfoWithEnvironment[]);
     const [loaded, setLoaded] = useState(false);
@@ -61,8 +59,8 @@ export const MicroservicesScreen: React.FunctionComponent = withRouteApplication
     useEffect(() => {
         Promise.all([
             getApplications(),
-            getApplication(applicationId),
-            getMicroservices(applicationId),
+            getApplication(currentApplicationId),
+            getMicroservices(currentApplicationId),
         ]).then(values => {
             const applicationsData = values[0] as HttpResponseApplications;
             const applicationData = values[1];
@@ -110,8 +108,7 @@ export const MicroservicesScreen: React.FunctionComponent = withRouteApplication
         );
     }
 
-    const nav = getDefaultMenu(history, applicationId, currentEnvironment);
-
+    const nav = getDefaultMenu(history, currentApplicationId, currentEnvironment);
 
     const routes = [
         {
@@ -163,13 +160,13 @@ export const MicroservicesScreen: React.FunctionComponent = withRouteApplication
 
 
     const redirectUrl = generatePath('/microservices/application/:applicationId/:environment/overview', {
-        applicationId,
+        applicationId: currentApplicationId,
         environment: currentEnvironment,
     });
 
     return (
         <LayoutWithSidebar navigation={nav}>
-            <TopNavBar routes={routes} applications={applications} applicationId={applicationId} environment={currentEnvironment} />
+            <TopNavBar routes={routes} applications={applications} applicationId={currentApplicationId} environment={currentEnvironment} />
             <Switch>
                 <Route exact path="/microservices/application/:applicationId/:environment/overview">
                     <MicroservicesOverviewScreen application={application} environment={currentEnvironment} />

--- a/Source/SelfService/Web/screens/microservicesScreen.tsx
+++ b/Source/SelfService/Web/screens/microservicesScreen.tsx
@@ -48,7 +48,7 @@ import { TopNavBar } from '../components/topNavBar';
 import { HttpResponseApplication, getApplications, getApplication, HttpResponseApplications } from '../api/application';
 import { withRouteApplicationState } from './withRouteApplicationState';
 
-export const MicroservicesScreen: React.FunctionComponent = withRouteApplicationState(({routeApplicationParams: routeApplicationProps}) => {
+export const MicroservicesScreen: React.FunctionComponent = withRouteApplicationState(() => {
     const history = useHistory();
     const { setNotification, currentEnvironment, currentApplicationId } = useGlobalContext();
 
@@ -98,7 +98,7 @@ export const MicroservicesScreen: React.FunctionComponent = withRouteApplication
         );
     }
 
-    if (!isEnvironmentValidFromUri(routeApplicationProps, applications, currentApplicationId, currentEnvironment)) {
+    if (!isEnvironmentValidFromUri(applications, currentApplicationId, currentEnvironment)) {
         return (
             <PickEnvironment
                 applications={applications}

--- a/Source/SelfService/Web/screens/microservicesScreen.tsx
+++ b/Source/SelfService/Web/screens/microservicesScreen.tsx
@@ -57,6 +57,10 @@ export const MicroservicesScreen: React.FunctionComponent = withRouteApplication
     const [loaded, setLoaded] = useState(false);
 
     useEffect(() => {
+        if (!currentEnvironment || !currentApplicationId) {
+            return;
+        }
+
         Promise.all([
             getApplications(),
             getApplication(currentApplicationId),
@@ -75,7 +79,6 @@ export const MicroservicesScreen: React.FunctionComponent = withRouteApplication
             setApplication(applicationData);
             mergeMicroservicesFromGit(applicationData.microservices);
 
-
             const microservicesData = values[2] as HttpResponseMicroservices;
             const microservices = microservicesData.microservices.filter(microservice => microservice.environment === currentEnvironment);
             mergeMicroservicesFromK8s(microservices);
@@ -84,7 +87,7 @@ export const MicroservicesScreen: React.FunctionComponent = withRouteApplication
             console.log(error);
             setNotification('Failed getting data from the server', 'error');
         });
-    }, []);
+    }, [currentEnvironment, currentApplicationId]);
 
     if (!loaded) {
         return null;

--- a/Source/SelfService/Web/screens/withRouteApplicationState.tsx
+++ b/Source/SelfService/Web/screens/withRouteApplicationState.tsx
@@ -3,10 +3,10 @@
 
 import React, { useEffect, ComponentType } from 'react';
 import { useGlobalContext } from '../stores/notifications';
-import { RouteApplicationProps, useRouteApplicationProps } from '../utils/route';
+import { RouteApplicationParams, useRouteApplicationParams } from '../utils/route';
 
 export type PropsWithRouteApplicationProps = {
-    routeApplicationProps: RouteApplicationProps
+    routeApplicationParams: RouteApplicationParams
 };
 
 export function withRouteApplicationState<T extends PropsWithRouteApplicationProps>(
@@ -14,7 +14,7 @@ export function withRouteApplicationState<T extends PropsWithRouteApplicationPro
     Component: ComponentType<T>
 ) {
     return React.memo(function RouteApplicationState() {
-        const routeApplicationProps = useRouteApplicationProps();
+        const routeApplicationParams = useRouteApplicationParams();
         const {
             currentApplicationId,
             currentEnvironment,
@@ -23,15 +23,15 @@ export function withRouteApplicationState<T extends PropsWithRouteApplicationPro
         } = useGlobalContext();
 
         useEffect(() => {
-            if (currentApplicationId !== routeApplicationProps.applicationId) {
-                setCurrentApplicationId(routeApplicationProps.applicationId);
+            if (currentApplicationId !== routeApplicationParams.applicationId) {
+                setCurrentApplicationId(routeApplicationParams.applicationId);
             }
 
-            if (currentEnvironment !== routeApplicationProps.environment) {
-                setCurrentEnvironment(routeApplicationProps.environment);
+            if (currentEnvironment !== routeApplicationParams.environment) {
+                setCurrentEnvironment(routeApplicationParams.environment);
             }
         }, []);
 
-        return <Component {...({routeApplicationProps} as T)} />;
+        return <Component {...{routeApplicationParams} as T} />;
     });
 }

--- a/Source/SelfService/Web/screens/withRouteApplicationState.tsx
+++ b/Source/SelfService/Web/screens/withRouteApplicationState.tsx
@@ -1,0 +1,22 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import React, { useContext, useMemo, ComponentType } from 'react';
+import { GlobalContext } from '../stores/notifications';
+import { RouteApplicationProps, useRouteApplicationProps } from '../utils/route';
+
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export function withRouteApplicationState<T extends RouteApplicationProps>(Component: ComponentType<T>) {
+
+    return React.memo(function RouteApplicationState() {
+        const routeApplicationProps = useRouteApplicationProps();
+        const context = useContext(GlobalContext);
+
+        useMemo(() => {
+            console.log('setting context from url', routeApplicationProps.applicationId, routeApplicationProps.environment);
+            context.setCurrentApplicationId(routeApplicationProps.applicationId);
+            context.setCurrentEnvironment(routeApplicationProps.environment);
+        }, [routeApplicationProps.applicationId, routeApplicationProps.environment]);
+        return <Component {...routeApplicationProps as T}/>;
+    });
+};

--- a/Source/SelfService/Web/screens/withRouteApplicationState.tsx
+++ b/Source/SelfService/Web/screens/withRouteApplicationState.tsx
@@ -1,22 +1,37 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-import React, { useContext, useMemo, ComponentType } from 'react';
-import { GlobalContext } from '../stores/notifications';
+import React, { useEffect, ComponentType } from 'react';
+import { useGlobalContext } from '../stores/notifications';
 import { RouteApplicationProps, useRouteApplicationProps } from '../utils/route';
 
-// eslint-disable-next-line @typescript-eslint/naming-convention
-export function withRouteApplicationState<T extends RouteApplicationProps>(Component: ComponentType<T>) {
+export type PropsWithRouteApplicationProps = {
+    routeApplicationProps: RouteApplicationProps
+};
 
+export function withRouteApplicationState<T extends PropsWithRouteApplicationProps>(
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    Component: ComponentType<T>
+) {
     return React.memo(function RouteApplicationState() {
         const routeApplicationProps = useRouteApplicationProps();
-        const context = useContext(GlobalContext);
+        const {
+            currentApplicationId,
+            currentEnvironment,
+            setCurrentEnvironment,
+            setCurrentApplicationId,
+        } = useGlobalContext();
 
-        useMemo(() => {
-            console.log('setting context from url', routeApplicationProps.applicationId, routeApplicationProps.environment);
-            context.setCurrentApplicationId(routeApplicationProps.applicationId);
-            context.setCurrentEnvironment(routeApplicationProps.environment);
-        }, [routeApplicationProps.applicationId, routeApplicationProps.environment]);
-        return <Component {...routeApplicationProps as T}/>;
+        useEffect(() => {
+            if (currentApplicationId !== routeApplicationProps.applicationId) {
+                setCurrentApplicationId(routeApplicationProps.applicationId);
+            }
+
+            if (currentEnvironment !== routeApplicationProps.environment) {
+                setCurrentEnvironment(routeApplicationProps.environment);
+            }
+        }, []);
+
+        return <Component {...({routeApplicationProps} as T)} />;
     });
-};
+}

--- a/Source/SelfService/Web/screens/withRouteApplicationState.tsx
+++ b/Source/SelfService/Web/screens/withRouteApplicationState.tsx
@@ -21,11 +21,11 @@ export function withRouteApplicationState(Component: ComponentType) {
         } = useGlobalContext();
 
         useEffect(() => {
-            if (currentApplicationId !== routeApplicationParams.applicationId) {
+            if (routeApplicationParams.applicationId && currentApplicationId !== routeApplicationParams.applicationId) {
                 setCurrentApplicationId(routeApplicationParams.applicationId);
             }
 
-            if (currentEnvironment !== routeApplicationParams.environment) {
+            if (routeApplicationParams.environment && currentEnvironment !== routeApplicationParams.environment) {
                 setCurrentEnvironment(routeApplicationParams.environment);
             }
         }, []);

--- a/Source/SelfService/Web/screens/withRouteApplicationState.tsx
+++ b/Source/SelfService/Web/screens/withRouteApplicationState.tsx
@@ -5,13 +5,17 @@ import React, { useEffect, ComponentType } from 'react';
 import { useGlobalContext } from '../stores/notifications';
 import { RouteApplicationParams, useRouteApplicationParams } from '../utils/route';
 
-export type PropsWithRouteApplicationProps = {
+export type WithRouteApplicationProps = {
     routeApplicationParams: RouteApplicationParams
 };
 
-// eslint-disable-next-line @typescript-eslint/naming-convention
-export function withRouteApplicationState(Component: ComponentType) {
-    return React.memo(function RouteApplicationState() {
+export function withRouteApplicationState<ComponentProps>(
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    WrappedComponent: ComponentType<ComponentProps & WithRouteApplicationProps>
+) {
+    // // eslint-disable-next-line @typescript-eslint/naming-convention
+    // export function withRouteApplicationState(Component: ComponentType) {
+    return React.memo(function RouteApplicationState(props: ComponentProps) {
         const routeApplicationParams = useRouteApplicationParams();
         const {
             currentApplicationId,
@@ -30,6 +34,6 @@ export function withRouteApplicationState(Component: ComponentType) {
             }
         }, []);
 
-        return <Component />;
+        return <WrappedComponent {...props as ComponentProps} routeApplicationParams={routeApplicationParams} />;
     });
 }

--- a/Source/SelfService/Web/screens/withRouteApplicationState.tsx
+++ b/Source/SelfService/Web/screens/withRouteApplicationState.tsx
@@ -9,10 +9,8 @@ export type PropsWithRouteApplicationProps = {
     routeApplicationParams: RouteApplicationParams
 };
 
-export function withRouteApplicationState<T extends PropsWithRouteApplicationProps>(
-    // eslint-disable-next-line @typescript-eslint/naming-convention
-    Component: ComponentType<T>
-) {
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export function withRouteApplicationState(Component: ComponentType) {
     return React.memo(function RouteApplicationState() {
         const routeApplicationParams = useRouteApplicationParams();
         const {
@@ -32,6 +30,6 @@ export function withRouteApplicationState<T extends PropsWithRouteApplicationPro
             }
         }, []);
 
-        return <Component {...{routeApplicationParams} as T} />;
+        return <Component />;
     });
 }

--- a/Source/SelfService/Web/utils/route.ts
+++ b/Source/SelfService/Web/utils/route.ts
@@ -1,24 +1,17 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-import { useRouteMatch } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 
 export type RouteApplicationProps = {
-    applicationId: string
-    environment: string
+    applicationId: string;
+    environment: string;
 };
 
-export const withRouteApplicationProps = (prefix: string): RouteApplicationProps => {
-    let match = useRouteMatch(`/${prefix}/application/:applicationId`);
-    const applicationId = (match?.params as RouteApplicationProps)?.applicationId ? (match?.params as RouteApplicationProps)?.applicationId : '';
-
-    // TODO I think this is a hot mess
-    match = useRouteMatch(`/${prefix}/application/:applicationId/:environment`);
-    const environment = (match?.params as RouteApplicationProps)?.environment ? (match?.params as RouteApplicationProps)?.environment : '';
-
-    //const currentEnvironment = getCurrentEnvironment();
+export const useRouteApplicationProps = (): RouteApplicationProps => {
+    const { applicationId, environment } = useParams();
     return {
-        applicationId,
-        environment,
+        applicationId: applicationId || '',
+        environment: environment || '',
     } as RouteApplicationProps;
 };

--- a/Source/SelfService/Web/utils/route.ts
+++ b/Source/SelfService/Web/utils/route.ts
@@ -3,15 +3,15 @@
 
 import { useParams } from 'react-router-dom';
 
-export type RouteApplicationProps = {
+export type RouteApplicationParams = {
     applicationId: string;
     environment: string;
 };
 
-export const useRouteApplicationProps = (): RouteApplicationProps => {
+export const useRouteApplicationParams = (): RouteApplicationParams => {
     const { applicationId, environment } = useParams();
     return {
         applicationId: applicationId || '',
         environment: environment || '',
-    } as RouteApplicationProps;
+    } as RouteApplicationParams;
 };


### PR DESCRIPTION
## Summary
Opening direct links to microservices in an environment failed sometimes. The cause of this failure is related to which environment the user has last visited. If the user has last been in "Dev", and the link is pointing to "Prod", it would fail. This information is currently stored in local storage.

This PR introduces a higher-order component that reads the `environment` and `applicationId` parameters from the URL, and overwrites these in the global context, which also updates the value in local storage.

### Fixed

- Fix direct links to environments not working when pointing to another environment than the user last visited
