### PR TITLE
Load more logs with "infinite scrolling" when viewing date-range logs

### DIFF
--- a/Source/SelfService/Web/logging/logPanel.tsx
+++ b/Source/SelfService/Web/logging/logPanel.tsx
@@ -63,6 +63,16 @@ export type LogPanelProps = {
      * Whether or not to show the 'Show log line context' button.
      */
     enableShowLineContextButton?: boolean;
+
+    /**
+     * Elements to add after the LogPanel title divider, just before any actual log lines.
+     */
+    header?: React.ReactNode;
+
+    /**
+     * Elements to add to the end of the LogPanel, just after all actual log lines.
+     */
+    footer?: React.ReactNode;
 };
 
 /**
@@ -143,6 +153,7 @@ export const LogPanel = (props: LogPanelProps) => {
                         }}
                         className={showTimestamp ? '' : 'hide-timestamp'}
                     >
+                        {props.header}
                         <LogLines
                             lines={props.logs.lines}
                             showContextButtonInLines={props.enableShowLineContextButton ?? false}
@@ -154,6 +165,7 @@ export const LogPanel = (props: LogPanelProps) => {
                                 enableShowLineContextButton={props.enableShowLineContextButton ?? false}
                             />
                         }
+                        {props.footer}
                     </Box>
                 </Paper>
             </Grid>

--- a/Source/SelfService/Web/logging/logPanelAbsolute.tsx
+++ b/Source/SelfService/Web/logging/logPanelAbsolute.tsx
@@ -59,7 +59,7 @@ export type LogPanelAbsoluteProps = {
 
     /**
      * The maximum number of lines to fetch in the first request.
-     * Defaults to 100;
+     * Defaults to 1000;
      */
     autoLoadMoreNumberOfLines?: number;
 
@@ -79,7 +79,7 @@ export const LogPanelAbsolute = (props: LogPanelAbsoluteProps) => {
     if (props.loadMoreLogsRef !== undefined) props.loadMoreLogsRef.current = loadMoreLogs;
 
     const handleInViewChange = useCallback((visible: boolean) => {
-        if (props.autoLoadMoreLogs === true && visible) loadMoreLogs(props.autoLoadMoreNumberOfLines ?? 100);
+        if (props.autoLoadMoreLogs === true && visible) loadMoreLogs(props.autoLoadMoreNumberOfLines ?? 1000);
     }, [props.autoLoadMoreLogs, props.autoLoadMoreNumberOfLines, loadMoreLogs]);
 
     return <LogPanel
@@ -93,7 +93,7 @@ export const LogPanelAbsolute = (props: LogPanelAbsoluteProps) => {
             <InView
                 onChange={handleInViewChange}
                 // TODO: We can set the rootMargin to trigger earlier than reaching the actual bottom
-                fallbackInView={false} // TODO: This will mean that infinite scrolling doesn't work on old browsers, do we care?
+                fallbackInView={false}
             />
         }
     />;

--- a/Source/SelfService/Web/logging/logPanelRelative.tsx
+++ b/Source/SelfService/Web/logging/logPanelRelative.tsx
@@ -40,15 +40,20 @@ export type LogPanelRelativeProps = {
      * Whether or not to display the 'SHOW' context button for each line.
      */
     showContextButtonInLines?: boolean;
+
+    /**
+     * The maximum number of lines to fetch.
+     * Defaults to 1000;
+     */
+    numberOfLines?: number;
 };
 
 export const LogPanelRelative = (props: LogPanelRelativeProps) => {
     const [labels, pipeline] = logPanelQueryLabels(props.applicationId, props.environment, props.filters);
 
-    const newestFirst = true; // TODO: Where to move these
-    const limit = 1000;
+    const newestFirst = true; // TODO: What is required to support ordering the other way? Might impact the hooks and the LogPanel.
 
-    const logs = useLogsFromLast(props.last, newestFirst, labels, pipeline, limit, parseLogLine);
+    const logs = useLogsFromLast(props.last, newestFirst, labels, pipeline, props.numberOfLines ?? 1000, parseLogLine);
 
     return <LogPanel
         application={props.application}

--- a/Source/SelfService/Web/package.json
+++ b/Source/SelfService/Web/package.json
@@ -32,6 +32,7 @@
         "date-fns": "^2.28.0",
         "generate-password-browser": "^1.1.0",
         "notistack": "2.0.4",
+        "react-intersection-observer": "^9.3.3",
         "react-markdown": "^7.1.0",
         "remark-gfm": "^3.0.1",
         "rxjs": "^7.5.5",

--- a/Source/SelfService/Web/screens/logsScreen.tsx
+++ b/Source/SelfService/Web/screens/logsScreen.tsx
@@ -135,6 +135,7 @@ export const LogsScreen: React.FunctionComponent = withRouteApplicationState(({ 
                                 filters={filters}
                                 from={filters.dateRange.start}
                                 to={filters.dateRange.stop}
+                                autoLoadMoreLogs
                             // showContextButtonInLines
                             />
                     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5526,6 +5526,11 @@ react-dom@18.0.0:
     loose-envify "^1.1.0"
     scheduler "^0.21.0"
 
+react-intersection-observer@^9.3.3:
+  version "9.3.3"
+  resolved "https://registry.yarnpkg.com/react-intersection-observer/-/react-intersection-observer-9.3.3.tgz#1266fad4c09d8380462548b71bbc73e0e1c0c089"
+  integrity sha512-IEXX+Qd3/Bi2EzR2TYBLosHIaIMOTpgKRp5UH//eWOuteO/lpyTpQXt5ACy/ZugI6v0nwJBfiKLvWtCaKiRI7g==
+
 react-is@^16.13.1, react-is@^16.6.0, react-is@^16.7.0:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"


### PR DESCRIPTION
## Summary

Adds "infinite scrolling" to the date-range log view (`LogPanelAbsolute`). This works by adding an empty div to the bottom of the `LogPanel` and when it is scrolled into the viewport, it triggers loading more logs (which only happens if there are more to load).

Currently this will only work on browsers with the `IntersectionObserver` api supported: https://caniuse.com/mdn-api_intersectionobserver. Which I believe is fine. For browsers without the support, no auto-loading will happen.

### Added

- `LogPanel` accepts extra content before and after the log-lines with a `header` and `footer` property.
- Some hardcoded values in `LogPanelRelative` and `LogPanelAbsolute` are exposed now with props as defaults.
- `LogPanelAbsolute` now accepts a Ref as a prop that will be set to the `loadMoreLogs` function so it ready to accept loading more logs from the outside. This made sense to prepare it for the "Context Popover" that we might get to.
