### PR TITLE
Fix microservice creation and request to default to public

### DIFF
--- a/Source/SelfService/Web/api/index.ts
+++ b/Source/SelfService/Web/api/index.ts
@@ -50,6 +50,7 @@ export type MicroserviceSimpleExtra = {
     headImage: string;
     runtimeImage: string;
     ingress: MicroserviceIngressPath;
+    isPublic: boolean;
 };
 
 export type MicroserviceBusinessMomentAdaptor = {

--- a/Source/SelfService/Web/microservice/base/create.tsx
+++ b/Source/SelfService/Web/microservice/base/create.tsx
@@ -48,7 +48,8 @@ export const Create: React.FunctionComponent<Props> = (props) => {
             ingress: {
                 path: '/',
                 pathType: 'Prefix',
-            }
+            },
+            isPublic: true
         }
     } as MicroserviceSimple;
 

--- a/Source/SelfService/Web/microservice/base/view.tsx
+++ b/Source/SelfService/Web/microservice/base/view.tsx
@@ -133,6 +133,8 @@ export const View: React.FunctionComponent<Props> = (props) => {
                 },
                 headImage,
                 runtimeImage,
+                // TODO this is now hardcoded just so that we can land https://github.com/dolittle/Studio/pull/167
+                isPublic: true
             },
         };
     }


### PR DESCRIPTION
## Summary

Fix microservice creation to default to a public microservice. This is because platform-api v4 has a breaking change where it defaults to private microservice creation if the `isPublic` property on the request is not set (as `bool` types in Go default to `false`).

## Reference
- https://github.com/dolittle/platform-api/pull/102
- https://github.com/dolittle-platform/Operations/pull/192
