### PR TITLE
Make the TextField for arguments not required

### DIFF
--- a/Source/SelfService/Web/microservice/components/headArguments.tsx
+++ b/Source/SelfService/Web/microservice/components/headArguments.tsx
@@ -45,6 +45,7 @@ export const HeadArguments: React.FunctionComponent<Props> = (props) => {
                     <TextField
                         id={'headArg' + argIndex.toString()}
                         label='Argument'
+                        required={false}
                         value={arg}
                         onChange={(event) => handleArg(event, argIndex)}
                         size='small'


### PR DESCRIPTION
## Summary

Make the `TextField` for arguments not required.