### PR TITLE
m3connector experience in Studio - version 1

### DIFF
--- a/Source/SelfService/Web/App.tsx
+++ b/Source/SelfService/Web/App.tsx
@@ -29,6 +29,7 @@ import '@fontsource/rubik';
 import { ApplicationScreen } from './screens/applicationScreen';
 import { Box } from '@mui/material';
 import { ContainerRegistryScreen } from './screens/containerRegistryScreen';
+import { M3ConnectorScreen } from './screens/m3connectorScreen';
 
 const typography = {
     fontFamily: 'Rubik',
@@ -138,6 +139,10 @@ export const App = () => {
 
                                     <Route path="/containerregistry/application/:applicationId/:environment">
                                         <ContainerRegistryScreen />
+                                    </Route>
+
+                                    <Route path="/m3connector/application/:applicationId">
+                                        <M3ConnectorScreen />
                                     </Route>
 
                                     <Route path="/admin/">

--- a/Source/SelfService/Web/api/m3connector.ts
+++ b/Source/SelfService/Web/api/m3connector.ts
@@ -27,7 +27,7 @@ export async function getData(applicationId: string, environment: string): Promi
         });
     const jsonResult = await result.json() as any;
 
-    const data = jsonResult.data;
+    const data = jsonResult.data ?? {};
     return {
         accessKey: data['accessKey.pem'] ?? '',
         ca: data['ca.pem'] ?? '',

--- a/Source/SelfService/Web/api/m3connector.ts
+++ b/Source/SelfService/Web/api/m3connector.ts
@@ -28,13 +28,22 @@ export async function getData(applicationId: string, environment: string): Promi
     const jsonResult = await result.json() as any;
 
     const data = jsonResult.data ?? {};
+    const configDataStr = data['config.json'] ?? '';
+    let configData = {
+        brokerUrl: '',
+        topics: [] as string[]
+    };
+
+    try {
+        configData = JSON.parse(configDataStr);
+    } catch (e) {
+        // do nothing
+    }
+
     return {
         accessKey: data['accessKey.pem'] ?? '',
         ca: data['ca.pem'] ?? '',
         certificate: data['certificate.pem'] ?? '',
-        config: data['config.json'] ?? {
-            brokerUrl: '',
-            topics: [] as string[]
-        },
+        config: configData,
     } as M3ConnectorData;
 }

--- a/Source/SelfService/Web/api/m3connector.ts
+++ b/Source/SelfService/Web/api/m3connector.ts
@@ -1,0 +1,40 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { getServerUrlPrefix } from './api';
+
+export type M3ConnectorData = {
+    accessKey: string
+    ca: string
+    certificate: string
+    config: M3ConnectorDataConfig
+};
+
+export type M3ConnectorDataConfig = {
+    brokerUrl: string
+    topics: string[]
+};
+
+
+export async function getData(applicationId: string, environment: string): Promise<M3ConnectorData> {
+    const url = `${getServerUrlPrefix()}/live/application/${applicationId}/configmap/${environment.toLocaleLowerCase()}-kafka-files`;
+
+    const result = await fetch(
+        url,
+        {
+            method: 'GET',
+            mode: 'cors'
+        });
+    const jsonResult = await result.json() as any;
+
+    const data = jsonResult.data;
+    return {
+        accessKey: data['accessKey.pem'] ?? '',
+        ca: data['ca.pem'] ?? '',
+        certificate: data['certificate.pem'] ?? '',
+        config: data['config.json'] ?? {
+            brokerUrl: '',
+            topics: [] as string[]
+        },
+    } as M3ConnectorData;
+}

