### PR TITLE
Fix form errors

### DIFF
--- a/Source/SelfService/Web/insights/runtimeStatsV1/utils.ts
+++ b/Source/SelfService/Web/insights/runtimeStatsV1/utils.ts
@@ -1,23 +1,23 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-export function getFailingPartions(data: any): any[] {
-    return Object.entries(Object.keys(data)
-        .reduce((obj, key) => {
-            const found = data[key]
-                .filter(state => state.failingPartitions);
-            if (found.length >= 1) {
-                obj[key] = found;
-            }
-            return obj;
-        }, {})).flatMap(([key, value]) => {
-            // Well this is ugly as hell
-            const d = value as unknown as any[];
-            return d.map(state => {
-                return {
-                    store: key,
-                    ...state,
-                };
-            });
-        });
-};
+// export function getFailingPartions(data: any): any[] {
+//     return Object.entries(Object.keys(data)
+//         .reduce((obj, key) => {
+//             const found = data[key]
+//                 .filter(state => state.failingPartitions);
+//             if (found.length >= 1) {
+//                 obj[key] = found;
+//             }
+//             return obj;
+//         }, {})).flatMap(([key, value]) => {
+//             // Well this is ugly as hell
+//             const d = value as unknown as any[];
+//             return d.map(state => {
+//                 return {
+//                     store: key,
+//                     ...state,
+//                 };
+//             });
+//         });
+// };

--- a/Source/SelfService/Web/utils/formTextFieldsValidation.ts
+++ b/Source/SelfService/Web/utils/formTextFieldsValidation.ts
@@ -19,7 +19,7 @@ export type FormErrorStates = {
 };
 
 const validateEmail = (error: FormErrorStates, email: string) => {
-    const emailRegex = /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:.[a-zA-Z0-9-]+)*$/;
+    const emailRegex = /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
 
     if (!email.trim() || !email.match(emailRegex)) {
         error.contactEmailError.emailErrorMessage = 'Please enter a valid email address.';


### PR DESCRIPTION
## Summary

'Create new application' form email validation was too lose. I updated the regex to make the check more efficient.

<img width="754" alt="Screenshot 2022-09-13 at 16 48 13" src="https://user-images.githubusercontent.com/19160439/189918519-7d73c5b2-d3c1-4105-b1ea-f46afb5554f2.png">

### Fixed

- 'Create new application' form email error sensitivity.

