### PR TITLE
Improve the container registry image tags list

### DIFF
--- a/Source/SelfService/Web/apis/solutions/containerregistry.ts
+++ b/Source/SelfService/Web/apis/solutions/containerregistry.ts
@@ -20,7 +20,11 @@ export type Image = {
 };
 
 export type Tag = {
-    name: string;
+    name: string,
+    createdTime: Date,
+    lastUpdateTime: Date,
+    digest: string,
+    signed: boolean
 };
 
 export type ContainerRegistryTags = {
@@ -28,13 +32,21 @@ export type ContainerRegistryTags = {
     tags: Tag[]
 };
 
+export type HTTPResponseTag = {
+    name: string,
+    createdTime: string,
+    lastUpdateTime: string,
+    digest: string,
+    signed: boolean
+};
+
 export type HTTPResponseTags = {
     name: string,
-    tags: string[]
+    tags: HTTPResponseTag[]
 };
 
 export async function getTagsInContainerRegistry(applicationId: string, image: string): Promise<ContainerRegistryTags> {
-    const url = `${getServerUrlPrefix()}/application/${applicationId}/containerregistry/tags/${image}`;
+    const url = `${getServerUrlPrefix()}/application/${applicationId}/containerregistry/image-tags/${image}`;
 
     const result = await fetch(
         url,
@@ -43,9 +55,14 @@ export async function getTagsInContainerRegistry(applicationId: string, image: s
             mode: 'cors'
         });
     const jsonResult = await result.json() as HTTPResponseTags;
+
     const items = jsonResult.tags.map(n => {
         return {
-            name: n
+            name: n.name,
+            createdTime: new Date(n.createdTime),
+            lastUpdateTime: new Date(n.lastUpdateTime),
+            digest: n.digest,
+            signed: n.signed
         };
     });
 

--- a/Source/SelfService/Web/applications/containerregistry/container.tsx
+++ b/Source/SelfService/Web/applications/containerregistry/container.tsx
@@ -67,7 +67,7 @@ export const ContainerRegistryContainer: React.FunctionComponent<Props> = (props
 
                     <Route path="/welcome" element={<Welcome applicationId={applicationId} />} />
 
-                    <Route path="/tags/:image" element={<Tags url={containerRegistryImages.url} applicationId={applicationId} />} />
+                    <Route path="/tags/:image" element={<Tags url={containerRegistryImages.url} applicationId={applicationId} environment={environment} />} />
                 </Routes>
             </div>
         </>

--- a/Source/SelfService/Web/applications/containerregistry/tags.tsx
+++ b/Source/SelfService/Web/applications/containerregistry/tags.tsx
@@ -2,17 +2,19 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 import React, { useEffect, useState } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams, Link as RouterLink } from 'react-router-dom';
 import {
     Table, TableContainer, TableHead,
     TableRow, TableCell, TableBody
 } from '@mui/material';
 
 import Paper from '@mui/material/Paper';
+import Link from '@mui/material/Link';
 import { ContainerRegistryTags, getTagsInContainerRegistry } from '../../apis/solutions/containerregistry';
 
 type Props = {
     url: string
+    environment: string
     applicationId: string
 };
 
@@ -29,6 +31,7 @@ export const View: React.FunctionComponent<Props> = (props) => {
     }
 
     const applicationId = _props.applicationId;
+    const environment = _props.environment;
 
     const [loaded, setLoaded] = useState(false);
     const [containerRegistryTags, setContainerRegistryTags] = useState({
@@ -45,6 +48,7 @@ export const View: React.FunctionComponent<Props> = (props) => {
         });
     }, []);
 
+    const msCreatePath = `/microservices/application/${applicationId}/${environment}/create?kind=dolittle-microservice`;
 
     if (!loaded) {
         return null;
@@ -58,13 +62,35 @@ export const View: React.FunctionComponent<Props> = (props) => {
                     <TableHead>
                         <TableRow>
                             <TableCell><b>Name</b></TableCell>
+                            <TableCell><b>Created At</b></TableCell>
+                            <TableCell><b>Last Updated At</b></TableCell>
+                            <TableCell><b>Digest</b></TableCell>
+                            <TableCell><b>Signed</b></TableCell>
                         </TableRow>
                     </TableHead>
                     <TableBody>
                         {containerRegistryTags.tags.map(row => (
                             <TableRow key={row.name} sx={{ '&:last-child td, &:last-child th': { border: 0 } }}>
-                                <TableCell component="th" scope="row">
-                                    {row.name}
+                                <TableCell component="td" scope="row">
+                                    <Link component={RouterLink}
+                                          to={msCreatePath + '#head-image='+image+':'+row.name}>
+                                        {row.name}
+                                    </Link>
+                                </TableCell>
+                                <TableCell component="td" scope="row">
+                                    {row.createdTime.toLocaleString()}
+                                </TableCell>
+                                <TableCell component="td" scope="row">
+                                    {row.lastUpdateTime.toLocaleString()}
+                                </TableCell>
+                                <TableCell component="td" scope="row">
+                                    <Link component={RouterLink}
+                                          to={msCreatePath + '#head-image='+image+'@'+row.digest}>
+                                        {row.digest}
+                                    </Link>
+                                </TableCell>
+                                <TableCell component="td" scope="row">
+                                    {row.signed ? 'true' : 'false' }
                                 </TableCell>
                             </TableRow>
                         ))}

--- a/Source/SelfService/Web/applications/containerregistry/tags.tsx
+++ b/Source/SelfService/Web/applications/containerregistry/tags.tsx
@@ -26,12 +26,13 @@ export const View: React.FunctionComponent<Props> = (props) => {
     const _props = props!;
     const { image } = useParams<ViewParams>();
 
-    if(!image) {
+    if (!image) {
         return null;
     }
 
     const applicationId = _props.applicationId;
     const environment = _props.environment;
+    const imagePath = `${_props.url}/${image}`;
 
     const [loaded, setLoaded] = useState(false);
     const [containerRegistryTags, setContainerRegistryTags] = useState({
@@ -56,7 +57,7 @@ export const View: React.FunctionComponent<Props> = (props) => {
 
     return (
         <>
-            <p>{_props.url}/{image}</p>
+            <p>{imagePath}</p>
             <TableContainer component={Paper}>
                 <Table sx={{ minWidth: 480 }} aria-label="Docker images" size="small">
                     <TableHead>
@@ -73,7 +74,7 @@ export const View: React.FunctionComponent<Props> = (props) => {
                             <TableRow key={row.name} sx={{ '&:last-child td, &:last-child th': { border: 0 } }}>
                                 <TableCell component="td" scope="row">
                                     <Link component={RouterLink}
-                                          to={msCreatePath + '#head-image='+image+':'+row.name}>
+                                        to={`${msCreatePath}'#head-image=${imagePath}:${row.name}`}>
                                         {row.name}
                                     </Link>
                                 </TableCell>
@@ -85,12 +86,12 @@ export const View: React.FunctionComponent<Props> = (props) => {
                                 </TableCell>
                                 <TableCell component="td" scope="row">
                                     <Link component={RouterLink}
-                                          to={msCreatePath + '#head-image='+image+'@'+row.digest}>
+                                        to={`${msCreatePath}'#head-image=${imagePath}:${row.name}@${row.digest}`}>
                                         {row.digest}
                                     </Link>
                                 </TableCell>
                                 <TableCell component="td" scope="row">
-                                    {row.signed ? 'true' : 'false' }
+                                    {row.signed ? 'true' : 'false'}
                                 </TableCell>
                             </TableRow>
                         ))}

--- a/Source/SelfService/Web/applications/containerregistry/tags.tsx
+++ b/Source/SelfService/Web/applications/containerregistry/tags.tsx
@@ -70,28 +70,28 @@ export const View: React.FunctionComponent<Props> = (props) => {
                         </TableRow>
                     </TableHead>
                     <TableBody>
-                        {containerRegistryTags.tags.map(row => (
-                            <TableRow key={row.name} sx={{ '&:last-child td, &:last-child th': { border: 0 } }}>
+                        {containerRegistryTags.tags.map(tag => (
+                            <TableRow key={tag.name} sx={{ '&:last-child td, &:last-child th': { border: 0 } }}>
                                 <TableCell component="td" scope="row">
                                     <Link component={RouterLink}
-                                        to={`${msCreatePath}'#head-image=${imagePath}:${row.name}`}>
-                                        {row.name}
+                                        to={`${msCreatePath}#head-image=${imagePath}:${tag.name}`}>
+                                        {tag.name}
                                     </Link>
                                 </TableCell>
                                 <TableCell component="td" scope="row">
-                                    {row.createdTime.toLocaleString()}
+                                    {tag.createdTime.toLocaleString()}
                                 </TableCell>
                                 <TableCell component="td" scope="row">
-                                    {row.lastUpdateTime.toLocaleString()}
+                                    {tag.lastUpdateTime.toLocaleString()}
                                 </TableCell>
                                 <TableCell component="td" scope="row">
                                     <Link component={RouterLink}
-                                        to={`${msCreatePath}'#head-image=${imagePath}:${row.name}@${row.digest}`}>
-                                        {row.digest}
+                                        to={`${msCreatePath}#head-image=${imagePath}:${tag.name}@${tag.digest}`}>
+                                        {tag.digest}
                                     </Link>
                                 </TableCell>
                                 <TableCell component="td" scope="row">
-                                    {row.signed ? 'true' : 'false'}
+                                    {tag.signed ? 'true' : 'false'}
                                 </TableCell>
                             </TableRow>
                         ))}

--- a/Source/SelfService/Web/applications/microservice/deployMicroservice/deployMicroservice.tsx
+++ b/Source/SelfService/Web/applications/microservice/deployMicroservice/deployMicroservice.tsx
@@ -3,7 +3,7 @@
 
 import React, { useState } from 'react';
 
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useLocation } from 'react-router-dom';
 import { useSnackbar } from 'notistack';
 
 import { Guid } from '@dolittle/rudiments';
@@ -46,6 +46,7 @@ export type DeployMicroserviceProps = {
 export const DeployMicroservice = ({ application, environment }: DeployMicroserviceProps) => {
     const { enqueueSnackbar } = useSnackbar();
     const navigate = useNavigate();
+    const location = useLocation();
 
     const [isLoading, setIsLoading] = useState(false);
     const [showM3ConnectorInfo, setShowM3ConnectorInfo] = useState(false);
@@ -64,6 +65,7 @@ export const DeployMicroservice = ({ application, environment }: DeployMicroserv
         },
     ];
 
+    const frag = new URLSearchParams(location.hash.slice(1));
     const handleCreateMicroservice = async (values: MicroserviceFormParameters) => {
         setIsLoading(true);
 
@@ -123,7 +125,7 @@ export const DeployMicroservice = ({ application, environment }: DeployMicroserv
                     microserviceName: '',
                     developmentEnvironment: environment,
                     runtimeVersion: latestRuntimeVersion,
-                    headImage: '', //nginxdemos/hello:latest
+                    headImage: frag.get('head-image') || '', //nginxdemos/hello:latest
                     headPort: 80,
                     entrypoint: '',
                     isPublic: false,


### PR DESCRIPTION
### Summary

This changes the tag list to use the new image-tags endpoint in platform-api, to get a list of
tags (sorted by creation date), with additional meta data.
It also adds linking between the tags list and the create microservice
screen, where it prefills the head image field with the value found in
the URI fragment identifier.

### Added

- Mechanism for adding prefilled image name to the head image field in the create new microservice screen
- New metadata to the tags list
- Links from the tags list to the create new microservice screen

### Changed

- The tags api to use the `image-tags` endpoint instead of `tags`
- The tags list
- The create new microservice screen (to be able to get an optional image name from the URI fragment identifier for the head image field)
