### PR TITLE
Show shimmering lines while fetching log lines

### DIFF
--- a/Environment/mock/monitoring/logs/generated.js
+++ b/Environment/mock/monitoring/logs/generated.js
@@ -59,10 +59,6 @@ generateRandomLogsEveryOtherSecond(generated);
 
 
 exports.queryGeneratedLogs = (query, from, to, limit, direction) => {
-    if (direction === 'forward') {
-        throw new Error('Direction forward is not implemented');
-    }
-
     const filtered = generated.filter(({ stream, line }) => {
         if (line[0] < from || line[0] > to) {
             return false;
@@ -97,10 +93,19 @@ exports.queryGeneratedLogs = (query, from, to, limit, direction) => {
         }
 
         return true;
-    }).slice(0, limit);
+    });
+
+    let limited = filtered;
+    if (limited.length > limit) {
+        if (direction === 'forward') {
+            limited = filtered.slice(0, limit);
+        } else {
+            limited = filtered.slice(-limit);
+        }
+    }
 
     const grouped = [];
-    grouping: for (const entry of filtered) {
+    grouping: for (const entry of limited) {
         for (const [stream, entries] of grouped) {
             if (stream === entry.stream) {
                 entries.push(entry.line);

--- a/Environment/mock/monitoring/logs/index.js
+++ b/Environment/mock/monitoring/logs/index.js
@@ -76,7 +76,9 @@ routes.get('/query_range', (req, res) => {
     console.log('Getting logs');
     const query = parseQuery(req.query.query);
     const result = queryGeneratedLogs(query, BigInt(req.query.start), BigInt(req.query.end), parseInt(req.query.limit), req.query.direction);
-    res.status(200).json(result).end();
+    global.setTimeout(() => {
+        res.status(200).json(result).end();
+    }, 2000);
 });
 
 routes.ws('/tail', (ws, req) => {

--- a/Source/SelfService/Web/logging/logLine.tsx
+++ b/Source/SelfService/Web/logging/logLine.tsx
@@ -2,9 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 import React from 'react';
-import { Box } from '@mui/material';
+import { Box, Skeleton } from '@mui/material';
 import { format } from 'date-fns';
-import { nb } from 'date-fns/locale';
 
 import { ColoredLine, ColoredLineSection, TerminalColor } from './lineParsing';
 import { ButtonText } from '../theme/buttonText';
@@ -73,6 +72,7 @@ const coloredLineSectionCss = (section: ColoredLineSection): React.CSSProperties
 };
 
 export type LogLineProps = {
+    loading?: boolean;
     timestamp: bigint;
     labels: DataLabels;
     line: ColoredLine;
@@ -85,33 +85,44 @@ const formatTimestamp = (timestamp: bigint): string => {
     return format(date, '[yyyy-MM-dd HH:mm:ss]');
 };
 
+const SkeletonWhenLoading = (props: { loading?: boolean, children: React.ReactNode }) =>
+    props.loading === true
+        ? <Skeleton>{props.children}</Skeleton>
+        : <>{props.children}</>;
+
 export const LogLine = (props: LogLineProps) => {
     // TODO: The tab-width is dependent on styling. How do we make sure we don't change this?
     const leadingWhitespace = props.line.leading.spaces + props.line.leading.tabs * 8;
     const leadingEmSpace = `${leadingWhitespace * 0.6}em`;
 
     return (
-        <Box>
+        <Box sx={{ display: 'flex' }}>
             {
                 props.enableShowLineContextButton &&
-                <Box sx={{ display: 'table-cell', whiteSpace: 'nowrap', pr: 2 }}>
-                    <ButtonText
-                        size='small'
-                        buttonType='secondary'
-                        sx={{ p: 0 }}
-                        onClick={event => props.onClickShowLineContext(props.timestamp, props.labels, event)}
-                    >Show</ButtonText>
+                <Box sx={{ whiteSpace: 'nowrap', pr: 2 }}>
+                    <SkeletonWhenLoading loading={props.loading}>
+                        <ButtonText
+                            size='small'
+                            buttonType='secondary'
+                            sx={{ p: 0 }}
+                            onClick={event => props.onClickShowLineContext(props.timestamp, props.labels, event)}
+                        >Show</ButtonText>
+                    </SkeletonWhenLoading>
                 </Box>
             }
-            <Box className='log-line-timestamp' sx={{ display: 'table-cell', whiteSpace: 'nowrap', pr: 2 }}>
-                {formatTimestamp(props.timestamp)}
+            <Box className='log-line-timestamp' sx={{ whiteSpace: 'nowrap', pr: 2 }}>
+                <SkeletonWhenLoading loading={props.loading}>
+                    <span>{formatTimestamp(props.timestamp)}</span>
+                </SkeletonWhenLoading>
             </Box>
-            <Box
-                sx={{ display: 'table-cell' }}
-                style={leadingWhitespace > 0 ? { paddingLeft: leadingEmSpace, textIndent: `-${leadingEmSpace}` } : undefined}>
-                {props.line.sections.map((section, i) => (
-                    <span key={i} /*style={coloredLineSectionCss(section)}*/>{section.text}</span>
-                ))}
+            <Box sx={{ flexGrow: 1 }} style={leadingWhitespace > 0 ? { paddingLeft: leadingEmSpace, textIndent: `-${leadingEmSpace}` } : undefined}>
+                {
+                    props.loading === true
+                        ? <><Skeleton /><Skeleton /></>
+                        : props.line.sections.map((section, i) => (
+                            <span key={i} /*style={coloredLineSectionCss(section)}*/>{section.text}</span>
+                        ))
+                }
             </Box>
         </Box>
     );

--- a/Source/SelfService/Web/logging/logLine.tsx
+++ b/Source/SelfService/Web/logging/logLine.tsx
@@ -118,7 +118,7 @@ export const LogLine = (props: LogLineProps) => {
             <Box sx={{ flexGrow: 1 }} style={leadingWhitespace > 0 ? { paddingLeft: leadingEmSpace, textIndent: `-${leadingEmSpace}` } : undefined}>
                 {
                     props.loading === true
-                        ? <><Skeleton /><Skeleton /></>
+                        ? <><Skeleton /><Skeleton /><Skeleton /></>
                         : props.line.sections.map((section, i) => (
                             <span key={i} /*style={coloredLineSectionCss(section)}*/>{section.text}</span>
                         ))

--- a/Source/SelfService/Web/logging/logPanel.tsx
+++ b/Source/SelfService/Web/logging/logPanel.tsx
@@ -10,6 +10,7 @@ import { QueryLabels } from './loki/queries';
 
 import { LogFilterMicroservice, LogFilterObject } from './logFilter/logFilterPanel';
 import { ColoredLine } from './lineParsing';
+import { ShimmeringLogLines } from './shimmeringLogLines';
 import { LogLines } from './logLines';
 
 
@@ -87,7 +88,7 @@ export const LogPanel = (props: LogPanelProps) => {
         );
     }
 
-    if (props.logs.lines.length === 0) {
+    if (!props.logs.loading && props.logs.lines.length === 0) {
         return (
             <Grid container spacing={2} sx={{ pt: 2 }}>
                 <Grid item xs={12} md={6}>
@@ -147,6 +148,12 @@ export const LogPanel = (props: LogPanelProps) => {
                             showContextButtonInLines={props.enableShowLineContextButton ?? false}
                             onClickShowContextButton={handleOnClickShowLineContext}
                         />
+                        {
+                            props.logs.loading &&
+                            <ShimmeringLogLines
+                                enableShowLineContextButton={props.enableShowLineContextButton ?? false}
+                            />
+                        }
                     </Box>
                 </Paper>
             </Grid>

--- a/Source/SelfService/Web/logging/loki/useLogsFromLast.ts
+++ b/Source/SelfService/Web/logging/loki/useLogsFromLast.ts
@@ -102,16 +102,7 @@ export const useLogsFromLast = <T>(last: bigint, newestFirst: boolean, labels: Q
             catchError(error => of({ loading: false, failed: true, error, lines: [] })),
         );
 
-        const results = fetches.pipe(
-            scan((last, next) => ({
-                loading: next.loading,
-                lines: next.loading ? last.lines : next.lines,
-                failed: next.failed,
-                error: next.error,
-            }), { loading: false, failed: false, lines: [] } as ObservableLogLines<T>),
-        );
-
-        const subscription = results.subscribe(setResult);
+        const subscription = fetches.subscribe(setResult);
         return () => subscription.unsubscribe();
     }, []);
 

--- a/Source/SelfService/Web/logging/loki/useLogsFromRange.ts
+++ b/Source/SelfService/Web/logging/loki/useLogsFromRange.ts
@@ -3,7 +3,7 @@
 
 import { useEffect, useRef, useState } from 'react';
 import { of, from as rxFrom, Observable, Subject, EMPTY } from 'rxjs';
-import { distinctUntilChanged, map, concatMap, startWith, scan, tap, take, switchMap, expand, catchError } from 'rxjs/operators';
+import { distinctUntilChanged, map, concatMap, startWith, tap, take, switchMap, expand, catchError } from 'rxjs/operators';
 
 import { LogLine, TransformedLogLine, ObservablePartialLogLines } from './logLines';
 import { labelsAndPipelineToLogQL, queryRange, QueryLabels } from './queries';
@@ -127,7 +127,7 @@ export const useLogsFromRange = <T>(from: bigint, to: bigint, newestFirst: boole
                                     startWith<State<T>>({ initialFetch: false, loading: true, parameters: state.parameters, lines: state.lines, moreLinesAvailable: false }),
                                 )),
                         );
-                    }, 1),
+                    }),
                     map(({ loading, lines, moreLinesAvailable }): ObservablePartialLogLines<T> => ({ loading, failed: false, lines, moreLinesAvailable })),
                 );
             }),

--- a/Source/SelfService/Web/logging/shimmeringLogLines.tsx
+++ b/Source/SelfService/Web/logging/shimmeringLogLines.tsx
@@ -1,0 +1,35 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import React from 'react';
+
+import { LogLine } from './logLine';
+
+const noopClickHandler = () => { };
+const shimmerLabels = {};
+const shimmerTimestamp = 0n;
+const shimmerLine = { sections: [], leading: { spaces: 0, tabs: 0 } };
+
+export type ShimmeringLogLinesProps = {
+    enableShowLineContextButton: boolean;
+};
+
+export const ShimmeringLogLines = (props: ShimmeringLogLinesProps) =>
+    <>
+        <LogLine
+            loading
+            enableShowLineContextButton={props.enableShowLineContextButton}
+            onClickShowLineContext={noopClickHandler}
+            labels={shimmerLabels}
+            timestamp={shimmerTimestamp}
+            line={shimmerLine}
+        />
+        <LogLine
+            loading
+            enableShowLineContextButton={props.enableShowLineContextButton}
+            onClickShowLineContext={noopClickHandler}
+            labels={shimmerLabels}
+            timestamp={shimmerTimestamp}
+            line={shimmerLine}
+        />
+    </>;

--- a/Source/SelfService/Web/logging/shimmeringLogLines.tsx
+++ b/Source/SelfService/Web/logging/shimmeringLogLines.tsx
@@ -24,12 +24,4 @@ export const ShimmeringLogLines = (props: ShimmeringLogLinesProps) =>
             timestamp={shimmerTimestamp}
             line={shimmerLine}
         />
-        <LogLine
-            loading
-            enableShowLineContextButton={props.enableShowLineContextButton}
-            onClickShowLineContext={noopClickHandler}
-            labels={shimmerLabels}
-            timestamp={shimmerTimestamp}
-            line={shimmerLine}
-        />
     </>;


### PR DESCRIPTION
## Summary

Adds shimmering LogLines in a LogPanel that is currently loading more logs. Also fixed the "No logs found" message so that it does not appear while loading logs.

Note: A slightly annoying behaviour is - if you toggle the Timestamp while shimmering lines are shown, the animation is not in sync with the text. But this is kind of edge case, as the loading doesn't really appear for long.

![image](https://user-images.githubusercontent.com/1014990/173665357-8d1964b0-0fc3-476c-b255-e4786861cf9b.png)

### Changed

- The `useLogsFromLast` no longer retains the last loaded logs while loading more, this seems more in line with the designed UX with these new shimmering lines.

### Fixed

- A tiny bug in `useLogFromRange` caused it to not update the state to `loading: true` while fetching logs.
