### PR TITLE
Configure caching of the SelfService/Web server

### DIFF
--- a/Source/SelfService/Web/.docker/custom-entrypoint.sh
+++ b/Source/SelfService/Web/.docker/custom-entrypoint.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec "/docker-entrypoint.sh" "nginx" "-g" "daemon off;"

--- a/Source/SelfService/Web/.docker/nginx.conf
+++ b/Source/SelfService/Web/.docker/nginx.conf
@@ -1,0 +1,39 @@
+user  nginx;
+worker_processes  auto;
+
+error_log  /var/log/nginx/error.log debug;
+pid        /var/run/nginx.pid;
+
+events {
+    worker_connections  1024;
+}
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  /var/log/nginx/access.log  main;
+
+    sendfile           on;
+    keepalive_timeout  65;
+
+    server {
+        listen       8043 default_server;
+        server_name  _;
+        root         /usr/share/nginx/html;
+
+        location ~* /(selfservice/)?(.*[^/]+\.[^./]+)$ {
+            try_files /$2 =404;
+            add_header Cache-Control 'public, max-age=604800, immutable';
+        }
+
+        location / {
+            try_files /index.html =404;
+            add_header Cache-Control 'no-store';
+        }
+    }
+}

--- a/Source/SelfService/Web/Dockerfile
+++ b/Source/SelfService/Web/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.16.0 AS shared-build
+FROM node:16.16.0 AS build
 
 # Install dependencies
 WORKDIR /build
@@ -21,8 +21,11 @@ WORKDIR /build/Source/SelfService/Web
 RUN yarn build
 
 # Copy bundled artifacts
-FROM pierrezemb/gostatic as base
-WORKDIR /app
-COPY --from=shared-build /build/Source/SelfService/Web/wwwroot ./public
+FROM nginx:1.23.1
 
-ENTRYPOINT ["/goStatic"]
+COPY --from=build /build/Source/SelfService/Web/wwwroot /usr/share/nginx/html
+COPY Source/SelfService/Web/.docker/nginx.conf /etc/nginx/nginx.conf
+COPY Source/SelfService/Web/.docker/custom-entrypoint.sh /custom-entrypoint.sh
+
+# Replace NGINX entrypoint so we don't break compatibility with previous gostatic images when deployed
+ENTRYPOINT ["/custom-entrypoint.sh"]


### PR DESCRIPTION
## Summary

Fixes an issue we have where navigating back to e.g. `dolittle.studio` after logging out caused a cached version of the frontend to be loaded - which then failed to get any data because the user is not logged in. By changing the server of the SelfService/Web frontend to NGINX, and setting up explicit caching rules - the browsers should now only cache the static files (which webpack invalidates by changing the name) and not any paths leading to the `index.html` file. This means that the frontend will be reloaded on any browser navigation.

### Changed

- The SelfService/Web server from `gostatic` to `nginx` to allow more control of the serving of content.

### Fixed

- The SPA caching that caused strange behaviour when navigating after logging out, and old versions of the SPA served after new deployments until a manual refresh.
