### PR TITLE
Modify /api rewrites to only be active for development

### DIFF
--- a/Source/Bridge/bridge-frontend/next.config.js
+++ b/Source/Bridge/bridge-frontend/next.config.js
@@ -10,16 +10,21 @@ const nextConfig = {
   },
   output: 'standalone',
   async rewrites() {
-    return [
+    const rewrites = [
       {
         source: "/api/cats",
         destination: "https://meowfacts.herokuapp.com"
-      },
-      {
-        source: "/api/:path*",
-        destination: "http://localhost:5000/:path*" // Proxy to Backend
-      },
+      }
     ];
+
+    if(process.env.NODE_ENV === 'development') {
+      rewrites.push(
+        {
+          source: "/api/:path*",
+          destination: "http://localhost:5000/:path*" // Proxy to Backend on localhost
+        });
+    }
+    return rewrites;
   }
 }
 


### PR DESCRIPTION
## Summary

No longer proxy requests to `/api` in production, and trust the ingress will kick in when it is set up