--- a/Source/SelfService/Web/layout/layoutWithSidebar.tsx
+++ b/Source/SelfService/Web/layout/layoutWithSidebar.tsx
@@ -143,7 +143,7 @@ export const getMenuWithApplication = (history: History<LocationState>, applicat
     if (hasConnector) {
         // Put before documentation link
         items.splice(items.length - 1, 0, {
-            href: `/m3connector/application/${applicationId}/overview`,
+            href: `/m3connector/application/${applicationId}/${environment}/details`,
             name: 'M3 Connector'
         });
     }

--- a/Source/SelfService/Web/layout/layoutWithSidebar.tsx
+++ b/Source/SelfService/Web/layout/layoutWithSidebar.tsx
@@ -8,6 +8,7 @@ import { History, LocationState } from 'history';
 
 import './layout.scss';
 import { AlertBox } from '../components/alertBox';
+import { HttpResponseApplication } from '../api/application';
 
 type Props = {
     navigation: React.ReactNode
@@ -57,6 +58,28 @@ export const LayoutWithSidebar: React.FunctionComponent<Props> = (props) => {
     );
 };
 
+export const getDefaultMenuWithItems = (history: History<LocationState>, items: any[]): React.ReactNode => {
+    return (
+        <>
+            <ul>
+                {items.map(link => {
+                    return (
+                        <li key={link.name}>
+                            <a href="#" onClick={(event) => {
+                                event.preventDefault();
+                                const href = link.href;
+                                history.push(href);
+                            }}>
+                                {link.name}
+                            </a>
+                        </li>
+                    );
+                })}
+            </ul>
+        </>
+    );
+};
+
 export const getDefaultMenu = (history: History<LocationState>, applicationId: string, environment: string): React.ReactNode => {
     const items = [
         {
@@ -85,23 +108,47 @@ export const getDefaultMenu = (history: History<LocationState>, applicationId: s
         },
     ];
 
-    return (
-        <>
-            <ul>
-                {items.map(link => {
-                    return (
-                        <li key={link.name}>
-                            <a href="#" onClick={(event) => {
-                                event.preventDefault();
-                                const href = link.href;
-                                history.push(href);
-                            }}>
-                                {link.name}
-                            </a>
-                        </li>
-                    );
-                })}
-            </ul>
-        </>
-    );
+    return getDefaultMenuWithItems(history, items);
+};
+
+
+export const getMenuWithApplication = (history: History<LocationState>, application: HttpResponseApplication, environment: string): React.ReactNode => {
+    const applicationId = application.id;
+
+    const hasConnector = application.environments.find(_environment => _environment.connections.m3Connector);
+    const items = [
+        {
+            href: `/backups/application/${applicationId}/overview`,
+            name: 'Backups'
+        },
+        {
+            href: `/microservices/application/${applicationId}/${environment}/overview`,
+            name: 'Microservices'
+        },
+        {
+            href: `/insights/application/${applicationId}/${environment}/overview`,
+            name: 'Insights'
+        },
+        {
+            href: `/containerregistry/application/${applicationId}/${environment}/overview`,
+            name: 'Container Registry'
+        },
+        {
+            href: `/documentation/application/${applicationId}/${environment}/overview`,
+            name: 'Documentation'
+        },
+    ];
+
+
+    if (hasConnector) {
+        // Put before documentation link
+        items.splice(items.length - 1, 0, {
+            href: `/m3connector/application/${applicationId}/overview`,
+            name: 'M3 Connector'
+        });
+    }
+
+
+
+    return getDefaultMenuWithItems(history, items);
 };

--- a/Source/SelfService/Web/layout/layoutWithSidebar.tsx
+++ b/Source/SelfService/Web/layout/layoutWithSidebar.tsx
@@ -76,6 +76,10 @@ export const getDefaultMenu = (history: History<LocationState>, applicationId: s
             name: 'Container Registry'
         },
         {
+            href: `/m3connector/application/${applicationId}/overview`,
+            name: 'M3 Connector'
+        },
+        {
             href: `/documentation/application/${applicationId}/${environment}/overview`,
             name: 'Documentation'
         },

--- a/Source/SelfService/Web/m3connector/container.tsx
+++ b/Source/SelfService/Web/m3connector/container.tsx
@@ -1,0 +1,40 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import React from 'react';
+import { Switch, Route } from 'react-router-dom';
+import { HttpResponseApplication } from '../api/application';
+
+import { View as Overview } from './overview';
+import { View as Details } from './details';
+import { View as Setup } from './setup';
+
+
+type Props = {
+    application: HttpResponseApplication
+};
+
+export const Container: React.FunctionComponent<Props> = (props) => {
+    const _props = props!;
+    const application = _props.application;
+    const applicationId = application.id;
+
+    return (
+        <>
+
+            <h1>M3 Connector</h1>
+            <Switch>
+                <Route exact path="/m3connector/application/:applicationId/overview">
+                    <Overview application={application} />
+                </Route>
+                <Route exact path="/m3connector/application/:applicationId/:environment/setup">
+                    <Setup application={application} />
+                </Route>
+
+                <Route exact path="/m3connector/application/:applicationId/:environment/details">
+                    <Details applicationId={applicationId} />
+                </Route>
+            </Switch>
+        </>
+    );
+};

--- a/Source/SelfService/Web/m3connector/details.tsx
+++ b/Source/SelfService/Web/m3connector/details.tsx
@@ -1,0 +1,64 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import TextareaAutosize from '@mui/material/TextareaAutosize';
+import React, { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { getData, M3ConnectorData } from '../api/m3connector';
+
+type Props = {
+    applicationId: string
+};
+
+export const View: React.FunctionComponent<Props> = (props) => {
+    const _props = props!;
+    const applicationId = _props.applicationId;
+    const { environment } = useParams();
+
+    const [loaded, setLoaded] = useState(false);
+    const [data, setData] = useState({} as M3ConnectorData);
+
+    useEffect(() => {
+        Promise.all([
+            getData(applicationId, environment)
+        ]).then(values => {
+            setData(values[0]);
+            setLoaded(true);
+        });
+    }, []);
+
+
+    if (!loaded) {
+        return null;
+    }
+
+    return (
+        <>
+            <h1>Data</h1>
+            <h2>accessKey.pem</h2>
+            <TextareaAutosize
+                value={data.accessKey}
+                style={{ width: 600 }}
+            />
+
+            <h2>ca.pem</h2>
+            <TextareaAutosize
+                value={data.ca}
+                style={{ width: 600 }}
+            />
+
+
+            <h2>certificate.pem</h2>
+            <TextareaAutosize
+                value={data.certificate}
+                style={{ width: 600 }}
+            />
+
+            <h2>Config</h2>
+            <TextareaAutosize
+                value={JSON.stringify(data.config, null, '  ')}
+                style={{ width: 600 }}
+            />
+        </>
+    );
+};

--- a/Source/SelfService/Web/m3connector/details.tsx
+++ b/Source/SelfService/Web/m3connector/details.tsx
@@ -34,7 +34,12 @@ export const View: React.FunctionComponent<Props> = (props) => {
 
     return (
         <>
-            <h1>Data</h1>
+            <h2>Config</h2>
+            <TextareaAutosize
+                value={JSON.stringify(data.config, null, '  ')}
+                style={{ width: 600 }}
+            />
+
             <h2>accessKey.pem</h2>
             <TextareaAutosize
                 value={data.accessKey}
@@ -54,11 +59,6 @@ export const View: React.FunctionComponent<Props> = (props) => {
                 style={{ width: 600 }}
             />
 
-            <h2>Config</h2>
-            <TextareaAutosize
-                value={JSON.stringify(data.config, null, '  ')}
-                style={{ width: 600 }}
-            />
         </>
     );
 };

--- a/Source/SelfService/Web/m3connector/overview.tsx
+++ b/Source/SelfService/Web/m3connector/overview.tsx
@@ -1,0 +1,53 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import React from 'react';
+import { HttpResponseApplication } from '../api/application';
+import { useHistory } from 'react-router-dom';
+import { ButtonText } from '../theme/buttonText';
+
+type Props = {
+    application: HttpResponseApplication
+};
+
+type EnvironmentInfo = {
+    name: string
+    connected: boolean
+};
+
+export const View: React.FunctionComponent<Props> = (props) => {
+    const history = useHistory();
+    const _props = props!;
+    const application = _props.application;
+    const applicationId = application.id;
+
+    const environments = application.environments.map(_environment => ({
+        name: _environment.name,
+        connected: _environment.connections.m3Connector,
+    })) as EnvironmentInfo[];
+
+    return (
+        <>
+            <h1>Overview</h1>
+
+
+            {environments.map(row => (
+                <>
+                    <h2>{row.name}</h2>
+
+                    <ButtonText onClick={async () => {
+                        const environment = row.name;
+                        const href = row.connected ?
+                            `/m3connector/application/${applicationId}/${environment}/details` :
+                            `/m3connector/application/${applicationId}/${environment}/setup`;
+                        history.push(href);
+                    }}>{row.connected ? 'View Details' : 'Setup'}</ButtonText>
+                </>
+            ))
+            }
+        </>
+    );
+};
+
+
+

--- a/Source/SelfService/Web/m3connector/setup.tsx
+++ b/Source/SelfService/Web/m3connector/setup.tsx
@@ -1,0 +1,51 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import React from 'react';
+import { HttpResponseApplication } from '../api/application';
+import { useParams, useHistory } from 'react-router-dom';
+import { ButtonText } from '../theme/buttonText';
+
+type Props = {
+    application: HttpResponseApplication
+};
+
+export const View: React.FunctionComponent<Props> = (props) => {
+    const history = useHistory();
+    const { environment } = useParams();
+    const _props = props!;
+    const application = _props.application;
+    const applicationId = application.id;
+
+    console.log('environment', environment);
+
+    const environmentInfo = application.environments.find(_environment => _environment.name === environment)!;
+    if (!environmentInfo) {
+        return <p>Environment not found</p>;
+    }
+
+    const isSetup = environmentInfo.connections.m3Connector;
+
+    if (isSetup) {
+        return (
+            <>
+                <p>Already setup</p>
+                <ButtonText onClick={async () => {
+                    const href = `/m3connector/application/${applicationId}/${environment}/details`;
+                    history.push(href);
+                }}>View Details</ButtonText>
+            </>
+        );
+    }
+
+    return (
+        <>
+            <p>Environment {environment}</p>
+            <p>ApplicationId {applicationId}</p>
+            <p>TODO: trigger creation of m3connector kafka setup (@joel)</p>
+        </>
+    );
+};
+
+
+

--- a/Source/SelfService/Web/screens/backupsScreen.tsx
+++ b/Source/SelfService/Web/screens/backupsScreen.tsx
@@ -11,7 +11,7 @@ import {
 
 import { getApplication, HttpResponseApplication } from '../api/application';
 import { ViewCard } from '../backup/viewCard';
-import { getDefaultMenu, LayoutWithSidebar } from '../layout/layoutWithSidebar';
+import { getMenuWithApplication, LayoutWithSidebar } from '../layout/layoutWithSidebar';
 import { BreadCrumbContainer } from '../layout/breadcrumbs';
 import { useRouteApplicationParams } from '../utils/route';
 import { ListView } from '../backup/listView';
@@ -58,7 +58,7 @@ export const BackupsScreen: React.FunctionComponent<Props> = (props) => {
         );
     }
     const environments = application.environments;
-    const nav = getDefaultMenu(history, application.id, currentEnvironment);
+    const nav = getMenuWithApplication(history, application, currentEnvironment);
 
     const routes = [
         {

--- a/Source/SelfService/Web/screens/containerRegistryScreen.tsx
+++ b/Source/SelfService/Web/screens/containerRegistryScreen.tsx
@@ -10,7 +10,7 @@ import {
 } from 'react-router-dom';
 
 import { ShortInfoWithEnvironment } from '../api/api';
-import { getDefaultMenu, LayoutWithSidebar } from '../layout/layoutWithSidebar';
+import { getMenuWithApplication, LayoutWithSidebar } from '../layout/layoutWithSidebar';
 
 
 import { RouteNotFound } from '../components/notfound';
@@ -85,7 +85,7 @@ export const ContainerRegistryScreen: React.FunctionComponent = withRouteApplica
         );
     }
 
-    const nav = getDefaultMenu(history, application.id, currentEnvironment);
+    const nav = getMenuWithApplication(history, application, currentEnvironment);
 
     const routes = [];
 

--- a/Source/SelfService/Web/screens/documentationScreen.tsx
+++ b/Source/SelfService/Web/screens/documentationScreen.tsx
@@ -10,7 +10,7 @@ import {
 } from 'react-router-dom';
 
 import { ShortInfoWithEnvironment } from '../api/api';
-import { getDefaultMenu, LayoutWithSidebar } from '../layout/layoutWithSidebar';
+import { getMenuWithApplication, LayoutWithSidebar } from '../layout/layoutWithSidebar';
 
 
 // I wonder if scss is scoped like svelte. I hope so!
@@ -18,7 +18,6 @@ import { getDefaultMenu, LayoutWithSidebar } from '../layout/layoutWithSidebar';
 import '../application/applicationScreen.scss';
 
 import { DocumentationContainerScreen } from '../documentation/container';
-import { useRouteApplicationParams } from '../utils/route';
 import { RouteNotFound } from '../components/notfound';
 import { PickEnvironment, isEnvironmentValidFromUri } from '../components/pickEnvironment';
 import { useGlobalContext } from '../stores/notifications';
@@ -93,7 +92,7 @@ export const DocumentationScreen: React.FunctionComponent = withRouteApplication
         );
     }
 
-    const nav = getDefaultMenu(history, application.id, currentEnvironment);
+    const nav = getMenuWithApplication(history, application, currentEnvironment);
 
     const routes = [
         {

--- a/Source/SelfService/Web/screens/insightsScreen.tsx
+++ b/Source/SelfService/Web/screens/insightsScreen.tsx
@@ -6,7 +6,7 @@ import { Route, useHistory, Switch, generatePath } from 'react-router-dom';
 
 import { ShortInfoWithEnvironment } from '../api/api';
 
-import { getDefaultMenu, LayoutWithSidebar } from '../layout/layoutWithSidebar';
+import { getMenuWithApplication, LayoutWithSidebar } from '../layout/layoutWithSidebar';
 // Not scoped like svelte
 import '../application/applicationScreen.scss';
 import { PickEnvironment } from '../components/pickEnvironment';
@@ -85,7 +85,7 @@ export const InsightsScreen: React.FunctionComponent = withRouteApplicationState
         );
     }
 
-    const nav = getDefaultMenu(history, application.id, environment);
+    const nav = getMenuWithApplication(history, application, currentEnvironment);
 
     const routes = [
         {

--- a/Source/SelfService/Web/screens/m3connectorScreen.tsx
+++ b/Source/SelfService/Web/screens/m3connectorScreen.tsx
@@ -1,0 +1,79 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import React, { useEffect, useState } from 'react';
+import {
+    Route,
+    Switch,
+    useHistory,
+} from 'react-router-dom';
+
+import { getApplication, HttpResponseApplication } from '../api/application';
+import { getDefaultMenu, LayoutWithSidebar } from '../layout/layoutWithSidebar';
+import { BreadCrumbContainer } from '../layout/breadcrumbs';
+import { useRouteApplicationParams } from '../utils/route';
+import { useGlobalContext } from '../stores/notifications';
+import { getData } from '../api/m3connector';
+import { Container } from '../m3connector/container';
+
+type Props = {
+    application?: HttpResponseApplication
+};
+
+export const M3ConnectorScreen: React.FunctionComponent<Props> = (props) => {
+    const history = useHistory();
+    const { currentEnvironment } = useGlobalContext();
+
+    const routeApplicationProps = useRouteApplicationParams();
+    const applicationId = routeApplicationProps.applicationId;
+    const [application, setApplication] = useState({} as HttpResponseApplication);
+    const [loaded, setLoaded] = useState(false);
+
+    useEffect(() => {
+        Promise.all([
+            getApplication(applicationId),
+        ]).then(values => {
+            const applicationData = values[0];
+            if (!applicationData?.id) {
+                const href = `/problem`;
+                history.push(href);
+                return;
+            }
+
+            setApplication(applicationData);
+            setLoaded(true);
+        });
+    }, []);
+
+    if (!loaded) {
+        return null;
+    }
+
+    if (application.id === '') {
+        return (
+            <>
+                <h1>Application  not found</h1>
+            </>
+        );
+    }
+    const nav = getDefaultMenu(history, application.id, currentEnvironment);
+
+    const routes = [];
+
+    return (
+        <>
+            <LayoutWithSidebar navigation={nav}>
+                <div id="topNavBar" className="nav flex-container">
+                    <div className="left flex-start">
+                        <BreadCrumbContainer routes={routes} />
+                    </div>
+                </div>
+                <Switch>
+                    <Route path="/m3connector/application/:applicationId">
+                        <Container application={application} />
+                    </Route>
+                </Switch>
+            </LayoutWithSidebar>
+        </>
+    );
+};

--- a/Source/SelfService/Web/screens/m3connectorScreen.tsx
+++ b/Source/SelfService/Web/screens/m3connectorScreen.tsx
@@ -9,11 +9,11 @@ import {
 } from 'react-router-dom';
 
 import { getApplication, HttpResponseApplication } from '../api/application';
-import { getDefaultMenu, LayoutWithSidebar } from '../layout/layoutWithSidebar';
+import { getMenuWithApplication, LayoutWithSidebar } from '../layout/layoutWithSidebar';
 import { BreadCrumbContainer } from '../layout/breadcrumbs';
 import { useRouteApplicationParams } from '../utils/route';
 import { useGlobalContext } from '../stores/notifications';
-import { getData } from '../api/m3connector';
+
 import { Container } from '../m3connector/container';
 
 type Props = {
@@ -56,7 +56,8 @@ export const M3ConnectorScreen: React.FunctionComponent<Props> = (props) => {
             </>
         );
     }
-    const nav = getDefaultMenu(history, application.id, currentEnvironment);
+
+    const nav = getMenuWithApplication(history, application, currentEnvironment);
 
     const routes = [];
 

--- a/Source/SelfService/Web/screens/microservicesScreen.tsx
+++ b/Source/SelfService/Web/screens/microservicesScreen.tsx
@@ -26,7 +26,7 @@ import { Delete as DeleteView } from '../microservice/delete';
 import { PodLogScreen } from '../microservice/podLogScreen';
 import {
     LayoutWithSidebar,
-    getDefaultMenu
+    getMenuWithApplication
 } from '../layout/layoutWithSidebar';
 
 // I wonder if scss is scoped like svelte. I hope so!
@@ -113,7 +113,7 @@ export const MicroservicesScreen: React.FunctionComponent = withRouteApplication
         );
     }
 
-    const nav = getDefaultMenu(history, currentApplicationId, currentEnvironment);
+    const nav = getMenuWithApplication(history, application, currentEnvironment);
 
     const routes = [
         {


### PR DESCRIPTION
## Summary

Add m3connector link on the left to allow the user to interact with the m3 connector setup in the platform

## Added
- Able to get an overview of which environment has m3connector setup
- Able to view details about the m3 connector
- Able to trigger setup of the m3 connector (not talking to the backend)


Solves: https://app.asana.com/0/1202121266838773/1202253446321915/f