### PR TITLE
Only show microservices in current env in filter

### DIFF
--- a/Source/SelfService/Web/screens/logsScreen.tsx
+++ b/Source/SelfService/Web/screens/logsScreen.tsx
@@ -104,10 +104,12 @@ export const LogsScreen: React.FunctionComponent = withRouteApplicationState(({ 
 
     const nav = getMenuWithApplication(history, application, currentEnvironment);
 
-    const availableMicroservices: LogFilterMicroservice[] = application.microservices.map(microservice => ({
-        id: microservice.dolittle.microserviceId,
-        name: microservice.name,
-    }));
+    const availableMicroservices: LogFilterMicroservice[] = application.microservices
+        .filter(_ => _.environment === currentEnvironment)
+        .map(microservice => ({
+            id: microservice.dolittle.microserviceId,
+            name: microservice.name,
+        }));
 
     return (
         <LayoutWithSidebar navigation={nav}>


### PR DESCRIPTION
## Summary
 - Fixes so that the microservice filter dropdown only shows microservices for the current environment