### PR TITLE
Domain and range for graph

### DIFF
--- a/Source/DesignSystem/molecules/Metrics/Graph.stories.tsx
+++ b/Source/DesignSystem/molecules/Metrics/Graph.stories.tsx
@@ -14,6 +14,7 @@ export default metadata;
 export const Normal = createStory({
     title: 'CPU Usage',
     subtitle: 'Last 24 hours',
+    unit: 'CPUs',
     data: [
         {
             group: 'Head',
@@ -26,4 +27,14 @@ export const Normal = createStory({
             values: data.second,
         },
     ],
+    range: [0, 2],
+});
+
+export const Empty = createStory({
+    title: 'CPU Usage',
+    subtitle: 'Last 24 hours',
+    unit: 'CPUs',
+    data: [],
+    domain: [ data.first[0].time, data.first.slice(-1)[0].time ],
+    range: [0, 2],
 });

--- a/Source/DesignSystem/molecules/Metrics/Graph.tsx
+++ b/Source/DesignSystem/molecules/Metrics/Graph.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-import React, { useMemo } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import { Vega } from 'react-vega';
 
 import { Box, Paper, Stack, SxProps, Theme, Typography } from '@mui/material';
@@ -13,11 +13,37 @@ import { useThemedSpec } from './theming';
  * The props for a {@link Graph} component.
  */
 export type GraphProps = {
+    /**
+     * The title of the plot.
+     */
     title: string;
+    /**
+     * An optional subtitle to display below the title of the plot.
+     */
     subtitle?: string;
+    /**
+     * An optional unit to display next to the title of the plot.
+     */
     unit?: string;
+    /**
+     * The datasets to use for the plot.
+     */
     data: DataSet[];
+    /**
+     * An optional domain (time) to use for the horisontal axis. Defaults to the domain of the datasets.
+     */
+    domain?: [number, number];
+    /**
+     * An optional range (values) to use for the vertical axis. Defaults to the range of the datasets.
+     */
+    range?: [number, number];
+    /**
+     * An optional height to use for the plot. Defaults to 200px.
+     */
     height?: number;
+    /**
+     * Optional MUI sx-styling to apply to the Paper container of the plot.
+     */
     sx?: SxProps<Theme>;
 };
 
@@ -27,97 +53,150 @@ export type GraphProps = {
  * @returns The rendered {@link JSX.Element}.
  */
 export const Graph = (props: GraphProps) => {
-    const [spec, vegaRef] = useThemedSpec({
-        width: 'container',
-        height: 'container',
-        autosize: {
-            contains: 'content',
-            type: 'pad',
-        },
-        padding: 0,
-        background: '#0000',
-        config: {
-            legend: {
-                disable: true,
+    const [spec, vegaRef, setParams] = useThemedSpec(
+        {
+            width: 'container',
+            height: 'container',
+            autosize: {
+                contains: 'content',
+                type: 'pad',
             },
-            axis: {
-                title: null,
-                labelColor: { expr: 'theme.palette.text.secondary' },
-                gridColor: { expr: 'theme.palette.outlineborder' },
-                domainColor: { expr: 'theme.palette.outlineborder' },
-                tickColor: { expr: 'theme.palette.outlineborder' },
-                ticks: false,
-                labelFont: { expr: 'theme.typography.body2.fontFamily' },
-                labelFontSize: { expr: 'theme.typography.body2.fontSize' },
-                labelFontWeight: { expr: 'theme.typography.body2.fontWeight' },
-                labelPadding: { expr: 'theme.spacing * 2' },
-            },
-            view: {
-                stroke: { expr: 'theme.palette.outlineborder' },
-            }
-        },
-        layer: [
-            {
-                mark: {
-                    type: 'area',
-                    line: true,
-                    strokeWidth: 2,
-                    strokeJoin: 'round',
-                    fillOpacity: 0.2,
+            padding: 0,
+            background: '#0000',
+            config: {
+                legend: {
+                    disable: true,
                 },
-                encoding: {
-                    x: {
-                        field: 'time',
-                        type: 'temporal',
-                        scale: {
-                            type: 'time',
-                        },
-                        axis: {
-                            labelExpr: `
-                                    hours(datum.value) == 0
-                                        ? timeFormat(datum.value, '%b %-d')
-                                        : timeFormat(datum.value, '%H:%M')
-                                `,
-                        },
-                    },
-                    y: {
-                        field: 'value',
-                        type: 'quantitative',
-                        stack: false,
-                    },
-                    color: {
-                        field: 'index',
-                        type: 'nominal',
-                        scale: {
-                            scheme: { expr: 'colorscheme' },
-                        }
-                    },
+                axis: {
+                    title: null,
+                    labelColor: { expr: 'theme.palette.text.secondary' },
+                    gridColor: { expr: 'theme.palette.outlineborder' },
+                    domainColor: { expr: 'theme.palette.outlineborder' },
+                    tickColor: { expr: 'theme.palette.outlineborder' },
+                    ticks: false,
+                    labelFont: { expr: 'theme.typography.body2.fontFamily' },
+                    labelFontSize: { expr: 'theme.typography.body2.fontSize' },
+                    labelFontWeight: { expr: 'theme.typography.body2.fontWeight' },
+                    labelPadding: { expr: 'theme.spacing * 2' },
                 },
-            },
-            {
-                mark: {
-                    type: 'rule',
-                    strokeWidth: 2,
-                    strokeCap: 'round',
-                    strokeDash: [2, 4],
-                },
-                encoding: {
-                    y: {
-                        field: 'value',
-                        aggregate: 'mean',
-                    },
-                    color: {
-                        field: 'index',
-                        type: 'nominal',
-                        scale: {
-                            scheme: { expr: 'colorscheme' },
-                        }
-                    },
+                view: {
+                    stroke: { expr: 'theme.palette.outlineborder' },
                 }
-            }
-        ],
-        data: { name: 'table' },
-    });
+            },
+            layer: [
+                {
+                    mark: {
+                        type: 'area',
+                        clip: true,
+                        line: true,
+                        strokeWidth: 2,
+                        strokeJoin: 'round',
+                        fillOpacity: 0.2,
+                    },
+                    encoding: {
+                        x: {
+                            field: 'time',
+                            type: 'temporal',
+                            scale: {
+                                type: 'time',
+                                domain: { expr: 'calculated_domain' }
+                            },
+                            axis: {
+                                labelExpr: `
+                                        hours(datum.value) == 0
+                                            ? timeFormat(datum.value, '%b %-d')
+                                            : timeFormat(datum.value, '%H:%M')
+                                    `,
+                            },
+                        },
+                        y: {
+                            field: 'value',
+                            type: 'quantitative',
+                            stack: false,
+                            scale: {
+                                domain: { expr: 'calculated_range' }
+                            }
+                        },
+                        color: {
+                            field: 'index',
+                            type: 'nominal',
+                            scale: {
+                                scheme: { expr: 'colorscheme' },
+                            }
+                        },
+                    },
+                },
+                {
+                    mark: {
+                        type: 'rule',
+                        clip: true,
+                        strokeWidth: 2,
+                        strokeCap: 'round',
+                        strokeDash: [2, 4],
+                    },
+                    encoding: {
+                        y: {
+                            field: 'value',
+                            aggregate: 'mean',
+                            scale: {
+                                domain: { expr: 'calculated_range' }
+                            }
+                        },
+                        color: {
+                            field: 'index',
+                            type: 'nominal',
+                            scale: {
+                                scheme: { expr: 'colorscheme' },
+                            }
+                        },
+                    }
+                }
+            ],
+            data: { name: 'table' },
+            transform: [
+                {
+                    filter: {
+                        field: 'time',
+                        range: { signal: 'filter_domain' },
+                    }
+                }
+            ],
+        },
+        [
+            {
+                name: 'domain',
+                value: props.domain ?? null,
+            },
+            {
+                name: 'range',
+                value: props.range ?? null,
+            },
+            {
+                name: 'filter_domain',
+                expr: 'domain == null ? [MIN_VALUE, MAX_VALUE] : domain'
+            },
+            {
+                name: 'calculated_domain',
+                expr: 'domain == null ? extent(pluck(data("table"),"time")) : domain',
+            },
+            {
+                name: 'calculated_range',
+                expr: 'range == null ? extent(pluck(data("table"),"value")) : range',
+            },
+        ]);
+
+    useEffect(() => {
+        setParams([
+            {
+                name: 'domain',
+                value: props.domain ?? null,
+            },
+            {
+                name: 'range',
+                value: props.range ?? null,
+            },
+        ]);
+    }, [setParams, props.domain, props.range]);
 
     const table = useMemo(() =>
         props.data.flatMap((dataset, index) => dataset.values.map(datapoint => ({ ...datapoint, index })))

--- a/Source/SelfService/Web/microservice/microserviceView/healthStatus/healthStatus.tsx
+++ b/Source/SelfService/Web/microservice/microserviceView/healthStatus/healthStatus.tsx
@@ -66,7 +66,7 @@ export const HealthStatus = ({ applicationId, microserviceId, data, environment 
         window.location.reload();
     };
 
-
+    const timeRange = useMemo<[number, number]>(() => [ Date.now()-86_400_000, Date.now() ], [ Date.now() / 60_000 ]);
     const cpu = useMetricsFromLast(`microservice:container_cpu_usage_seconds:rate_max{application_id="${applicationId}", environment="${environment}", microservice_id="${microserviceId}"}`, 86_400, 60);
     const memory = useMetricsFromLast(`microservice:container_memory_working_set_bytes:max{application_id="${applicationId}", environment="${environment}", microservice_id="${microserviceId}"}`, 86_400, 60);
 
@@ -127,11 +127,11 @@ export const HealthStatus = ({ applicationId, microserviceId, data, environment 
 
             {cpu.loading
                 ? null
-                : <Graph title='CPU Usage' unit='CPUs' subtitle='Last 24 hours' sx={{ mt: 3 }} data={cpuGraphData} />
+                : <Graph title='CPU Usage' unit='CPUs' subtitle='Last 24 hours' range={[0, 2]} domain={timeRange} sx={{ mt: 3 }} data={cpuGraphData} />
             }
             {memory.loading
                 ? null
-                : <Graph title='Memory Usage' unit='MiB' subtitle='Last 24 hours' sx={{ mt: 3 }} data={memoryGraphData} />
+                : <Graph title='Memory Usage' unit='MiB' subtitle='Last 24 hours' range={[0, 2048]} domain={timeRange} sx={{ mt: 3 }} data={memoryGraphData} />
             }
         </>
     );


### PR DESCRIPTION
## Summary

Adds a `range` and `domain` property on the `Graph` component so that we can make the empty-state look a bit better. The HealthStatus page should now look like this when there is no data:
![image](https://user-images.githubusercontent.com/1014990/193765926-616154f9-5ab0-4aa5-b265-4a5f7447b693.png)

### Added

- `range` and `domain` props to set the extends on a `Graph` component explicitly. By default they are calculated from the data.

### Changed

- The `HealthStatus` page sets the domain to be the last 24 hours - and sensible ranges for CPU and Memory.