### PR TITLE
Fix Graph size calculation bug caused by scrollbar appearing.

### DIFF
--- a/Source/SelfService/Web/App.tsx
+++ b/Source/SelfService/Web/App.tsx
@@ -8,6 +8,7 @@ import { LicenseInfo } from '@mui/x-license-pro';
 
 import { themeDark } from '@dolittle/design-system';
 
+import { useViewportResize } from './utils/useViewportResize';
 import { ApplicationsScreen } from './screens/applicationsScreen/applicationsScreen';
 
 import { uriWithAppPrefix } from './store';
@@ -52,6 +53,8 @@ const snackbarStyles = {
 };
 
 export const App = () => {
+    useViewportResize();
+
     const { pathname } = useLocation();
     // Little hack to force redirect
     if (['', '/', uriWithAppPrefix('/')].includes(pathname)) {

--- a/Source/SelfService/Web/utils/useViewportResize.ts
+++ b/Source/SelfService/Web/utils/useViewportResize.ts
@@ -13,16 +13,26 @@ export const useViewportResize = (): void => {
     useEffect(() => {
         if (window.visualViewport === null) return;
 
-        const listener = (_: Event) => {
-            const event = new Event(
-                'resize',
-                {
-                    bubbles: false,
-                    cancelable: false,
-                    composed: false,
-                });
+        let lastSeenHeight = window.innerHeight;
+        let lastSeenWidth = window.innerWidth;
 
-            window.dispatchEvent(event);
+        const listener = (_: Event) => {
+            const windowResized = lastSeenHeight !== window.innerHeight || lastSeenWidth !== window.innerWidth;
+
+            lastSeenHeight = window.innerHeight;
+            lastSeenWidth = window.innerWidth;
+
+            if (!windowResized) {
+                const event = new Event(
+                    'resize',
+                    {
+                        bubbles: false,
+                        cancelable: false,
+                        composed: false,
+                    });
+
+                window.dispatchEvent(event);
+            }
         };
 
         window.visualViewport.addEventListener('resize', listener);

--- a/Source/SelfService/Web/utils/useViewportResize.ts
+++ b/Source/SelfService/Web/utils/useViewportResize.ts
@@ -1,0 +1,31 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { useEffect } from 'react';
+
+/**
+ * Adds a listener to the `window.visualViewport:resize` event, that re-dispatches a `window:resize`.
+ * Some components that we use (e.g. Vega graphs) use the `window:resize` event to update their own size.
+ * The `window:resize` event is not triggered when a scrollbar is shown or hidden, causing their size to be wrong
+ * when DOM elements are added later making a scrollbar appear. This re-dispatching fixes that issue.
+ */
+export const useViewportResize = (): void => {
+    useEffect(() => {
+        if (window.visualViewport === null) return;
+
+        const listener = (_: Event) => {
+            const event = new Event(
+                'resize',
+                {
+                    bubbles: false,
+                    cancelable: false,
+                    composed: false,
+                });
+
+            window.dispatchEvent(event);
+        };
+
+        window.visualViewport.addEventListener('resize', listener);
+        return () => window.visualViewport?.removeEventListener('resize', listener);
+    }, [window.visualViewport]);
+};

--- a/Source/SelfService/Web/utils/useViewportResize.ts
+++ b/Source/SelfService/Web/utils/useViewportResize.ts
@@ -8,6 +8,7 @@ import { useEffect } from 'react';
  * Some components that we use (e.g. Vega graphs) use the `window:resize` event to update their own size.
  * The `window:resize` event is not triggered when a scrollbar is shown or hidden, causing their size to be wrong
  * when DOM elements are added later making a scrollbar appear. This re-dispatching fixes that issue.
+ * If this issue is ever fixed: https://github.com/vega/vega-lite/issues/8447, we can probably remove this workaround.
  */
 export const useViewportResize = (): void => {
     useEffect(() => {


### PR DESCRIPTION
## Summary

The `Vega` graph components use the `window:resize` event to re-calculate their own size. However, it turns out that this event **is not triggered** when a scrollbar is shown or hidden. This lead to some graphs having the wrong size if more content was loaded later and making the scrollbar appear.

This little fix listens to the `window.visualViewport:resize` event, which **is triggered** when a scrollbar is shown or hidden, and re-dispatches a new `window:resize` event. This forces `Vega` graphs to recalculate as normal, and it shouldn't cause issues for other elements.

### Fixed

- The `Vega` graphs did not re-calculate their size when a scrollbar appeared, which meant that for small windows the `CPU Usage` graph would be a little too wide when the `Memory Usage` graph appeared.