### PR TITLE
Fix some terminal bugs - and make it a bit larger

### DIFF
--- a/Source/DesignSystem/atoms/Terminal/useXTerm.ts
+++ b/Source/DesignSystem/atoms/Terminal/useXTerm.ts
@@ -69,7 +69,13 @@ export const useXTerm = (options: ITerminalOptions): Terminal => {
 const createRefCallback = (xterm: XTerminal, fit: FitAddon, resolve: (value: XTerminal) => void): RefCallback<HTMLDivElement> =>
     (container) => {
         if (container === null) {
-            xterm.dispose();
+            try {
+                xterm.dispose();
+            } catch (error) {
+                // There doesn't seem to be a way to unload the WebglAddon - and disposing of it throws an exception.
+                // For now, we can't really don anythin but catch the error, and allow any resources that are still kept to leak :(
+                console.warn('Could not dispose of XTerm', error);
+            }
             return;
         };
 

--- a/Source/SelfService/Web/microservice/microserviceView/terminal/View.tsx
+++ b/Source/SelfService/Web/microservice/microserviceView/terminal/View.tsx
@@ -24,6 +24,9 @@ export const View = (props: ViewProps) => {
     return (
         <Terminal
             connect={connect}
+            sx={{
+                height: '70vh',
+            }}
         />
     );
 };

--- a/Source/SelfService/Web/microservice/microserviceView/terminal/View.tsx
+++ b/Source/SelfService/Web/microservice/microserviceView/terminal/View.tsx
@@ -18,7 +18,7 @@ export const View = (props: ViewProps) => {
     const url = useTTYdUrl(props.applicationId, props.environment, props.microserviceId);
 
     const connect = useMemo<TerminalConnect>(() =>
-        ({ columns, rows }) => ttydConnect(url, columns, rows)
+        ({ columns, rows, signal }) => ttydConnect(url, columns, rows, signal)
     , [url]);
 
     return (


### PR DESCRIPTION
## Summary

Fixes a bug that caused the page to go blank when navigating away from the Terminal-tab. Also make it a bit larger (depending on viewport height) so we get more room to play.

### Changed

- The Terminal view is now `70vh` tall.

### Fixed

- A bug in the `xterm.js` library causes it to `throw` whenever it is disposed (at least using the `WebglAddon`. For now we are just catching this.

