### PR TITLE
Microservice dropdown, view in absolute date range and timestamps for Logs

### DIFF
--- a/Source/SelfService/Web/logging/logFilter/activeFilters.tsx
+++ b/Source/SelfService/Web/logging/logFilter/activeFilters.tsx
@@ -14,7 +14,7 @@ export type ActiveFiltersProps = {
 export const ActiveFilters = (props: ActiveFiltersProps) => {
 
     const clearFilters = () => {
-        props.updateFilters({ searchTerms: [] });
+        props.updateFilters({ ...props.filters, searchTerms: [] });
     };
 
     const removeTerm = (term: string, index: number) => {

--- a/Source/SelfService/Web/logging/logFilter/activeFilters.tsx
+++ b/Source/SelfService/Web/logging/logFilter/activeFilters.tsx
@@ -4,7 +4,7 @@
 import { Chip, Typography } from '@mui/material';
 import React from 'react';
 import { ButtonText } from '../../theme/buttonText';
-import { LogFilterObject } from './logFilterPanel';
+import { LogFilterMicroservice, LogFilterObject } from './logFilterPanel';
 
 export type ActiveFiltersProps = {
     filters: LogFilterObject;
@@ -26,6 +26,17 @@ export const ActiveFilters = (props: ActiveFiltersProps) => {
         });
     };
 
+    const removeMicroservice = (microservice: LogFilterMicroservice, index: number) => {
+        if (props.filters.microservice === undefined) return;
+
+        const microservices = [...props.filters.microservice];
+        microservices.splice(index, 1);
+        props.updateFilters({
+            ...props.filters,
+            microservice: microservices
+        });
+    };
+
     return (
         <>
             <ButtonText
@@ -38,17 +49,27 @@ export const ActiveFilters = (props: ActiveFiltersProps) => {
             </ButtonText>
             {props.filters.searchTerms.map((s, index) =>
                 <Chip
-                    key={index.toString()}
+                    key={index}
                     label={`"${s}"`}
-                    onDelete={() => { removeTerm(s, index); }}
+                    onDelete={() => removeTerm(s, index)}
                     color='primary'
                     size='small'
                     sx={{ ml: 1 }}
                 />
             )}
             <Typography variant='body1' component='span' sx={{ mx: 2 }}>|</Typography>
+            {props.filters.microservice?.map((microservice, index) =>
+                <Chip
+                    key={index}
+                    label={microservice.name}
+                    onDelete={() => removeMicroservice(microservice, index)}
+                    color='primary'
+                    size='small'
+                    sx={{ mr: 1 }}
+                />
+            )}
             <Chip
-                label='Live logs'
+                label={props.filters.dateRange === 'live' ? 'Live logs' : 'Date range'}
                 color='primary'
                 size='small'
             />

--- a/Source/SelfService/Web/logging/logFilter/activeFilters.tsx
+++ b/Source/SelfService/Web/logging/logFilter/activeFilters.tsx
@@ -48,7 +48,7 @@ export const ActiveFilters = (props: ActiveFiltersProps) => {
             )}
             <Typography variant='body1' component='span' sx={{ mx: 2 }}>|</Typography>
             <Chip
-                label='Last 24 hours'
+                label='Live logs'
                 color='primary'
                 size='small'
             />

--- a/Source/SelfService/Web/logging/logFilter/dateRangeFilter.tsx
+++ b/Source/SelfService/Web/logging/logFilter/dateRangeFilter.tsx
@@ -1,0 +1,127 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import React, { useState, useEffect } from 'react';
+import { MenuItem, Select, SelectChangeEvent, TextField } from '@mui/material';
+import { DateTimePicker, LocalizationProvider } from '@mui/x-date-pickers';
+import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
+import { nb } from 'date-fns/locale';
+
+import { LogFilterDateRange } from './logFilterPanel';
+
+export type DateRangeFilterProps = {
+    range: LogFilterDateRange;
+    onSetDateRange: (range: LogFilterDateRange) => void;
+};
+
+const beginningOfToday = () => {
+    const date = new Date();
+    date.setHours(0, 0, 0, 0);
+    return date;
+};
+
+const endOfToday = () => {
+    const date = new Date();
+    date.setHours(23, 59, 59, 999);
+    return date;
+};
+
+export const DateRangeFilter = (props: DateRangeFilterProps) => {
+    const [startDate, setStartDate] = useState<Date | null>(beginningOfToday);
+    const [stopDate, setStopDate] = useState<Date | null>(endOfToday);
+
+    const selectValue = props.range === 'live' ? 'live' : 'daterange';
+
+    useEffect(() => {
+        if (props.range === 'live') return;
+
+        const start = Number(props.range.start / 1_000_000n);
+        if (startDate === null || startDate.valueOf() !== start) {
+            setStartDate(new Date(start));
+        }
+
+        const stop = Number(props.range.stop / 1_000_000n);
+        if (stopDate === null || stopDate.valueOf() !== stop) {
+            setStopDate(new Date(stop));
+        }
+
+    }, [props.range]);
+
+    const handleOnChange = (event: SelectChangeEvent<string>) => {
+        if (event.target.value === 'daterange') {
+            let start = startDate, stop = stopDate;
+
+            if (start === null) {
+                start = beginningOfToday();
+                setStartDate(start);
+            }
+
+            if (stop === null) {
+                stop = endOfToday();
+                setStopDate(stop);
+            }
+
+            props.onSetDateRange({
+                start: BigInt(start.valueOf()) * 1_000_000n,
+                stop: BigInt(stop.valueOf()) * 1_000_000n,
+            });
+
+        } else {
+            props.onSetDateRange('live');
+        }
+    };
+
+    const handleOnStartDateChange = (value: Date | null) => {
+        setStartDate(value);
+
+        if (props.range !== 'live' && value !== null && BigInt(value.valueOf()) * 1_000_000n < props.range.stop) {
+            props.onSetDateRange({
+                start: BigInt(value.valueOf()) * 1_000_000n,
+                stop: props.range.stop,
+            });
+        }
+    };
+
+    const handleOnStopDateChange = (value: Date | null) => {
+        setStopDate(value);
+
+        if (props.range !== 'live' && value !== null && BigInt(value.valueOf()) * 1_000_000n > props.range.start) {
+            props.onSetDateRange({
+                start: props.range.start,
+                stop: BigInt(value.valueOf()) * 1_000_000n,
+            });
+        }
+    };
+
+    return (
+        <LocalizationProvider dateAdapter={AdapterDateFns} adapterLocale={nb}>
+            <Select
+                variant='standard'
+                value={selectValue}
+                onChange={handleOnChange}
+            >
+                <MenuItem value='live'>Live logs</MenuItem>
+                <MenuItem value='daterange'>Date range</MenuItem>
+            </Select>
+            {
+                props.range !== 'live' &&
+                <>
+                    <DateTimePicker
+                        renderInput={(props) => <TextField {...props} variant='outlined' label='Start' />}
+                        mask='__.__.____ __:__'
+                        value={startDate}
+                        onChange={handleOnStartDateChange}
+                        maxDateTime={stopDate === null ? undefined : stopDate}
+                    />
+                    <DateTimePicker
+                        renderInput={(props) => <TextField {...props} variant='outlined' label='End' />}
+                        mask='__.__.____ __:__'
+                        value={stopDate}
+                        onChange={handleOnStopDateChange}
+                        minDateTime={startDate === null ? undefined : startDate}
+                    />
+                </>
+            }
+        </LocalizationProvider>
+    );
+};

--- a/Source/SelfService/Web/logging/logFilter/dateRangeFilter.tsx
+++ b/Source/SelfService/Web/logging/logFilter/dateRangeFilter.tsx
@@ -110,30 +110,37 @@ export const DateRangeFilter = (props: DateRangeFilterProps) => {
             {
                 props.range !== 'live' &&
                 <>
-                    <Box component='span'>
-                        <DateTimePicker
-                            renderInput={(props) => <TextField {...props} variant='outlined' />}
-                            InputProps={dateTimePickerInputProps}
-                            label='Start'
-                            mask='__.__.____ __:__'
-                            value={startDate}
-                            onChange={handleOnStartDateChange}
-                            maxDateTime={stopDate === null ? undefined : stopDate}
-                        />
-                    </Box>
-                    <Box component='span'>
-                        <DateTimePicker
-                            renderInput={(props) => <TextField {...props} variant='outlined' />}
-                            InputProps={dateTimePickerInputProps}
-                            mask='__.__.____ __:__'
-                            label='End'
-                            value={stopDate}
-                            onChange={handleOnStopDateChange}
-                            minDateTime={startDate === null ? undefined : startDate}
-                        />
+                    <Box component='span'
+                        sx={{
+                            display: 'inline-block',
+                            verticalAlign: 'top'
+                        }}
+                    >
+                        <Box component='span' mr={1}>
+                            <DateTimePicker
+                                renderInput={(props) => <TextField {...props} variant='outlined' />}
+                                InputProps={dateTimePickerInputProps}
+                                label='Start'
+                                mask='__.__.____ __:__'
+                                value={startDate}
+                                onChange={handleOnStartDateChange}
+                                maxDateTime={stopDate === null ? undefined : stopDate}
+                            />
+                        </Box>
+                        <Box component='span'>
+                            <DateTimePicker
+                                renderInput={(props) => <TextField {...props} variant='outlined' />}
+                                InputProps={dateTimePickerInputProps}
+                                mask='__.__.____ __:__'
+                                label='End'
+                                value={stopDate}
+                                onChange={handleOnStopDateChange}
+                                minDateTime={startDate === null ? undefined : startDate}
+                            />
+                        </Box>
                     </Box>
                 </>
             }
-        </LocalizationProvider>
+        </LocalizationProvider >
     );
 };

--- a/Source/SelfService/Web/logging/logFilter/dateRangeFilter.tsx
+++ b/Source/SelfService/Web/logging/logFilter/dateRangeFilter.tsx
@@ -2,12 +2,13 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 import React, { useState, useEffect } from 'react';
-import { MenuItem, Select, SelectChangeEvent, TextField } from '@mui/material';
+import { Box, InputProps, MenuItem, SelectChangeEvent, TextField } from '@mui/material';
 import { DateTimePicker, LocalizationProvider } from '@mui/x-date-pickers';
 import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
 import { nb } from 'date-fns/locale';
 
 import { LogFilterDateRange } from './logFilterPanel';
+import { FilterSelect } from './filterSelect';
 
 export type DateRangeFilterProps = {
     range: LogFilterDateRange;
@@ -93,33 +94,44 @@ export const DateRangeFilter = (props: DateRangeFilterProps) => {
         }
     };
 
+    const dateTimePickerInputProps: Partial<InputProps> = {
+        size: 'small',
+    };
+
     return (
         <LocalizationProvider dateAdapter={AdapterDateFns} adapterLocale={nb}>
-            <Select
-                variant='standard'
+            <FilterSelect
                 value={selectValue}
                 onChange={handleOnChange}
             >
                 <MenuItem value='live'>Live logs</MenuItem>
-                <MenuItem value='daterange'>Date range</MenuItem>
-            </Select>
+                <MenuItem value='daterange'>Date range...</MenuItem>
+            </FilterSelect>
             {
                 props.range !== 'live' &&
                 <>
-                    <DateTimePicker
-                        renderInput={(props) => <TextField {...props} variant='outlined' label='Start' />}
-                        mask='__.__.____ __:__'
-                        value={startDate}
-                        onChange={handleOnStartDateChange}
-                        maxDateTime={stopDate === null ? undefined : stopDate}
-                    />
-                    <DateTimePicker
-                        renderInput={(props) => <TextField {...props} variant='outlined' label='End' />}
-                        mask='__.__.____ __:__'
-                        value={stopDate}
-                        onChange={handleOnStopDateChange}
-                        minDateTime={startDate === null ? undefined : startDate}
-                    />
+                    <Box component='span'>
+                        <DateTimePicker
+                            renderInput={(props) => <TextField {...props} variant='outlined' />}
+                            InputProps={dateTimePickerInputProps}
+                            label='Start'
+                            mask='__.__.____ __:__'
+                            value={startDate}
+                            onChange={handleOnStartDateChange}
+                            maxDateTime={stopDate === null ? undefined : stopDate}
+                        />
+                    </Box>
+                    <Box component='span'>
+                        <DateTimePicker
+                            renderInput={(props) => <TextField {...props} variant='outlined' />}
+                            InputProps={dateTimePickerInputProps}
+                            mask='__.__.____ __:__'
+                            label='End'
+                            value={stopDate}
+                            onChange={handleOnStopDateChange}
+                            minDateTime={startDate === null ? undefined : startDate}
+                        />
+                    </Box>
                 </>
             }
         </LocalizationProvider>

--- a/Source/SelfService/Web/logging/logFilter/filterSelect.tsx
+++ b/Source/SelfService/Web/logging/logFilter/filterSelect.tsx
@@ -1,0 +1,20 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import React from 'react';
+import { Select, SelectProps } from '@mui/material';
+
+export type FilterSelectProps<T> = SelectProps<T>;
+
+export const FilterSelect = <T,>(props: FilterSelectProps<T>) =>
+    <Select
+        {...props}
+        variant='standard'
+        sx={{
+            ...props.sx,
+            '&:before, &:hover:not(.Mui-disabled):before, &:after': {
+                border: 'none',
+            },
+            'typography': 'button',
+        }}
+    />;

--- a/Source/SelfService/Web/logging/logFilter/logFilterPanel.tsx
+++ b/Source/SelfService/Web/logging/logFilter/logFilterPanel.tsx
@@ -5,6 +5,7 @@ import React from 'react';
 import { Grid } from '@mui/material';
 import { ActiveFilters } from './activeFilters';
 import { SearchFilter } from './searchFilter';
+import { MicroserviceFilter } from './microserviceFilter';
 
 export type LogFilterDateRange = {
     start: number;
@@ -23,12 +24,12 @@ export type LogFilterObject = {
 
 
 export type LogFilterPanelProps = {
-    microservices?: LogFilterMicroservice[];
+    microservices: LogFilterMicroservice[];
     filters: LogFilterObject;
     setSearchFilters: (filter: LogFilterObject) => void;
 };
 
-export const LogFilterPanel = ({ filters, setSearchFilters }: LogFilterPanelProps) => {
+export const LogFilterPanel = ({ microservices, filters, setSearchFilters }: LogFilterPanelProps) => {
 
     const onUpdateFilters = (filters: LogFilterObject) => {
         setSearchFilters(filters);
@@ -41,11 +42,24 @@ export const LogFilterPanel = ({ filters, setSearchFilters }: LogFilterPanelProp
         });
     };
 
+    const onSelectMicroservices = (selection: LogFilterMicroservice[]) => {
+        setSearchFilters({
+            ...filters,
+            microservice: selection,
+        });
+    };
+
     return (
         <>
             <Grid container spacing={2}>
                 <Grid item xs={12} md={6}>
                     <SearchFilter onSearch={onSearched} />
+                </Grid>
+                <Grid item xs={2}>
+                    <MicroserviceFilter
+                        availableMicroservices={microservices}
+                        selectedMicroservices={filters.microservice}
+                        onSelectMicroservices={onSelectMicroservices} />
                 </Grid>
                 <Grid item xs={12}>
                     <ActiveFilters filters={filters} updateFilters={onUpdateFilters} />

--- a/Source/SelfService/Web/logging/logFilter/logFilterPanel.tsx
+++ b/Source/SelfService/Web/logging/logFilter/logFilterPanel.tsx
@@ -1,15 +1,16 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-import React from 'react';
+import React, { useCallback } from 'react';
 import { Grid } from '@mui/material';
 import { ActiveFilters } from './activeFilters';
 import { SearchFilter } from './searchFilter';
 import { MicroserviceFilter } from './microserviceFilter';
+import { DateRangeFilter } from './dateRangeFilter';
 
-export type LogFilterDateRange = {
-    start: number;
-    stop: number;
+export type LogFilterDateRange = 'live' | {
+    start: bigint;
+    stop: bigint;
 };
 export type LogFilterMicroservice = {
     name: string;
@@ -18,7 +19,7 @@ export type LogFilterMicroservice = {
 
 export type LogFilterObject = {
     searchTerms: string[];
-    dateRange?: LogFilterDateRange;
+    dateRange: LogFilterDateRange;
     microservice?: LogFilterMicroservice[];
 };
 
@@ -31,23 +32,30 @@ export type LogFilterPanelProps = {
 
 export const LogFilterPanel = ({ microservices, filters, setSearchFilters }: LogFilterPanelProps) => {
 
-    const onUpdateFilters = (filters: LogFilterObject) => {
+    const onUpdateFilters = useCallback((filters: LogFilterObject) => {
         setSearchFilters(filters);
-    };
+    }, [setSearchFilters]);
 
-    const onSearched = (query: string) => {
+    const onSearched = useCallback((query: string) => {
         setSearchFilters({
             ...filters,
             searchTerms: filters.searchTerms.concat(query)
         });
-    };
+    }, [setSearchFilters]);
 
-    const onSelectMicroservices = (selection: LogFilterMicroservice[]) => {
+    const onSelectMicroservices = useCallback((selection: LogFilterMicroservice[]) => {
         setSearchFilters({
             ...filters,
             microservice: selection,
         });
-    };
+    }, [setSearchFilters]);
+
+    const onSetDateRange = useCallback((range: LogFilterDateRange) => {
+        setSearchFilters({
+            ...filters,
+            dateRange: range,
+        });
+    }, [setSearchFilters]);
 
     return (
         <>
@@ -60,6 +68,11 @@ export const LogFilterPanel = ({ microservices, filters, setSearchFilters }: Log
                         availableMicroservices={microservices}
                         selectedMicroservices={filters.microservice}
                         onSelectMicroservices={onSelectMicroservices} />
+                </Grid>
+                <Grid item xs={2}>
+                    <DateRangeFilter
+                        range={filters.dateRange}
+                        onSetDateRange={onSetDateRange} />
                 </Grid>
                 <Grid item xs={12}>
                     <ActiveFilters filters={filters} updateFilters={onUpdateFilters} />

--- a/Source/SelfService/Web/logging/logFilter/logFilterPanel.tsx
+++ b/Source/SelfService/Web/logging/logFilter/logFilterPanel.tsx
@@ -1,8 +1,9 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-import React, { useCallback } from 'react';
+import React from 'react';
 import { Grid } from '@mui/material';
+
 import { ActiveFilters } from './activeFilters';
 import { SearchFilter } from './searchFilter';
 import { MicroserviceFilter } from './microserviceFilter';
@@ -32,30 +33,30 @@ export type LogFilterPanelProps = {
 
 export const LogFilterPanel = ({ microservices, filters, setSearchFilters }: LogFilterPanelProps) => {
 
-    const onUpdateFilters = useCallback((filters: LogFilterObject) => {
+    const onUpdateFilters = (filters: LogFilterObject) => {
         setSearchFilters(filters);
-    }, [setSearchFilters]);
+    };
 
-    const onSearched = useCallback((query: string) => {
+    const onSearched = (query: string) => {
         setSearchFilters({
             ...filters,
             searchTerms: filters.searchTerms.concat(query)
         });
-    }, [setSearchFilters]);
+    };
 
-    const onSelectMicroservices = useCallback((selection: LogFilterMicroservice[]) => {
+    const onSelectMicroservices = (selection: LogFilterMicroservice[]) => {
         setSearchFilters({
             ...filters,
             microservice: selection,
         });
-    }, [setSearchFilters]);
+    };
 
-    const onSetDateRange = useCallback((range: LogFilterDateRange) => {
+    const onSetDateRange = (range: LogFilterDateRange) => {
         setSearchFilters({
             ...filters,
             dateRange: range,
         });
-    }, [setSearchFilters]);
+    };
 
     return (
         <>

--- a/Source/SelfService/Web/logging/logFilter/logFilterPanel.tsx
+++ b/Source/SelfService/Web/logging/logFilter/logFilterPanel.tsx
@@ -63,13 +63,11 @@ export const LogFilterPanel = ({ microservices, filters, setSearchFilters }: Log
                 <Grid item xs={12} md={6}>
                     <SearchFilter onSearch={onSearched} />
                 </Grid>
-                <Grid item xs={2}>
+                <Grid item xs={12} md={6} sx={{ '& > *': { ml: 2 } }}>
                     <MicroserviceFilter
                         availableMicroservices={microservices}
                         selectedMicroservices={filters.microservice}
                         onSelectMicroservices={onSelectMicroservices} />
-                </Grid>
-                <Grid item xs={2}>
                     <DateRangeFilter
                         range={filters.dateRange}
                         onSetDateRange={onSetDateRange} />

--- a/Source/SelfService/Web/logging/logFilter/logFilterPanel.tsx
+++ b/Source/SelfService/Web/logging/logFilter/logFilterPanel.tsx
@@ -61,10 +61,10 @@ export const LogFilterPanel = ({ microservices, filters, setSearchFilters }: Log
     return (
         <>
             <Grid container spacing={2}>
-                <Grid item xs={12} md={6}>
+                <Grid item xs={12} lg={4}>
                     <SearchFilter onSearch={onSearched} />
                 </Grid>
-                <Grid item xs={12} md={6} sx={{ '& > *': { ml: 2 } }}>
+                <Grid item xs={12} lg={8} sx={{ '& > *': { ml: 2, py: 0.5 } }}>
                     <MicroserviceFilter
                         availableMicroservices={microservices}
                         selectedMicroservices={filters.microservice}

--- a/Source/SelfService/Web/logging/logFilter/microserviceFilter.tsx
+++ b/Source/SelfService/Web/logging/logFilter/microserviceFilter.tsx
@@ -2,9 +2,10 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 import React from 'react';
-import { MenuItem, Select, SelectChangeEvent } from '@mui/material';
+import { MenuItem, SelectChangeEvent } from '@mui/material';
 
 import { LogFilterMicroservice } from './logFilterPanel';
+import { FilterSelect } from './filterSelect';
 
 export type MicroserviceFilterProps = {
     availableMicroservices: LogFilterMicroservice[];
@@ -40,8 +41,7 @@ export const MicroserviceFilter = (props: MicroserviceFilterProps) => {
     };
 
     return (
-        <Select
-            variant='standard'
+        <FilterSelect
             multiple={true}
             displayEmpty
             value={selectedMicroserviceIds}
@@ -52,6 +52,6 @@ export const MicroserviceFilter = (props: MicroserviceFilterProps) => {
                 // TODO: Add checkboxes here
                 <MenuItem key={i} value={microservice.id}>{microservice.name}</MenuItem>
             ))}
-        </Select>
+        </FilterSelect>
     );
 };

--- a/Source/SelfService/Web/logging/logFilter/microserviceFilter.tsx
+++ b/Source/SelfService/Web/logging/logFilter/microserviceFilter.tsx
@@ -49,6 +49,7 @@ export const MicroserviceFilter = (props: MicroserviceFilterProps) => {
             onChange={handleOnChange}
         >
             {props.availableMicroservices.map((microservice, i) => (
+                // TODO: Add checkboxes here
                 <MenuItem key={i} value={microservice.id}>{microservice.name}</MenuItem>
             ))}
         </Select>

--- a/Source/SelfService/Web/logging/logFilter/microserviceFilter.tsx
+++ b/Source/SelfService/Web/logging/logFilter/microserviceFilter.tsx
@@ -1,0 +1,56 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import React from 'react';
+import { MenuItem, Select, SelectChangeEvent } from '@mui/material';
+
+import { LogFilterMicroservice } from './logFilterPanel';
+
+export type MicroserviceFilterProps = {
+    availableMicroservices: LogFilterMicroservice[];
+    selectedMicroservices?: LogFilterMicroservice[];
+    onSelectMicroservices: (selection: LogFilterMicroservice[]) => void;
+};
+
+export const MicroserviceFilter = (props: MicroserviceFilterProps) => {
+
+    const selectedMicroserviceIds = props.selectedMicroservices === undefined
+        ? []
+        : props.selectedMicroservices.map(_ => _.id);
+
+    const handleOnChange = (event: SelectChangeEvent<string[]>): void => {
+        const ids = Array.isArray(event.target.value) ? event.target.value : [event.target.value];
+        const microservices = props.availableMicroservices.filter(_ => ids.includes(_.id));
+        props.onSelectMicroservices(microservices);
+    };
+
+    const renderValue = (selectedIds: string[]) => {
+        if (selectedIds.length === 0) {
+            return 'All microservices';
+        }
+
+        if (selectedIds.length === 1) {
+            const selectedMicroservice = props.availableMicroservices.find(_ => _.id === selectedIds[0]);
+            if (selectedMicroservice !== undefined) {
+                return selectedMicroservice.name;
+            }
+        }
+
+        return `${selectedIds.length} microservices`;
+    };
+
+    return (
+        <Select
+            variant='standard'
+            multiple={true}
+            displayEmpty
+            value={selectedMicroserviceIds}
+            renderValue={renderValue}
+            onChange={handleOnChange}
+        >
+            {props.availableMicroservices.map((microservice, i) => (
+                <MenuItem key={i} value={microservice.id}>{microservice.name}</MenuItem>
+            ))}
+        </Select>
+    );
+};

--- a/Source/SelfService/Web/logging/logLine.tsx
+++ b/Source/SelfService/Web/logging/logLine.tsx
@@ -3,6 +3,8 @@
 
 import React from 'react';
 import { Box } from '@mui/material';
+import { format } from 'date-fns';
+import { nb } from 'date-fns/locale';
 
 import { ColoredLine, ColoredLineSection, TerminalColor } from './lineParsing';
 import { ButtonText } from '../theme/buttonText';
@@ -78,16 +80,9 @@ export type LogLineProps = {
     onClickShowLineContext: (timestamp: bigint, labels: DataLabels, event: React.MouseEvent<HTMLElement, MouseEvent>) => void;
 };
 
-// TODO: Use DateFns for this
 const formatTimestamp = (timestamp: bigint): string => {
     const date = new Date(Number(timestamp / 1_000_000n));
-    return `${date.getFullYear()
-        }-${(date.getMonth() + 1).toString().padStart(2, '0')
-        }-${date.getDate().toString().padStart(2, '0')
-        } ${date.getHours().toString().padStart(2, '0')
-        }:${date.getMinutes().toString().padStart(2, '0')
-        }:${date.getSeconds().toString().padStart(2, '0')
-        }`;
+    return format(date, '[yyyy-MM-dd HH:mm:ss]');
 };
 
 export const LogLine = (props: LogLineProps) => {

--- a/Source/SelfService/Web/logging/logLine.tsx
+++ b/Source/SelfService/Web/logging/logLine.tsx
@@ -78,6 +78,7 @@ export type LogLineProps = {
     onClickShowLineContext: (timestamp: bigint, labels: DataLabels, event: React.MouseEvent<HTMLElement, MouseEvent>) => void;
 };
 
+// TODO: Use DateFns for this
 const formatTimestamp = (timestamp: bigint): string => {
     const date = new Date(Number(timestamp / 1_000_000n));
     return `${date.getFullYear()

--- a/Source/SelfService/Web/logging/logLine.tsx
+++ b/Source/SelfService/Web/logging/logLine.tsx
@@ -73,8 +73,12 @@ export type LogLineProps = {
 };
 
 export const LogLine = (props: LogLineProps) => {
+    // TODO: The tab-width is dependent on styling. How do we make sure we don't change this?
+    const leadingWhitespace = props.line.leading.spaces + props.line.leading.tabs * 8;
+    const leadingEmSpace = `${leadingWhitespace * 0.6}em`;
+
     return (
-        <Box>
+        <Box style={{ paddingLeft: leadingEmSpace, textIndent: `-${leadingEmSpace}` }}>
             {props.line.sections.map((section, i) => (
                 <span key={i} /*style={coloredLineSectionCss(section)}*/>{section.text}</span>
             ))}

--- a/Source/SelfService/Web/logging/logLine.tsx
+++ b/Source/SelfService/Web/logging/logLine.tsx
@@ -5,6 +5,8 @@ import React from 'react';
 import { Box } from '@mui/material';
 
 import { ColoredLine, ColoredLineSection, TerminalColor } from './lineParsing';
+import { ButtonText } from '../theme/buttonText';
+import { DataLabels } from './loki/types';
 
 
 const coloredLineSectionCss = (section: ColoredLineSection): React.CSSProperties => {
@@ -70,7 +72,10 @@ const coloredLineSectionCss = (section: ColoredLineSection): React.CSSProperties
 
 export type LogLineProps = {
     timestamp: bigint;
+    labels: DataLabels;
     line: ColoredLine;
+    enableShowLineContextButton: boolean;
+    onClickShowLineContext: (timestamp: bigint, labels: DataLabels, event: React.MouseEvent<HTMLElement, MouseEvent>) => void;
 };
 
 const formatTimestamp = (timestamp: bigint): string => {
@@ -91,6 +96,17 @@ export const LogLine = (props: LogLineProps) => {
 
     return (
         <Box>
+            {
+                props.enableShowLineContextButton &&
+                <Box sx={{ display: 'table-cell', whiteSpace: 'nowrap', pr: 2 }}>
+                    <ButtonText
+                        size='small'
+                        buttonType='secondary'
+                        sx={{ p: 0 }}
+                        onClick={event => props.onClickShowLineContext(props.timestamp, props.labels, event)}
+                    >Show</ButtonText>
+                </Box>
+            }
             <Box className='log-line-timestamp' sx={{ display: 'table-cell', whiteSpace: 'nowrap', pr: 2 }}>
                 {formatTimestamp(props.timestamp)}
             </Box>

--- a/Source/SelfService/Web/logging/logLine.tsx
+++ b/Source/SelfService/Web/logging/logLine.tsx
@@ -1,8 +1,8 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-import { Box } from '@mui/material';
 import React from 'react';
+import { Box } from '@mui/material';
 
 import { ColoredLine, ColoredLineSection, TerminalColor } from './lineParsing';
 
@@ -69,7 +69,19 @@ const coloredLineSectionCss = (section: ColoredLineSection): React.CSSProperties
 };
 
 export type LogLineProps = {
+    timestamp: bigint;
     line: ColoredLine;
+};
+
+const formatTimestamp = (timestamp: bigint): string => {
+    const date = new Date(Number(timestamp / 1_000_000n));
+    return `${date.getFullYear()
+        }-${(date.getMonth() + 1).toString().padStart(2, '0')
+        }-${date.getDate().toString().padStart(2, '0')
+        } ${date.getHours().toString().padStart(2, '0')
+        }:${date.getMinutes().toString().padStart(2, '0')
+        }:${date.getSeconds().toString().padStart(2, '0')
+        }`;
 };
 
 export const LogLine = (props: LogLineProps) => {
@@ -78,10 +90,17 @@ export const LogLine = (props: LogLineProps) => {
     const leadingEmSpace = `${leadingWhitespace * 0.6}em`;
 
     return (
-        <Box style={{ paddingLeft: leadingEmSpace, textIndent: `-${leadingEmSpace}` }}>
-            {props.line.sections.map((section, i) => (
-                <span key={i} /*style={coloredLineSectionCss(section)}*/>{section.text}</span>
-            ))}
+        <Box>
+            <Box className='log-line-timestamp' sx={{ display: 'table-cell', whiteSpace: 'nowrap', pr: 2 }}>
+                {formatTimestamp(props.timestamp)}
+            </Box>
+            <Box
+                sx={{ display: 'table-cell' }}
+                style={leadingWhitespace > 0 ? { paddingLeft: leadingEmSpace, textIndent: `-${leadingEmSpace}` } : undefined}>
+                {props.line.sections.map((section, i) => (
+                    <span key={i} /*style={coloredLineSectionCss(section)}*/>{section.text}</span>
+                ))}
+            </Box>
         </Box>
     );
 };

--- a/Source/SelfService/Web/logging/logLines.tsx
+++ b/Source/SelfService/Web/logging/logLines.tsx
@@ -1,0 +1,43 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import React from 'react';
+
+import { TransformedLogLine } from './loki/logLines';
+
+import { ColoredLine } from './lineParsing';
+import { LogLine } from './logLine';
+import { DataLabels } from './loki/types';
+
+export type LogLinesProps = {
+    lines: TransformedLogLine<ColoredLine>[];
+
+    /**
+     * Whether or not to display the 'SHOW' context button for each line.
+     */
+    showContextButtonInLines: boolean;
+
+    /**
+     * The callback to call when a 'SHOW' context button is clicked.
+     */
+    onClickShowContextButton: (timestamp: bigint, labels: DataLabels) => void;
+};
+
+export const LogLines = React.memo(function LogLines(props: LogLinesProps) {
+    return (
+        <>
+            {
+                props.lines.map(line =>
+                    <LogLine
+                        key={line.timestamp.toString()}
+                        timestamp={line.timestamp}
+                        labels={line.labels}
+                        line={line.data}
+                        enableShowLineContextButton={props.showContextButtonInLines}
+                        onClickShowLineContext={props.onClickShowContextButton}
+                    />
+                )
+            }
+        </>
+    );
+});

--- a/Source/SelfService/Web/logging/logPanel.tsx
+++ b/Source/SelfService/Web/logging/logPanel.tsx
@@ -49,6 +49,11 @@ export type LogPanelProps = {
     microservices?: LogFilterMicroservice[];
 
     /**
+     * The human readable description of what timespan the logs are displayed for.
+     */
+    timespan: string;
+
+    /**
      * The retrieved logs to render.
      */
     logs: ObservableLogLines<ColoredLine>;
@@ -95,7 +100,6 @@ export const LogPanel = (props: LogPanelProps) => {
         );
     }
 
-    // TODO: Change the title when live/range is displayed
     const microservices =
         props.microservices?.length ?? 0 === 0
             ? 'all Microservices'
@@ -103,7 +107,7 @@ export const LogPanel = (props: LogPanelProps) => {
                 ? `${props.microservices?.[0].name} Microservice`
                 : `${props.microservices?.join(', ')} Microservices`;
 
-    const title = <Typography variant='body2' color='textSecondary' fontStyle='italic' mt={1}>Displaying <b>live logs</b> for {props.application} Application, {props.environment} Environment, {microservices}</Typography>;
+    const title = <Typography variant='body2' color='textSecondary' fontStyle='italic' mt={1}>Displaying <b>{props.timespan}</b> for {props.application} Application, {props.environment} Environment, {microservices}</Typography>;
 
     return (
         <Grid container spacing={2} sx={{ pt: 2 }}>

--- a/Source/SelfService/Web/logging/logPanel.tsx
+++ b/Source/SelfService/Web/logging/logPanel.tsx
@@ -8,6 +8,7 @@ import { ObservableLogLines } from './loki/logLines';
 
 import { ColoredLine } from './lineParsing';
 import { LogLine } from './logLine';
+import { DataLabels } from './loki/types';
 
 
 /**
@@ -23,6 +24,11 @@ export type LogPanelProps = {
      * The title to render on the top of the panel.
      */
     title: React.ReactNode;
+
+    /**
+     * Whether or not to show the 'Show log line context' button.
+     */
+    enableShowLineContextButton: boolean;
 };
 
 /**
@@ -30,6 +36,10 @@ export type LogPanelProps = {
  */
 export const LogPanel = (props: LogPanelProps) => {
     const [showTimestamp, setShowTimestamp] = useState(false);
+
+    const handleOnClickShowLineContext = (timestamp: bigint, labels: DataLabels) => {
+        alert(`Show context for ${JSON.stringify(labels)} around ${timestamp}`);
+    };
 
     return (
         <Grid container spacing={2} sx={{ pt: 2 }}>
@@ -84,7 +94,10 @@ export const LogPanel = (props: LogPanelProps) => {
                                     <LogLine
                                         key={line.timestamp.toString()}
                                         timestamp={line.timestamp}
+                                        labels={line.labels}
                                         line={line.data}
+                                        enableShowLineContextButton={props.enableShowLineContextButton}
+                                        onClickShowLineContext={handleOnClickShowLineContext}
                                     />
                                 )}
                             </Box>

--- a/Source/SelfService/Web/logging/logPanel.tsx
+++ b/Source/SelfService/Web/logging/logPanel.tsx
@@ -111,16 +111,18 @@ export const LogPanel = (props: LogPanelProps) => {
                 <Paper elevation={1} sx={{ p: 2 }}>
                     <Grid container spacing={2}>
                         <Grid item xs={12} md={10}>{title}</Grid>
-                        <Grid item xs={12} md={1}>
-                            <FormGroup>
-                                <FormControlLabel
-                                    label='Timestamp'
-                                    control={<Switch
-                                        checked={showTimestamp}
-                                        onChange={(event) => setShowTimestamp(event.target.checked)}
-                                    />}
-                                />
-                            </FormGroup>
+                        <Grid item xs={12} md={2}>
+                            <Box display='flex' justifyContent='flex-end'>
+                                <FormGroup>
+                                    <FormControlLabel
+                                        label='Timestamp'
+                                        control={<Switch
+                                            checked={showTimestamp}
+                                            onChange={(event) => setShowTimestamp(event.target.checked)}
+                                        />}
+                                    />
+                                </FormGroup>
+                            </Box>
                         </Grid>
                     </Grid>
                     <Divider sx={{ borderColor: 'background.paper', m: 1 }} />

--- a/Source/SelfService/Web/logging/logPanel.tsx
+++ b/Source/SelfService/Web/logging/logPanel.tsx
@@ -54,7 +54,7 @@ export const LogPanel = (props: LogPanelProps) => {
                                     typography: 'monospace'
                                 }}
                             >
-                                {props.logs.lines.map(line => <LogLine key={line.timestamp} line={line.data} />)}
+                                {props.logs.lines.map(line => <LogLine key={line.timestamp.toString()} line={line.data} />)}
                             </Box>
                         </Paper>
                     </Grid>

--- a/Source/SelfService/Web/logging/logPanel.tsx
+++ b/Source/SelfService/Web/logging/logPanel.tsx
@@ -1,8 +1,8 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-import React from 'react';
-import { Alert, AlertTitle, Box, Grid, Link, Paper } from '@mui/material';
+import React, { useState } from 'react';
+import { Alert, AlertTitle, Box, Divider, FormControlLabel, FormGroup, Grid, Link, Paper, Switch } from '@mui/material';
 
 import { ObservableLogLines } from './loki/logLines';
 
@@ -18,12 +18,19 @@ export type LogPanelProps = {
      * The retrieved logs to render.
      */
     logs: ObservableLogLines<ColoredLine>;
+
+    /**
+     * The title to render on the top of the panel.
+     */
+    title: React.ReactNode;
 };
 
 /**
  * A component that renders {@link ObservableLogLines} in a log panel.
  */
 export const LogPanel = (props: LogPanelProps) => {
+    const [showTimestamp, setShowTimestamp] = useState(false);
+
     return (
         <Grid container spacing={2} sx={{ pt: 2 }}>
             {props.logs.failed
@@ -46,15 +53,40 @@ export const LogPanel = (props: LogPanelProps) => {
                     :
                     <Grid item xs={12}>
                         <Paper elevation={1} sx={{ p: 2 }}>
+                            <Grid container spacing={2}>
+                                <Grid item xs={12} md={10}>{props.title}</Grid>
+                                <Grid item xs={12} md={1}>
+                                    <FormGroup>
+                                        <FormControlLabel
+                                            label='Timestamp'
+                                            control={<Switch
+                                                checked={showTimestamp}
+                                                onChange={(event) => setShowTimestamp(event.target.checked)}
+                                            />}
+                                        />
+                                    </FormGroup>
+                                </Grid>
+                            </Grid>
+                            <Divider sx={{ borderColor: 'background.paper', m: 1 }} />
                             <Box
                                 component='pre'
                                 sx={{
-                                    m: 0,
-                                    whiteSpace: 'pre-wrap',
-                                    typography: 'monospace'
+                                    'm': 0,
+                                    'whiteSpace': 'pre-wrap',
+                                    'typography': 'monospace',
+                                    '&.hide-timestamp div.log-line-timestamp': {
+                                        display: 'none',
+                                    },
                                 }}
+                                className={showTimestamp ? '' : 'hide-timestamp'}
                             >
-                                {props.logs.lines.map(line => <LogLine key={line.timestamp.toString()} line={line.data} />)}
+                                {props.logs.lines.map(line =>
+                                    <LogLine
+                                        key={line.timestamp.toString()}
+                                        timestamp={line.timestamp}
+                                        line={line.data}
+                                    />
+                                )}
                             </Box>
                         </Paper>
                     </Grid>

--- a/Source/SelfService/Web/logging/logPanel.tsx
+++ b/Source/SelfService/Web/logging/logPanel.tsx
@@ -105,7 +105,7 @@ export const LogPanel = (props: LogPanelProps) => {
             ? 'all Microservices'
             : props.microservices?.length === 1
                 ? `${props.microservices?.[0].name} Microservice`
-                : `${props.microservices?.join(', ')} Microservices`;
+                : `${props.microservices?.map(_ => _.name).join(', ')} Microservices`;
 
     const title = <Typography variant='body2' color='textSecondary' fontStyle='italic' mt={1}>Displaying <b>{props.timespan}</b> for {props.application} Application, {props.environment} Environment, {microservices}</Typography>;
 

--- a/Source/SelfService/Web/logging/logPanel.tsx
+++ b/Source/SelfService/Web/logging/logPanel.tsx
@@ -56,7 +56,7 @@ export type LogPanelProps = {
     /**
      * Whether or not to show the 'Show log line context' button.
      */
-    enableShowLineContextButton: boolean;
+    enableShowLineContextButton?: boolean;
 };
 
 /**
@@ -138,7 +138,7 @@ export const LogPanel = (props: LogPanelProps) => {
                     >
                         <LogLines
                             lines={props.logs.lines}
-                            showContextButtonInLines={props.enableShowLineContextButton}
+                            showContextButtonInLines={props.enableShowLineContextButton ?? false}
                             onClickShowContextButton={handleOnClickShowLineContext}
                         />
                     </Box>

--- a/Source/SelfService/Web/logging/logPanel.tsx
+++ b/Source/SelfService/Web/logging/logPanel.tsx
@@ -101,7 +101,7 @@ export const LogPanel = (props: LogPanelProps) => {
     }
 
     const microservices =
-        props.microservices?.length ?? 0 === 0
+        props.microservices === undefined || props.microservices?.length === 0
             ? 'all Microservices'
             : props.microservices?.length === 1
                 ? `${props.microservices?.[0].name} Microservice`

--- a/Source/SelfService/Web/logging/logPanel.tsx
+++ b/Source/SelfService/Web/logging/logPanel.tsx
@@ -1,14 +1,32 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-import React, { useState } from 'react';
-import { Alert, AlertTitle, Box, Divider, FormControlLabel, FormGroup, Grid, Link, Paper, Switch } from '@mui/material';
+import React, { useState, useCallback } from 'react';
+import { Alert, AlertTitle, Box, Divider, FormControlLabel, FormGroup, Grid, Link, Paper, Switch, Typography } from '@mui/material';
 
 import { ObservableLogLines } from './loki/logLines';
-
-import { ColoredLine } from './lineParsing';
-import { LogLine } from './logLine';
 import { DataLabels } from './loki/types';
+import { QueryLabels } from './loki/queries';
+
+import { LogFilterMicroservice, LogFilterObject } from './logFilter/logFilterPanel';
+import { ColoredLine } from './lineParsing';
+import { LogLines } from './logLines';
+
+
+export const logPanelQueryLabels = (applicationId: string, environment: string, filters: LogFilterObject): [QueryLabels, string[]] => {
+    const labels = {
+        job: 'microservice',
+        application_id: applicationId,
+        environment,
+        microservice_id: filters.microservice !== undefined && filters.microservice.length > 0
+            ? filters.microservice.map(_ => _.id)
+            : undefined,
+    };
+
+    const pipeline = filters.searchTerms.map(term => `|= "${term}"`);
+
+    return [labels, pipeline];
+};
 
 
 /**
@@ -16,14 +34,24 @@ import { DataLabels } from './loki/types';
  */
 export type LogPanelProps = {
     /**
+     * The Application to the logs are for.
+     */
+    application: string;
+
+    /**
+     * The Environment to the logs are for.
+     */
+    environment: string;
+
+    /**
+     * The Environment to the logs are for.
+     */
+    microservices?: LogFilterMicroservice[];
+
+    /**
      * The retrieved logs to render.
      */
     logs: ObservableLogLines<ColoredLine>;
-
-    /**
-     * The title to render on the top of the panel.
-     */
-    title: React.ReactNode;
 
     /**
      * Whether or not to show the 'Show log line context' button.
@@ -37,73 +65,85 @@ export type LogPanelProps = {
 export const LogPanel = (props: LogPanelProps) => {
     const [showTimestamp, setShowTimestamp] = useState(false);
 
-    const handleOnClickShowLineContext = (timestamp: bigint, labels: DataLabels) => {
+    const handleOnClickShowLineContext = useCallback((timestamp: bigint, labels: DataLabels) => {
         alert(`Show context for ${JSON.stringify(labels)} around ${timestamp}`);
-    };
+    }, []);
 
-    return (
-        <Grid container spacing={2} sx={{ pt: 2 }}>
-            {props.logs.failed
-                ?
+    if (props.logs.failed) {
+        return (
+            <Grid container spacing={2} sx={{ pt: 2 }}>
                 <Grid item xs={12} md={6}>
                     <Alert severity='error' variant='outlined'>
                         <AlertTitle>Something went wrong</AlertTitle>
                         Please try again later. If the problem persists, please <Link href="mailto:support@dolittle.com">contact support</Link>.
                     </Alert>
                 </Grid>
-                :
-                props.logs.lines.length === 0
-                    ?
-                    <Grid item xs={12} md={6}>
-                        <Alert severity='info' variant='outlined'>
-                            <AlertTitle>No logs found</AlertTitle>
-                            Try adjusting the filters, or verify that your microservices are running.
-                        </Alert>
+            </Grid>
+        );
+    }
+
+    if (props.logs.lines.length === 0) {
+        return (
+            <Grid container spacing={2} sx={{ pt: 2 }}>
+                <Grid item xs={12} md={6}>
+                    <Alert severity='info' variant='outlined'>
+                        <AlertTitle>No logs found</AlertTitle>
+                        Try adjusting the filters, or verify that your microservices are running.
+                    </Alert>
+                </Grid>
+            </Grid>
+        );
+    }
+
+    // TODO: Change the title when live/range is displayed
+    const microservices =
+        props.microservices?.length ?? 0 === 0
+            ? 'all Microservices'
+            : props.microservices?.length === 1
+                ? `${props.microservices?.[0].name} Microservice`
+                : `${props.microservices?.join(', ')} Microservices`;
+
+    const title = <Typography variant='body2' color='textSecondary' fontStyle='italic' mt={1}>Displaying <b>live logs</b> for {props.application} Application, {props.environment} Environment, {microservices}</Typography>;
+
+    return (
+        <Grid container spacing={2} sx={{ pt: 2 }}>
+            <Grid item xs={12}>
+                <Paper elevation={1} sx={{ p: 2 }}>
+                    <Grid container spacing={2}>
+                        <Grid item xs={12} md={10}>{title}</Grid>
+                        <Grid item xs={12} md={1}>
+                            <FormGroup>
+                                <FormControlLabel
+                                    label='Timestamp'
+                                    control={<Switch
+                                        checked={showTimestamp}
+                                        onChange={(event) => setShowTimestamp(event.target.checked)}
+                                    />}
+                                />
+                            </FormGroup>
+                        </Grid>
                     </Grid>
-                    :
-                    <Grid item xs={12}>
-                        <Paper elevation={1} sx={{ p: 2 }}>
-                            <Grid container spacing={2}>
-                                <Grid item xs={12} md={10}>{props.title}</Grid>
-                                <Grid item xs={12} md={1}>
-                                    <FormGroup>
-                                        <FormControlLabel
-                                            label='Timestamp'
-                                            control={<Switch
-                                                checked={showTimestamp}
-                                                onChange={(event) => setShowTimestamp(event.target.checked)}
-                                            />}
-                                        />
-                                    </FormGroup>
-                                </Grid>
-                            </Grid>
-                            <Divider sx={{ borderColor: 'background.paper', m: 1 }} />
-                            <Box
-                                component='pre'
-                                sx={{
-                                    'm': 0,
-                                    'whiteSpace': 'pre-wrap',
-                                    'typography': 'monospace',
-                                    '&.hide-timestamp div.log-line-timestamp': {
-                                        display: 'none',
-                                    },
-                                }}
-                                className={showTimestamp ? '' : 'hide-timestamp'}
-                            >
-                                {props.logs.lines.map(line =>
-                                    <LogLine
-                                        key={line.timestamp.toString()}
-                                        timestamp={line.timestamp}
-                                        labels={line.labels}
-                                        line={line.data}
-                                        enableShowLineContextButton={props.enableShowLineContextButton}
-                                        onClickShowLineContext={handleOnClickShowLineContext}
-                                    />
-                                )}
-                            </Box>
-                        </Paper>
-                    </Grid>
-            }
+                    <Divider sx={{ borderColor: 'background.paper', m: 1 }} />
+                    <Box
+                        component='pre'
+                        sx={{
+                            'm': 0,
+                            'whiteSpace': 'pre-wrap',
+                            'typography': 'monospace',
+                            '&.hide-timestamp div.log-line-timestamp': {
+                                display: 'none',
+                            },
+                        }}
+                        className={showTimestamp ? '' : 'hide-timestamp'}
+                    >
+                        <LogLines
+                            lines={props.logs.lines}
+                            showContextButtonInLines={props.enableShowLineContextButton}
+                            onClickShowContextButton={handleOnClickShowLineContext}
+                        />
+                    </Box>
+                </Paper>
+            </Grid>
         </Grid>
     );
 };

--- a/Source/SelfService/Web/logging/logPanelAbsolute.tsx
+++ b/Source/SelfService/Web/logging/logPanelAbsolute.tsx
@@ -43,7 +43,7 @@ export type LogPanelAbsoluteProps = {
     /**
      * Whether or not to display the 'SHOW' context button for each line.
      */
-    showContextButtonInLines: boolean;
+    showContextButtonInLines?: boolean;
 };
 
 export const LogPanelAbsolute = (props: LogPanelAbsoluteProps) => {

--- a/Source/SelfService/Web/logging/logPanelAbsolute.tsx
+++ b/Source/SelfService/Web/logging/logPanelAbsolute.tsx
@@ -1,0 +1,64 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import React from 'react';
+
+import { useLogsFromRange } from './loki/useLogsFromRange';
+
+import { parseLogLine } from './lineParsing';
+import { LogFilterObject } from './logFilter/logFilterPanel';
+import { LogPanel, logPanelQueryLabels } from './logPanel';
+
+export type LogPanelAbsoluteProps = {
+    /**
+     * The Application to get logs for.
+     */
+    application: string;
+
+    /**
+     * The ApplicationID to get logs for.
+     */
+    applicationId: string;
+
+    /**
+     * The Environment to get logs for.
+     */
+    environment: string;
+
+    /**
+     * The filters to apply to the logs query.
+     */
+    filters: LogFilterObject;
+
+    /**
+     * The smallest time in Unix epoch nanoseconds to fetch logs from.
+     */
+    from: bigint;
+
+    /**
+     * The largest time in Unix epoch nanoseconds to fetch logs from.
+     */
+    to: bigint;
+
+    /**
+     * Whether or not to display the 'SHOW' context button for each line.
+     */
+    showContextButtonInLines: boolean;
+};
+
+export const LogPanelAbsolute = (props: LogPanelAbsoluteProps) => {
+    const [labels, pipeline] = logPanelQueryLabels(props.applicationId, props.environment, props.filters);
+
+    const newestFirst = true; // TODO: Where to move these
+    const limit = 1000;
+
+    const [logs, loadMoreLogs] = useLogsFromRange(props.from, props.to, newestFirst, labels, pipeline, limit, parseLogLine);
+
+    return <LogPanel
+        application={props.application}
+        environment={props.environment}
+        microservices={props.filters.microservice}
+        logs={logs}
+        enableShowLineContextButton={props.showContextButtonInLines}
+    />;
+};

--- a/Source/SelfService/Web/logging/logPanelAbsolute.tsx
+++ b/Source/SelfService/Web/logging/logPanelAbsolute.tsx
@@ -58,6 +58,7 @@ export const LogPanelAbsolute = (props: LogPanelAbsoluteProps) => {
         application={props.application}
         environment={props.environment}
         microservices={props.filters.microservice}
+        timespan='date range logs'
         logs={logs}
         enableShowLineContextButton={props.showContextButtonInLines}
     />;

--- a/Source/SelfService/Web/logging/logPanelRelative.tsx
+++ b/Source/SelfService/Web/logging/logPanelRelative.tsx
@@ -39,7 +39,7 @@ export type LogPanelRelativeProps = {
     /**
      * Whether or not to display the 'SHOW' context button for each line.
      */
-    showContextButtonInLines: boolean;
+    showContextButtonInLines?: boolean;
 };
 
 export const LogPanelRelative = (props: LogPanelRelativeProps) => {

--- a/Source/SelfService/Web/logging/logPanelRelative.tsx
+++ b/Source/SelfService/Web/logging/logPanelRelative.tsx
@@ -54,6 +54,7 @@ export const LogPanelRelative = (props: LogPanelRelativeProps) => {
         application={props.application}
         environment={props.environment}
         microservices={props.filters.microservice}
+        timespan='live logs'
         logs={logs}
         enableShowLineContextButton={props.showContextButtonInLines}
     />;

--- a/Source/SelfService/Web/logging/logPanelRelative.tsx
+++ b/Source/SelfService/Web/logging/logPanelRelative.tsx
@@ -1,0 +1,60 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import React from 'react';
+
+import { useLogsFromLast } from './loki/useLogsFromLast';
+
+import { LogFilterObject } from './logFilter/logFilterPanel';
+import { parseLogLine } from './lineParsing';
+import { LogPanel, logPanelQueryLabels } from './logPanel';
+
+export type LogPanelRelativeProps = {
+    /**
+     * The Application to get logs for.
+     */
+    application: string;
+
+    /**
+     * The ApplicationID to get logs for.
+     */
+    applicationId: string;
+
+    /**
+     * The Environment to get logs for.
+     */
+    environment: string;
+
+    /**
+     * The filters to apply to the logs query.
+     */
+    filters: LogFilterObject;
+
+    /**
+     * The time in nanoseconds to fetch logs from.
+     * Range: [now-last, now].
+     */
+    last: bigint;
+
+    /**
+     * Whether or not to display the 'SHOW' context button for each line.
+     */
+    showContextButtonInLines: boolean;
+};
+
+export const LogPanelRelative = (props: LogPanelRelativeProps) => {
+    const [labels, pipeline] = logPanelQueryLabels(props.applicationId, props.environment, props.filters);
+
+    const newestFirst = true; // TODO: Where to move these
+    const limit = 1000;
+
+    const logs = useLogsFromLast(props.last, newestFirst, labels, pipeline, limit, parseLogLine);
+
+    return <LogPanel
+        application={props.application}
+        environment={props.environment}
+        microservices={props.filters.microservice}
+        logs={logs}
+        enableShowLineContextButton={props.showContextButtonInLines}
+    />;
+};

--- a/Source/SelfService/Web/logging/loki/logLines.ts
+++ b/Source/SelfService/Web/logging/loki/logLines.ts
@@ -15,7 +15,7 @@ export type LogLine = {
     /**
      * The nanosecond Unix epoch timestamp of when the log line was scraped.
      */
-    timestamp: number;
+    timestamp: bigint;
 
     /**
      * The log line as text.

--- a/Source/SelfService/Web/logging/loki/parsing.ts
+++ b/Source/SelfService/Web/logging/loki/parsing.ts
@@ -17,7 +17,7 @@ export const parseAndMergeAllStreams = (streams: { stream: DataLabels, values: [
         for (const line of stream.values) {
             lines.push({
                 labels: stream.stream,
-                timestamp: parseInt(line[0]),
+                timestamp: BigInt(line[0]),
                 line: line[1],
             });
         }

--- a/Source/SelfService/Web/logging/loki/queries.ts
+++ b/Source/SelfService/Web/logging/loki/queries.ts
@@ -23,7 +23,7 @@ export const labelsAndPipelineToLogQL = (labels: DataLabels, pipeline: string[])
 export const buildRequestQuerystring = (request: QueryRequest | QueryRangeRequest): string =>
     Object.entries(request)
         .filter(entry => entry[1] !== undefined)
-        .map(entry => `${encodeURIComponent(entry[0])}=${encodeURIComponent(entry[1])}`)
+        .map(entry => `${encodeURIComponent(entry[0])}=${encodeURIComponent(entry[1].toString())}`)
         .join('&');
 
 const fetchFromLokiEnsuringJson = async (path: string, request: QueryRequest | QueryRangeRequest): Promise<any> => {

--- a/Source/SelfService/Web/logging/loki/queries.ts
+++ b/Source/SelfService/Web/logging/loki/queries.ts
@@ -5,13 +5,27 @@ import { DataLabels, QueryRequest, QueryResponse, QueryRangeRequest, QueryRangeR
 import { FailedToFetchFromLoki } from './failedToFetchFromLoki';
 
 /**
+ * Represents a set of labels to query for.
+ */
+export type QueryLabels = {
+    [label: string]: string | string[] | undefined;
+};
+
+/**
  * Generates a LogQL query from a label selector an filtering pipeline.
  * @param labels The metric or stream labels to select.
  * @param pipeline The filtering pipeline to apply.
  * @returns The LogQL query string.
  */
-export const labelsAndPipelineToLogQL = (labels: DataLabels, pipeline: string[]): string => {
-    const selector = Object.entries(labels).map(entry => `${entry[0]}="${entry[1]}"`).join(',');
+export const labelsAndPipelineToLogQL = (labels: QueryLabels, pipeline: string[]): string => {
+    const selector = Object.entries(labels)
+        .filter(entry => entry[1] !== undefined)
+        .map(entry => Array.isArray(entry[1])
+            ? entry[1].length > 1
+                ? `${entry[0]}=~"${entry[1].join('|')}"`
+                : `${entry[0]}="${entry[1][0]}"`
+            : `${entry[0]}="${entry[1]}"`)
+        .join(',');
     return `{${selector}}${pipeline.join(' ')}`;
 };
 

--- a/Source/SelfService/Web/logging/loki/types.ts
+++ b/Source/SelfService/Web/logging/loki/types.ts
@@ -125,7 +125,7 @@ export type QueryRequest = CommonQueryRequestProperties & {
     /**
      * The evaluation time for the query as a nanosecond Unix epoch. Defaults to now.
      */
-    time?: number;
+    time?: bigint;
 };
 
 /**
@@ -145,12 +145,12 @@ export type QueryRangeRequest = CommonQueryRequestProperties & {
     /**
      * The start time for the query as a nanosecond Unix epoch. Defaults to one hour ago.
      */
-    start?: number;
+    start?: bigint;
 
     /**
      * The end time for the query as a nanosecond Unix epoch. Defaults to now.
      */
-    end?: number;
+    end?: bigint;
 
     /**
      * Query resolution step width in duration format or float number of seconds.
@@ -180,7 +180,7 @@ export type TailRequest = CommonRequestProperties & {
     /**
      * The start time for the query as a nanosecond Unix epoch. Defaults to one hour ago.
      */
-    start?: number;
+    start?: bigint;
 
     /**
      *  The number of seconds to delay retrieving logs to let slow loggers catch up. Defaults to 0 and cannot be larger than 5.

--- a/Source/SelfService/Web/logging/loki/useLogsFromLast.ts
+++ b/Source/SelfService/Web/logging/loki/useLogsFromLast.ts
@@ -70,13 +70,13 @@ export const useLogsFromLast = <T>(last: bigint, newestFirst: boolean, labels: Q
                 map(lines => lines.map(line => ({ ...line, data: transform(line) }))),
 
                 // TODO: Enable toggling of this tail stuff
-                // concatMap((lines) => tailAfterLastReceivedLine(query, lines).pipe(
-                //     map(message => parseAndMergeAllStreams(message.streams)),
-                //     map(lines => lines.map(line => ({ ...line, data: transform(line) }))),
-                //     scan((lastLines, newLines) => {
-                //         return lastLines.concat(newLines);
-                //     }, lines),
-                // )),
+                concatMap((lines) => tailAfterLastReceivedLine(query, lines).pipe(
+                    map(message => parseAndMergeAllStreams(message.streams)),
+                    map(lines => lines.map(line => ({ ...line, data: transform(line) }))),
+                    scan((lastLines, newLines) => {
+                        return lastLines.concat(newLines);
+                    }, lines),
+                )),
 
                 tap(lines => lines.sort((a, b) => {
                     if (query.direction === 'forward') {

--- a/Source/SelfService/Web/logging/loki/useLogsFromLast.ts
+++ b/Source/SelfService/Web/logging/loki/useLogsFromLast.ts
@@ -6,8 +6,8 @@ import { of, from, Observable, Subject } from 'rxjs';
 import { distinctUntilChanged, map, catchError, concatMap, startWith, scan, tap, switchMap } from 'rxjs/operators';
 
 import { LogLine, TransformedLogLine, ObservableLogLines } from './logLines';
-import { DataLabels, QueryRangeRequest, TailResponseMessage } from './types';
-import { labelsAndPipelineToLogQL, queryRange } from './queries';
+import { QueryRangeRequest, TailResponseMessage } from './types';
+import { labelsAndPipelineToLogQL, QueryLabels, queryRange } from './queries';
 import { tail } from './streaming';
 import { parseAndMergeAllStreams } from './parsing';
 
@@ -39,7 +39,7 @@ const tailAfterLastReceivedLine = <T>(query: QueryRangeRequest, lines: Transform
  * @param transform The transform to apply to add extra data to each logline before returning.
  * @returns An observable object of loglines with transformed extra data.
  */
-export const useLogsFromLast = <T>(last: bigint, newestFirst: boolean, labels: DataLabels, pipeline: string[], limit: number, transform: (line: LogLine) => T): ObservableLogLines<T> => {
+export const useLogsFromLast = <T>(last: bigint, newestFirst: boolean, labels: QueryLabels, pipeline: string[], limit: number, transform: (line: LogLine) => T): ObservableLogLines<T> => {
     const [result, setResult] = useState<ObservableLogLines<T>>({ loading: false, failed: false, lines: [] });
     const subject = useRef<Subject<Parameters>>();
 

--- a/Source/SelfService/Web/logging/loki/useLogsFromLast.ts
+++ b/Source/SelfService/Web/logging/loki/useLogsFromLast.ts
@@ -23,19 +23,6 @@ const tailAfterLastReceivedLine = <T>(query: QueryRangeRequest, lines: Transform
     return tail({ query: query.query, start: lastReceivedTime + 1n, limit: query.limit });
 };
 
-const ensureUniqueTimestamps = <T>(lines: TransformedLogLine<T>[]): void => {
-    // TODO: We probably want to be smarter here if there are logs from different streams with the same timestamp
-    let i = 1;
-    while (i < lines.length) {
-        if (lines[i - 1].timestamp === lines[i].timestamp) {
-            lines.splice(i, 1);
-            continue;
-        }
-
-        i++;
-    }
-};
-
 // TODO: Does it even make sense to allow querying forward when useLogsFromLast?
 // With the streaming implementation now, it will attempt to retrieve any skipped logs using the tail request.
 // We might want to hardcode the Loki request to be backward (fetch the newest logs) - fix the limit - and just report that there are more logs we didn't retrieve.
@@ -108,9 +95,6 @@ export const useLogsFromLast = <T>(last: bigint, newestFirst: boolean, labels: D
                         return 0;
                     }
                 })),
-
-                tap(ensureUniqueTimestamps),
-
                 map((lines): ObservableLogLines<T> => ({ loading: false, failed: false, lines })),
                 startWith<ObservableLogLines<T>>({ loading: true, failed: false, lines: [] }),
             )),

--- a/Source/SelfService/Web/logging/loki/useLogsFromRange.ts
+++ b/Source/SelfService/Web/logging/loki/useLogsFromRange.ts
@@ -6,8 +6,7 @@ import { of, from as rxFrom, Observable, Subject, EMPTY } from 'rxjs';
 import { distinctUntilChanged, map, concatMap, startWith, scan, tap, take, switchMap, expand, catchError } from 'rxjs/operators';
 
 import { LogLine, TransformedLogLine, ObservablePartialLogLines } from './logLines';
-import { DataLabels } from './types';
-import { labelsAndPipelineToLogQL, queryRange } from './queries';
+import { labelsAndPipelineToLogQL, queryRange, QueryLabels } from './queries';
 import { parseAndMergeAllStreams } from './parsing';
 
 type Parameters = {
@@ -40,7 +39,7 @@ export type LoadMoreLinesIfAvailable = (limit: number) => void;
  * @param transform The transform to apply to add extra data to each logline before returning.
  * @returns An observable object of loglines with transformed extra data, and a function to call to load more lines if available.
  */
-export const useLogsFromRange = <T>(from: bigint, to: bigint, newestFirst: boolean, labels: DataLabels, pipeline: string[], limit: number, transform: (line: LogLine) => T): [ObservablePartialLogLines<T>, LoadMoreLinesIfAvailable] => {
+export const useLogsFromRange = <T>(from: bigint, to: bigint, newestFirst: boolean, labels: QueryLabels, pipeline: string[], limit: number, transform: (line: LogLine) => T): [ObservablePartialLogLines<T>, LoadMoreLinesIfAvailable] => {
     const [result, setResult] = useState<ObservablePartialLogLines<T>>({ loading: false, failed: false, lines: [], moreLinesAvailable: false });
     const subject = useRef<Subject<Parameters>>();
     const loadMoreSubject = useRef<Subject<number>>();

--- a/Source/SelfService/Web/package.json
+++ b/Source/SelfService/Web/package.json
@@ -15,6 +15,7 @@
         "ci": "yarn clean && yarn lint:ci && yarn build"
     },
     "dependencies": {
+        "@date-io/date-fns": "^2.14.0",
         "@dolittle/rudiments": "5.0.1",
         "@emotion/react": "^11.9.0",
         "@emotion/styled": "^11.8.1",
@@ -26,7 +27,9 @@
         "@mui/lab": "5.0.0-alpha.78",
         "@mui/material": "5.6.2",
         "@mui/styles": "5.6.2",
+        "@mui/x-date-pickers": "^5.0.0-alpha.4",
         "@shared/web": "1.0.1",
+        "date-fns": "^2.28.0",
         "generate-password-browser": "^1.1.0",
         "notistack": "2.0.4",
         "react-markdown": "^7.1.0",

--- a/Source/SelfService/Web/screens/logsScreen.tsx
+++ b/Source/SelfService/Web/screens/logsScreen.tsx
@@ -145,7 +145,8 @@ export const LogsScreen: React.FunctionComponent = withRouteApplicationState(({ 
                         logs={logs}
                         title={
                             <Typography variant='body2' color='textSecondary' fontStyle='italic' mt={1}>Displaying <b>live logs</b> for {application.name} Application, {currentEnvironment} Environment</Typography>
-                        } />
+                        }
+                        enableShowLineContextButton={filters.searchTerms.length > 0} />
                 </Box>
             </Box>
         </LayoutWithSidebar >

--- a/Source/SelfService/Web/screens/logsScreen.tsx
+++ b/Source/SelfService/Web/screens/logsScreen.tsx
@@ -124,7 +124,8 @@ export const LogsScreen: React.FunctionComponent = withRouteApplicationState(({ 
                                 environment={currentEnvironment}
                                 filters={filters}
                                 last={86_400n * 1_000_000_000n}
-                                showContextButtonInLines />
+                            // showContextButtonInLines
+                            />
                             : <LogPanelAbsolute
                                 application={application.name}
                                 applicationId={currentApplicationId}
@@ -132,7 +133,8 @@ export const LogsScreen: React.FunctionComponent = withRouteApplicationState(({ 
                                 filters={filters}
                                 from={filters.dateRange.start}
                                 to={filters.dateRange.stop}
-                                showContextButtonInLines />
+                            // showContextButtonInLines
+                            />
                     }
                 </Box>
             </Box>

--- a/Source/SelfService/Web/screens/logsScreen.tsx
+++ b/Source/SelfService/Web/screens/logsScreen.tsx
@@ -37,6 +37,7 @@ import { HttpResponseApplication, getApplications, getApplication, HttpResponseA
 
 import { LogFilterMicroservice, LogFilterObject, LogFilterPanel } from '../logging/logFilter/logFilterPanel';
 import { LogPanelRelative } from '../logging/logPanelRelative';
+import { LogPanelAbsolute } from '../logging/logPanelAbsolute';
 
 export const LogsScreen: React.FunctionComponent = withRouteApplicationState(({ routeApplicationParams }) => {
     const history = useHistory();
@@ -48,7 +49,7 @@ export const LogsScreen: React.FunctionComponent = withRouteApplicationState(({ 
     const [applications, setApplications] = useState({} as ShortInfoWithEnvironment[]);
     const [loaded, setLoaded] = useState(false);
 
-    const [filters, setFilters] = useState<LogFilterObject>({ searchTerms: [] });
+    const [filters, setFilters] = useState<LogFilterObject>({ dateRange: 'live', searchTerms: [] });
 
     useEffect(() => {
         if (!currentEnvironment || !currentApplicationId) {
@@ -115,14 +116,24 @@ export const LogsScreen: React.FunctionComponent = withRouteApplicationState(({ 
                 <Typography variant='h1'>Logs</Typography>
                 <Box mt={3}>
                     <LogFilterPanel microservices={availableMicroservices} filters={filters} setSearchFilters={setFilters} />
-                    <LogPanelRelative
-                        application={application.name}
-                        applicationId={currentApplicationId}
-                        environment={currentEnvironment}
-                        filters={filters}
-                        last={86_400n * 1_000_000_000n}
-                        showContextButtonInLines
-                    />
+                    {
+                        filters.dateRange === 'live'
+                            ? <LogPanelRelative
+                                application={application.name}
+                                applicationId={currentApplicationId}
+                                environment={currentEnvironment}
+                                filters={filters}
+                                last={86_400n * 1_000_000_000n}
+                                showContextButtonInLines />
+                            : <LogPanelAbsolute
+                                application={application.name}
+                                applicationId={currentApplicationId}
+                                environment={currentEnvironment}
+                                filters={filters}
+                                from={filters.dateRange.start}
+                                to={filters.dateRange.stop}
+                                showContextButtonInLines />
+                    }
                 </Box>
             </Box>
         </LayoutWithSidebar >

--- a/Source/SelfService/Web/screens/logsScreen.tsx
+++ b/Source/SelfService/Web/screens/logsScreen.tsx
@@ -58,7 +58,7 @@ export const LogsScreen: React.FunctionComponent = withRouteApplicationState(({ 
 
     const labels = { job: 'microservice', application_id: currentApplicationId, environment: currentEnvironment };
     const pipeline = logFilterToPipeline(filters);
-    const logs = useLogsFromLast(86400 * 1e9, true, labels, pipeline, 1000, parseLogLine);
+    const logs = useLogsFromLast(86_400n * 1_000_000_000n, true, labels, pipeline, 1000, parseLogLine);
 
 
     useEffect(() => {

--- a/Source/SelfService/Web/screens/logsScreen.tsx
+++ b/Source/SelfService/Web/screens/logsScreen.tsx
@@ -141,8 +141,11 @@ export const LogsScreen: React.FunctionComponent = withRouteApplicationState(({ 
                     mt={3}
                 >
                     <LogFilterPanel microservices={availableMicroservices} filters={filters} setSearchFilters={setFilters} />
-                    <Typography variant='body2' color='textSecondary' fontStyle='italic' mt={1}>Displaying logs for {application.name} Application, {currentEnvironment} Environment</Typography>
-                    <LogPanel logs={logs} />
+                    <LogPanel
+                        logs={logs}
+                        title={
+                            <Typography variant='body2' color='textSecondary' fontStyle='italic' mt={1}>Displaying <b>live logs</b> for {application.name} Application, {currentEnvironment} Environment</Typography>
+                        } />
                 </Box>
             </Box>
         </LayoutWithSidebar >

--- a/Source/SelfService/Web/theme/buttonText.tsx
+++ b/Source/SelfService/Web/theme/buttonText.tsx
@@ -17,6 +17,7 @@ type Props = {
     startIcon?: React.ReactNode;
     className?: any;
     size?: 'small' | 'medium' | 'large';
+    sx?: SxProps;
 };
 
 const defaultOnClick = (event: React.MouseEvent<HTMLElement>) => { };
@@ -69,7 +70,7 @@ const styles = {
     } as SxProps,
 };
 
-export const ButtonText: React.FunctionComponent<Props> = (props) => {
+export const ButtonText = (props: Props) => {
     const _props = props!;
     const children = _props.children;
     const onClick = _props.onClick ?? defaultOnClick;
@@ -83,7 +84,7 @@ export const ButtonText: React.FunctionComponent<Props> = (props) => {
 
     return (
         <MuiButton
-            sx={{ ...styles.base, ...buttonTypeStyles } as SxProps}
+            sx={{ ...styles.base, ...buttonTypeStyles, ...props.sx } as SxProps}
             disableRipple={true}
             disabled={disabled}
             startIcon={startIcon}

--- a/Source/SelfService/Web/tsconfig.json
+++ b/Source/SelfService/Web/tsconfig.json
@@ -2,7 +2,6 @@
     "extends": "../../../tsconfig.json",
     "compilerOptions": {
         "outDir": "./wwwroot",
-        "target": "es5",
         "lib": [
             "es2019",
             "DOM"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,7 @@
         "pretty": true,
         "noImplicitAny": false,
         "skipLibCheck": true,
-        "target": "ES2015",
+        "target": "ES2020",
         "moduleResolution": "node",
         "jsx": "react",
         "esModuleInterop": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -81,12 +81,24 @@
   resolved "https://registry.yarnpkg.com/@date-io/core/-/core-2.13.1.tgz#f041765aff5c55fbc7e37fdd75fc1792733426d6"
   integrity sha512-pVI9nfkf2qClb2Cxdq0Q4zJhdawMG4ybWZUVGifT78FDwzRMX2SwXBb55s5NRJk0HcIicDuxktmCtemZqMH1Zg==
 
+"@date-io/core@^2.14.0":
+  version "2.14.0"
+  resolved "https://registry.yarnpkg.com/@date-io/core/-/core-2.14.0.tgz#03e9b9b9fc8e4d561c32dd324df0f3ccd967ef14"
+  integrity sha512-qFN64hiFjmlDHJhu+9xMkdfDG2jLsggNxKXglnekUpXSq8faiqZgtHm2lsHCUuaPDTV6wuXHcCl8J1GQ5wLmPw==
+
 "@date-io/date-fns@^2.11.0":
   version "2.13.1"
   resolved "https://registry.yarnpkg.com/@date-io/date-fns/-/date-fns-2.13.1.tgz#19d8a245dab61c03c95ba492d679d98d2b0b4af5"
   integrity sha512-8fmfwjiLMpFLD+t4NBwDx0eblWnNcgt4NgfT/uiiQTGI81fnPu9tpBMYdAcuWxaV7LLpXgzLBx1SYWAMDVUDQQ==
   dependencies:
     "@date-io/core" "^2.13.1"
+
+"@date-io/date-fns@^2.14.0":
+  version "2.14.0"
+  resolved "https://registry.yarnpkg.com/@date-io/date-fns/-/date-fns-2.14.0.tgz#92ab150f488f294c135c873350d154803cebdbea"
+  integrity sha512-4fJctdVyOd5cKIKGaWUM+s3MUXMuzkZaHuTY15PH70kU1YTMrCoauA7hgQVx9qj0ZEbGrH9VSPYJYnYro7nKiA==
+  dependencies:
+    "@date-io/core" "^2.14.0"
 
 "@date-io/dayjs@^2.11.0":
   version "2.13.1"
@@ -95,6 +107,13 @@
   dependencies:
     "@date-io/core" "^2.13.1"
 
+"@date-io/dayjs@^2.14.0":
+  version "2.14.0"
+  resolved "https://registry.yarnpkg.com/@date-io/dayjs/-/dayjs-2.14.0.tgz#8d4e93e1d473bb5f25210866204dc33384ca4c20"
+  integrity sha512-4fRvNWaOh7AjvOyJ4h6FYMS7VHLQnIEeAV5ahv6sKYWx+1g1UwYup8h7+gPuoF+sW2hTScxi7PVaba2Jk/U8Og==
+  dependencies:
+    "@date-io/core" "^2.14.0"
+
 "@date-io/luxon@^2.11.1":
   version "2.13.1"
   resolved "https://registry.yarnpkg.com/@date-io/luxon/-/luxon-2.13.1.tgz#3701b3cabfffda5102af302979aa6e58acfda91a"
@@ -102,12 +121,26 @@
   dependencies:
     "@date-io/core" "^2.13.1"
 
+"@date-io/luxon@^2.14.0":
+  version "2.14.0"
+  resolved "https://registry.yarnpkg.com/@date-io/luxon/-/luxon-2.14.0.tgz#cd1641229e00a899625895de3a31e3aaaf66629f"
+  integrity sha512-KmpBKkQFJ/YwZgVd0T3h+br/O0uL9ZdE7mn903VPAG2ZZncEmaUfUdYKFT7v7GyIKJ4KzCp379CRthEbxevEVg==
+  dependencies:
+    "@date-io/core" "^2.14.0"
+
 "@date-io/moment@^2.11.0":
   version "2.13.1"
   resolved "https://registry.yarnpkg.com/@date-io/moment/-/moment-2.13.1.tgz#122a51e4bdedf71ff3babb264427737dc022c1e6"
   integrity sha512-XX1X/Tlvl3TdqQy2j0ZUtEJV6Rl8tOyc5WOS3ki52He28Uzme4Ro/JuPWTMBDH63weSWIZDlbR7zBgp3ZA2y1A==
   dependencies:
     "@date-io/core" "^2.13.1"
+
+"@date-io/moment@^2.14.0":
+  version "2.14.0"
+  resolved "https://registry.yarnpkg.com/@date-io/moment/-/moment-2.14.0.tgz#8300abd6ae8c55d8edee90d118db3cef0b1d4f58"
+  integrity sha512-VsoLXs94GsZ49ecWuvFbsa081zEv2xxG7d+izJsqGa2L8RPZLlwk27ANh87+SNnOUpp+qy2AoCAf0mx4XXhioA==
+  dependencies:
+    "@date-io/core" "^2.14.0"
 
 "@discoveryjs/json-ext@^0.5.0":
   version "0.5.7"
@@ -562,6 +595,17 @@
     prop-types "^15.7.2"
     react-is "^17.0.2"
 
+"@mui/utils@^5.7.0":
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@mui/utils/-/utils-5.8.0.tgz#4b1d19cbcf70773283375e763b7b3552b84cb58f"
+  integrity sha512-7LgUtCvz78676iC0wpTH7HizMdCrTphhBmRWimIMFrp5Ph6JbDFVuKS1CwYnWWxRyYKL0QzXrDL0lptAU90EXg==
+  dependencies:
+    "@babel/runtime" "^7.17.2"
+    "@types/prop-types" "^15.7.5"
+    "@types/react-is" "^16.7.1 || ^17.0.0"
+    prop-types "^15.8.1"
+    react-is "^17.0.2"
+
 "@mui/x-date-pickers@5.0.0-alpha.0":
   version "5.0.0-alpha.0"
   resolved "https://registry.yarnpkg.com/@mui/x-date-pickers/-/x-date-pickers-5.0.0-alpha.0.tgz#a62ffbab453d3c2dcd4ec20bd4f3f6338ad2ed3f"
@@ -572,6 +616,22 @@
     "@date-io/luxon" "^2.11.1"
     "@date-io/moment" "^2.11.0"
     "@mui/utils" "^5.2.3"
+    clsx "^1.1.1"
+    prop-types "^15.7.2"
+    react-transition-group "^4.4.2"
+    rifm "^0.12.1"
+
+"@mui/x-date-pickers@^5.0.0-alpha.4":
+  version "5.0.0-alpha.4"
+  resolved "https://registry.yarnpkg.com/@mui/x-date-pickers/-/x-date-pickers-5.0.0-alpha.4.tgz#853710d09b2dc29876e61a32d1f7b5c4b6d8816a"
+  integrity sha512-bPEsVygOI5KvrySYzi4ujJlRr4uskM5hDpcV8JCafHtSNQjUMQmCDtQKpAd8rViKBCBQMK8vhpqmf8ShfiZpLA==
+  dependencies:
+    "@babel/runtime" "^7.17.2"
+    "@date-io/date-fns" "^2.14.0"
+    "@date-io/dayjs" "^2.14.0"
+    "@date-io/luxon" "^2.14.0"
+    "@date-io/moment" "^2.14.0"
+    "@mui/utils" "^5.7.0"
     clsx "^1.1.1"
     prop-types "^15.7.2"
     react-transition-group "^4.4.2"
@@ -776,7 +836,7 @@
   resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"
   integrity sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==
 
-"@types/prop-types@*", "@types/prop-types@^15.7.4":
+"@types/prop-types@*", "@types/prop-types@^15.7.4", "@types/prop-types@^15.7.5":
   version "15.7.5"
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.5.tgz#5f19d2b85a98e9558036f6a3cacc8819420f05cf"
   integrity sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==
@@ -1980,6 +2040,11 @@ csstype@^3.0.11, csstype@^3.0.2:
   version "3.0.11"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.0.11.tgz#d66700c5eacfac1940deb4e3ee5642792d85cd33"
   integrity sha512-sa6P2wJ+CAbgyy4KFssIb/JNMLxFvKF1pCYCSXS8ZMuqZnMsrxqI2E5sPyoTpxoPU/gVZMzr2zjOfg8GIZOMsw==
+
+date-fns@^2.28.0:
+  version "2.28.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.28.0.tgz#9570d656f5fc13143e50c975a3b6bbeb46cd08b2"
+  integrity sha512-8d35hViGYx/QH0icHYCeLmsLmMUheMmTyV9Fcm6gvNwdw31yXXH+O85sOBJ+OLnLQMKZowvpKb6FgMIQjcpvQw==
 
 debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.9:
   version "2.6.9"
@@ -5364,7 +5429,7 @@ progress@^2.0.0:
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
   integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
 
-prop-types@^15.0.0, prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@^15.0.0, prop-types@^15.6.2, prop-types@^15.7.2, prop-types@^15.8.1:
   version "15.8.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
   integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==


### PR DESCRIPTION
## Summary

- Change the "Last 24 hours" into -> "Live logs" and enable streaming.
- Move the _selection description_ into the title of the LogPanel.
- Add `Timestamp` switch to the LogPanel, that turns on timestamps for each log line.
- Fix indentation of wrapped lines, the wrapped lines will now be indented the same amount as the leading whitespace of the original line.
- Enable "Date Range" selection to view logs from a absolute range (and implement the code to fetch logs from a range)
- Add the Microservice selection multi select dropdown, and corresponding chips in the filters.

To fix a bug with the math of nanosecond timestamps returned by Loki, I needed to use BigInts - which required an upgrade of the TypeScript target to ES2020. I believe this is OK now, and 90% reported by caniuse.com supports this feature.

Hidden updates we will use later:
- When using logs from range, internally there is a loadMoreLogs function returned that can be used to fetch the next N number of lines to display. This is intended to be used when viewing "Date Range" logs, and the user scrolls to the end (top or bottom) of the panel to view more logs. It also returns a boolean describing whether or not there are more logs to fetch.
- The `SHOW` context button in log lines are also implemented, and will call a provided handler function with the correct labels and timestamp to show the context of the logs in question. It is hidden right now - but can be used to implement the context view, and then enable the button.