### PR TITLE
Add exports storybook

### DIFF
--- a/Source/DesignSystem/atoms/Accordion/Accordion.tsx
+++ b/Source/DesignSystem/atoms/Accordion/Accordion.tsx
@@ -31,7 +31,7 @@ const styles = {
     }
 };
 
-type AccordionProps = {
+export type AccordionProps = {
     id: string;
     title: string;
     children: React.ReactNode;

--- a/Source/DesignSystem/atoms/Accordion/index.ts
+++ b/Source/DesignSystem/atoms/Accordion/index.ts
@@ -1,0 +1,4 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+export { Accordion } from './Accordion';

--- a/Source/DesignSystem/atoms/AlertBox/index.ts
+++ b/Source/DesignSystem/atoms/AlertBox/index.ts
@@ -1,0 +1,4 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+export { AlertBox, AlertBoxProps } from './AlertBox';

--- a/Source/DesignSystem/atoms/ConfirmDialog/ConfirmDialog.tsx
+++ b/Source/DesignSystem/atoms/ConfirmDialog/ConfirmDialog.tsx
@@ -3,12 +3,12 @@
 
 import React from 'react';
 
-import { Button } from '@dolittle/design-system/atoms/Button';
+import { Button } from '../Button';
 
 import { IconButton, Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle } from '@mui/material';
 import { CloseRounded } from '@mui/icons-material';
 
-type ConfirmDialogProps = {
+export type ConfirmDialogProps = {
     id: string;
     isOpen?: boolean;
     title: string;

--- a/Source/DesignSystem/atoms/ConfirmDialog/index.ts
+++ b/Source/DesignSystem/atoms/ConfirmDialog/index.ts
@@ -1,0 +1,4 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+export { ConfirmDialog, ConfirmDialogProps } from './ConfirmDialog';

--- a/Source/DesignSystem/atoms/Forms/Input.stories.tsx
+++ b/Source/DesignSystem/atoms/Forms/Input.stories.tsx
@@ -2,10 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 import React from 'react';
-import { componentStories } from '@dolittle/design-system';
 
-import { Form } from './Form';
-import { Input } from './Input';
+import { componentStories, Form, Input } from '@dolittle/design-system';
 
 const { metadata, createStory } = componentStories(Input, {
     actions: {
@@ -51,4 +49,3 @@ export const DisabledWithValue = createStory({
     label: 'Application Name',
     disabled: true,
 });
-

--- a/Source/DesignSystem/atoms/Forms/SwitchToggle.stories.tsx
+++ b/Source/DesignSystem/atoms/Forms/SwitchToggle.stories.tsx
@@ -20,10 +20,10 @@ export const Default = createStory({
 // Needs useState for value changes.
 export const DefaultActive = createStory({
     title: 'Default active switch with label',
-    checked: true,
+    isChecked: true,
 });
 
 export const DisabledSwitch = createStory({
     title: 'Disabled switch with label',
-    disabled: true,
+    isDisabled: true,
 });

--- a/Source/DesignSystem/atoms/Forms/SwitchToggle.tsx
+++ b/Source/DesignSystem/atoms/Forms/SwitchToggle.tsx
@@ -3,14 +3,22 @@
 
 import React from 'react';
 
-import { FormGroup, FormControlLabel, Switch, SwitchProps } from '@mui/material';
+import { FormGroup, FormControlLabel, Switch, SxProps } from '@mui/material';
 
-export const SwitchToggle = ({ checked, onChange, title, disabled, sx }: SwitchProps) =>
+export type SwitchToggleProps = {
+    title: string;
+    isChecked: boolean;
+    onChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
+    isDisabled?: boolean;
+    sx?: SxProps;
+};
+
+export const SwitchToggle = ({ title, isChecked, onChange, isDisabled, sx }: SwitchToggleProps) =>
     <FormGroup sx={{ width: 1 }}>
         <FormControlLabel
-            control={<Switch size='small' checked={checked} onChange={onChange} />}
             label={title}
-            disabled={disabled}
+            control={<Switch size='small' checked={isChecked} onChange={onChange} />}
+            disabled={isDisabled}
             sx={sx}
         />
     </FormGroup>;

--- a/Source/DesignSystem/atoms/Forms/index.ts
+++ b/Source/DesignSystem/atoms/Forms/index.ts
@@ -3,6 +3,6 @@
 
 export { Checkbox } from './Checkbox';
 export { Form, FormProps } from './Form';
-export { Input } from './Input';
+export { Input, InputProps } from './Input';
 export { Select, SelectProps } from './Select';
 export { SwitchToggle, SwitchToggleProps } from './SwitchToggle';

--- a/Source/DesignSystem/atoms/Forms/index.ts
+++ b/Source/DesignSystem/atoms/Forms/index.ts
@@ -3,6 +3,6 @@
 
 export { Checkbox } from './Checkbox';
 export { Form, FormProps } from './Form';
-export { Input, InputProps } from './Input';
-export { Select } from './Select';
-export { SwitchToggle } from './SwitchToggle';
+export { Input } from './Input';
+export { Select, SelectProps } from './Select';
+export { SwitchToggle, SwitchToggleProps } from './SwitchToggle';

--- a/Source/DesignSystem/atoms/IconButton/index.ts
+++ b/Source/DesignSystem/atoms/IconButton/index.ts
@@ -1,0 +1,4 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+export { IconButton } from './IconButton';

--- a/Source/DesignSystem/atoms/LoadingSpinner/index.ts
+++ b/Source/DesignSystem/atoms/LoadingSpinner/index.ts
@@ -1,0 +1,4 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+export { LoadingSpinner } from './LoadingSpinner';

--- a/Source/DesignSystem/atoms/Snackbar/Snackbar.stories.tsx
+++ b/Source/DesignSystem/atoms/Snackbar/Snackbar.stories.tsx
@@ -9,9 +9,8 @@ import { SnackbarProvider, useSnackbar } from 'notistack';
 import { Slide, SlideProps } from '@mui/material';
 import { ErrorRounded } from '@mui/icons-material';
 
-import { Button } from '@dolittle/design-system/atoms/Button';
+import { Button } from '../Button';
 import { IconButton } from '@dolittle/design-system/atoms/IconButton/IconButton';
-
 import { Snackbar as CustomSnackbar } from './Snackbar';
 
 function SlideTransition(props: SlideProps) {

--- a/Source/DesignSystem/atoms/Tabs/Tabs.tsx
+++ b/Source/DesignSystem/atoms/Tabs/Tabs.tsx
@@ -32,7 +32,7 @@ const styles = {
     }
 };
 
-export type Tab = {
+type Tab = {
     label: string
     render: () => React.ReactNode
     sx?: any

--- a/Source/DesignSystem/atoms/Tabs/index.ts
+++ b/Source/DesignSystem/atoms/Tabs/index.ts
@@ -1,0 +1,4 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+export { Tabs, TabsProps } from './Tabs';

--- a/Source/DesignSystem/index.ts
+++ b/Source/DesignSystem/index.ts
@@ -4,3 +4,16 @@
 export { componentStories, type ComponentStories } from './componentStories';
 export { themeDark } from './theming/theme';
 
+// Atoms
+export { Accordion } from './atoms/Accordion';
+export { AlertBox } from './atoms/AlertBox';
+export { Button } from './atoms/Button';
+export { ConfirmDialog } from './atoms/ConfirmDialog';
+export { Checkbox, Form, Input, Select, SwitchToggle } from './atoms/Forms';
+export { LoadingSpinner } from './atoms/LoadingSpinner';
+export { Summary } from './atoms/Metrics';
+export { Tabs } from './atoms/Tabs';
+export { InputMessages, OutputMessages, Terminal, TerminalConnect, TerminalStreams } from './atoms/Terminal';
+
+// Molecules
+export { Graph } from './molecules/Metrics/Graph';

--- a/Source/DesignSystem/molecules/Metrics/index.ts
+++ b/Source/DesignSystem/molecules/Metrics/index.ts
@@ -1,0 +1,4 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+export { Graph, GraphProps } from './Graph';

--- a/Source/SelfService/Web/application/create/create.tsx
+++ b/Source/SelfService/Web/application/create/create.tsx
@@ -7,10 +7,7 @@ import { useHistory } from 'react-router-dom';
 import { Box, Typography } from '@mui/material';
 
 import { Guid } from '@dolittle/rudiments';
-import { Checkbox, Form, Input } from '@dolittle/design-system/atoms/Forms';
-import { AlertBox } from '@dolittle/design-system/atoms/AlertBox/AlertBox';
-import { LoadingSpinner } from '@dolittle/design-system/atoms/LoadingSpinner/LoadingSpinner';
-import { Button } from '@dolittle/design-system/atoms/Button/Button';
+import { AlertBox, Button, Checkbox, Form, Input, LoadingSpinner } from '@dolittle/design-system';
 
 import { createApplication, HttpApplicationRequest } from '../../api/application';
 

--- a/Source/SelfService/Web/logging/logPanel.tsx
+++ b/Source/SelfService/Web/logging/logPanel.tsx
@@ -14,7 +14,7 @@ import {
     Typography,
 } from '@mui/material';
 
-import { AlertBox } from '@dolittle/design-system/atoms/AlertBox/AlertBox';
+import { AlertBox } from '@dolittle/design-system';
 
 import { ObservableLogLines, ObservablePartialLogLines } from './loki/logLines';
 import { DataLabels } from './loki/types';

--- a/Source/SelfService/Web/microservice/components/headArguments.tsx
+++ b/Source/SelfService/Web/microservice/components/headArguments.tsx
@@ -6,7 +6,7 @@ import React, { ChangeEvent } from 'react';
 import { Box, TextField } from '@mui/material';
 import { AddCircleRounded, DeleteRounded } from '@mui/icons-material/';
 
-import { Button } from '@dolittle/design-system/atoms/Button';
+import { Button } from '@dolittle/design-system';
 
 type HeadArgumentsProps = {
     cmdArgs: string[];

--- a/Source/SelfService/Web/microservice/helpers/index.ts
+++ b/Source/SelfService/Web/microservice/helpers/index.ts
@@ -1,0 +1,6 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+export { capitalize } from './stringHelpers';
+export { removeFromString } from './stringHelpers';
+export { formatTime, formatStartingDate } from './dateHelpers';

--- a/Source/SelfService/Web/microservice/helpers/index.ts
+++ b/Source/SelfService/Web/microservice/helpers/index.ts
@@ -1,6 +1,6 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-export { capitalize } from './stringHelpers';
-export { removeFromString } from './stringHelpers';
+export { capitalize, removeFromString } from './stringHelpers';
 export { formatTime, formatStartingDate } from './dateHelpers';
+export { DownloadLogs } from './downloadHelpers';

--- a/Source/SelfService/Web/microservice/microservice.tsx
+++ b/Source/SelfService/Web/microservice/microservice.tsx
@@ -3,10 +3,8 @@
 
 import React, { useEffect, useState } from 'react';
 import { useHistory } from 'react-router-dom';
-import { useSnackbar } from 'notistack';
 
-import { LoadingSpinner } from '@dolittle/design-system/atoms/LoadingSpinner/LoadingSpinner';
-import { Button } from '@dolittle/design-system/atoms/Button';
+import { useSnackbar } from 'notistack';
 
 import { HttpResponseApplication } from '../api/application';
 
@@ -15,6 +13,8 @@ import { canEditMicroservices, microservices } from '../stores/microservice';
 
 import { Paper, Typography } from '@mui/material';
 import { RocketLaunch } from '@mui/icons-material';
+
+import { Button, LoadingSpinner } from '@dolittle/design-system';
 
 import { NoMicroservices } from './noMicroservices';
 import { MicroserviceTable, MicroserviceObject } from './microserviceTable';

--- a/Source/SelfService/Web/microservice/microserviceStatus.tsx
+++ b/Source/SelfService/Web/microservice/microserviceStatus.tsx
@@ -7,7 +7,7 @@ import { GridRenderCellParams } from '@mui/x-data-grid-pro';
 import { Box, Typography } from '@mui/material';
 import { CheckCircleRounded, ErrorRounded, WarningRounded, QuestionMark } from '@mui/icons-material';
 
-import { Button } from '@dolittle/design-system/atoms/Button/Button';
+import { Button } from '@dolittle/design-system';
 
 const styles = {
     status: {

--- a/Source/SelfService/Web/microservice/microserviceTable.tsx
+++ b/Source/SelfService/Web/microservice/microserviceTable.tsx
@@ -11,7 +11,7 @@ import { StatusFieldCell, customStatusFieldSort } from './microserviceStatus';
 import { DataGridPro, GridColDef, GridValueGetterParams, GridRenderCellParams } from '@mui/x-data-grid-pro';
 import { Paper, Tooltip } from '@mui/material';
 
-import { capitalize, removeFromString } from './helpers/stringHelpers';
+import { capitalize, removeFromString } from './helpers';
 
 const sortByRuntimeVersion = (params: GridValueGetterParams) => {
     const runtimeVersion = removeFromString(params.row.edit?.extra?.runtimeImage, /dolittle\/runtime:/gi);

--- a/Source/SelfService/Web/microservice/microserviceView/configurationFilesSection/emptyDataTable.tsx
+++ b/Source/SelfService/Web/microservice/microserviceView/configurationFilesSection/emptyDataTable.tsx
@@ -6,37 +6,34 @@ import React from 'react';
 import { Paper, SxProps, Typography } from '@mui/material';
 import { AddCircle } from '@mui/icons-material';
 
-import { Button } from '@dolittle/design-system/atoms/Button';
+import { Button } from '@dolittle/design-system';
 
 type EmptyDataTableProps = {
     title: string;
     description: string;
     buttonText: string;
-    sx?: SxProps
+    sx?: SxProps;
     handleOnClick: () => void;
 };
 
-export const EmptyDataTable = ({ title, description, buttonText, sx, handleOnClick }: EmptyDataTableProps) => {
-    return (
-        <Paper sx={{ p: 2, ...sx }}>
-            <Typography variant='h2'>{title}</Typography>
-            <Typography variant='body1' sx={{ my: 2 }}>{description}</Typography>
+export const EmptyDataTable = ({ title, description, buttonText, sx, handleOnClick }: EmptyDataTableProps) =>
+    <Paper sx={{ p: 2, ...sx }}>
+        <Typography variant='h2'>{title}</Typography>
+        <Typography variant='body1' sx={{ my: 2 }}>{description}</Typography>
 
-            <Button
-                variant='filled'
-                label={buttonText}
-                startWithIcon={<AddCircle />}
-                isFullWidth
-                sx={{
-                    'backgroundColor': 'rgba(140, 154, 248, 0.08)',
-                    'color': 'primary.main',
-                    'minHeight': 30,
-                    '&:hover': {
-                        backgroundColor: 'rgba(140, 154, 248, 0.15)'
-                    }
-                }}
-                onClick={() => handleOnClick()}
-            />
-        </Paper>
-    );
-};
+        <Button
+            variant='filled'
+            label={buttonText}
+            startWithIcon={<AddCircle />}
+            isFullWidth
+            sx={{
+                'backgroundColor': 'rgba(140, 154, 248, 0.08)',
+                'color': 'primary.main',
+                'minHeight': 30,
+                '&:hover': {
+                    backgroundColor: 'rgba(140, 154, 248, 0.15)'
+                }
+            }}
+            onClick={() => handleOnClick()}
+        />
+    </Paper>;

--- a/Source/SelfService/Web/microservice/microserviceView/configurationFilesSection/environmentVariablesSection/environmentVariableSection.tsx
+++ b/Source/SelfService/Web/microservice/microserviceView/configurationFilesSection/environmentVariablesSection/environmentVariableSection.tsx
@@ -10,8 +10,7 @@ import { DataGridPro, GridColDef, GridRowId, GridRowModesModel, GridRowModes, Gr
 import { Box, Paper } from '@mui/material';
 import { AddCircle, DeleteRounded, DownloadRounded, ArrowDropDown } from '@mui/icons-material';
 
-import { Accordion } from '@dolittle/design-system/atoms/Accordion/Accordion';
-import { Button } from '@dolittle/design-system/atoms/Button';
+import { Accordion, Button } from '@dolittle/design-system';
 
 import { getEnvironmentVariables, getServerUrlPrefix, InputEnvironmentVariable, updateEnvironmentVariables } from '../../../../api/api';
 

--- a/Source/SelfService/Web/microservice/microserviceView/configurationFilesSection/filesSection/buttonGroup.tsx
+++ b/Source/SelfService/Web/microservice/microserviceView/configurationFilesSection/filesSection/buttonGroup.tsx
@@ -3,10 +3,10 @@
 
 import React from 'react';
 
-import { Button } from '@dolittle/design-system/atoms/Button';
-
 import { Box } from '@mui/material';
 import { AddCircle, DeleteRounded, DownloadRounded } from '@mui/icons-material';
+
+import { Button } from '@dolittle/design-system';
 
 type ButtonGroupProps = {
     filePrompt: () => void;

--- a/Source/SelfService/Web/microservice/microserviceView/configurationFilesSection/filesSection/deleteConfigFileDialog.tsx
+++ b/Source/SelfService/Web/microservice/microserviceView/configurationFilesSection/filesSection/deleteConfigFileDialog.tsx
@@ -3,10 +3,10 @@
 
 import React from 'react';
 
-import { ConfirmDialog } from '@dolittle/design-system/atoms/ConfirmDialog/ConfirmDialog';
-
 import { GridSelectionModel } from '@mui/x-data-grid-pro';
 import { Typography } from '@mui/material';
+
+import { ConfirmDialog } from '@dolittle/design-system';
 
 type DeleteConfigFileDialogProps = {
     selectedDataRows: GridSelectionModel;

--- a/Source/SelfService/Web/microservice/microserviceView/configurationFilesSection/filesSection/filesSection.tsx
+++ b/Source/SelfService/Web/microservice/microserviceView/configurationFilesSection/filesSection/filesSection.tsx
@@ -9,8 +9,7 @@ import { GridSelectionModel } from '@mui/x-data-grid-pro';
 import { IconButton } from '@mui/material';
 import { CloseRounded } from '@mui/icons-material';
 
-import { Accordion } from '@dolittle/design-system/atoms/Accordion/Accordion';
-import { Button } from '@dolittle/design-system/atoms/Button';
+import { Accordion, Button } from '@dolittle/design-system';
 
 import { getConfigFilesNamesList, getServerUrlPrefix, updateConfigFile, deleteConfigFile } from '../../../../api/api';
 

--- a/Source/SelfService/Web/microservice/microserviceView/configurationFilesSection/filesSection/validateFileDialog.tsx
+++ b/Source/SelfService/Web/microservice/microserviceView/configurationFilesSection/filesSection/validateFileDialog.tsx
@@ -3,7 +3,7 @@
 
 import React from 'react';
 
-import { ConfirmDialog } from '@dolittle/design-system/atoms/ConfirmDialog/ConfirmDialog';
+import { ConfirmDialog } from '@dolittle/design-system';
 
 import { Box, Typography } from '@mui/material';
 

--- a/Source/SelfService/Web/microservice/microserviceView/configurationFilesSection/restartInfoBox.tsx
+++ b/Source/SelfService/Web/microservice/microserviceView/configurationFilesSection/restartInfoBox.tsx
@@ -5,7 +5,7 @@ import React from 'react';
 
 import { Collapse } from '@mui/material';
 
-import { AlertBox } from '@dolittle/design-system/atoms/AlertBox/AlertBox';
+import { AlertBox } from '@dolittle/design-system';
 
 type RestartInfoBoxProps = {
     name: string;

--- a/Source/SelfService/Web/microservice/microserviceView/configurationFilesSection/setupSection/setupSection.tsx
+++ b/Source/SelfService/Web/microservice/microserviceView/configurationFilesSection/setupSection/setupSection.tsx
@@ -6,12 +6,10 @@ import { useHistory } from 'react-router-dom';
 
 import { useSnackbar } from 'notistack';
 
-import { Accordion, AccordionDetails, AccordionSummary, Box, Button as MuiButton, Tooltip, Typography } from '@mui/material';
+import { Accordion, AccordionDetails, AccordionSummary, Box, Tooltip, Typography } from '@mui/material';
 import { DeleteRounded, EditRounded, ExpandCircleDownRounded, SaveRounded, RestartAltRounded } from '@mui/icons-material';
 
-import { Button } from '@dolittle/design-system/atoms/Button';
-import { Form, Input, Select, SwitchToggle } from '@dolittle/design-system/atoms/Forms';
-import { ConfirmDialog } from '@dolittle/design-system/atoms/ConfirmDialog/ConfirmDialog';
+import { Button, ConfirmDialog, Form, Input, Select, SwitchToggle } from '@dolittle/design-system';
 
 import { canDeleteMicroservice, deleteMicroservice, MicroserviceStore } from '../../../../stores/microservice';
 
@@ -19,7 +17,7 @@ import { HttpResponseApplication } from '../../../../api/application';
 
 import { HeadArguments } from '../../../components/headArguments';
 import { RestartMicroserviceDialog } from '../../restartMicroserviceDialog';
-import { capitalize, removeFromString } from '../../../helpers/stringHelpers';
+import { capitalize, removeFromString } from '../../../helpers';
 
 const styles = {
     form: {
@@ -156,29 +154,27 @@ export const SetupSection = ({ application, applicationId, environment, microser
                 <AccordionDetails>
                     <Box>
                         <Tooltip title='Coming soon!' placement='top' arrow>
-                            {/* <Button
-                                variant='text'
-                                label='edit'
-                                disabled={formIsNotEditable}
-                                startWithIcon={<EditRounded />}
-                                //onClick={() => setFormIsNotEditable(false)}
-                                sx={{ mr: 2.5 }}
-                            /> */}
                             <span>
-                                <MuiButton disabled startIcon={<EditRounded />} sx={{ mr: 2.5 }}>edit</MuiButton>
+                                <Button
+                                    variant='text'
+                                    label='edit'
+                                    disabled={formIsNotEditable}
+                                    startWithIcon={<EditRounded />}
+                                    //onClick={() => setFormIsNotEditable(false)}
+                                    sx={{ mr: 2.5 }}
+                                />
                             </span>
                         </Tooltip>
                         <Tooltip title='Coming soon!' placement='top' arrow>
-                            {/* <Button
-                                variant='text'
-                                label='save'
-                                disabled={formIsNotEditable}
-                                startWithIcon={<SaveRounded />}
-                                //onClick={() => setFormIsNotEditable(true)}
-                                sx={{ mr: 2.5 }}
-                            /> */}
                             <span>
-                                <MuiButton disabled startIcon={<SaveRounded />} sx={{ mr: 2.5 }}>save</MuiButton>
+                                <Button
+                                    variant='text'
+                                    label='save'
+                                    disabled={formIsNotEditable}
+                                    startWithIcon={<SaveRounded />}
+                                    //onClick={() => setFormIsNotEditable(true)}
+                                    sx={{ mr: 2.5 }}
+                                />
                             </span>
                         </Tooltip>
                         <Button
@@ -240,8 +236,8 @@ export const SetupSection = ({ application, applicationId, environment, microser
 
                             <SwitchToggle
                                 title='Expose to a public URL'
-                                disabled={formIsNotEditable}
-                                checked={hasPublicURL}
+                                isChecked={hasPublicURL}
+                                isDisabled={formIsNotEditable}
                                 onChange={(event) => setHasPublicURL(event.target.checked)}
                                 sx={{ my: 2.5 }}
                             />
@@ -264,8 +260,8 @@ export const SetupSection = ({ application, applicationId, environment, microser
 
                                 <SwitchToggle
                                     title='Make M3 configuration available to microservice'
-                                    disabled={formIsNotEditable}
-                                    checked={useM3Connector}
+                                    isChecked={useM3Connector}
+                                    isDisabled={formIsNotEditable}
                                     onChange={(event) => setHasM3Connetcor(event.target.checked)}
                                     sx={{ mt: 2.5 }}
                                 />

--- a/Source/SelfService/Web/microservice/microserviceView/healthStatus/healthStatus.tsx
+++ b/Source/SelfService/Web/microservice/microserviceView/healthStatus/healthStatus.tsx
@@ -5,14 +5,11 @@ import React, { useMemo, useState } from 'react';
 
 import { RestartAltRounded } from '@mui/icons-material';
 
-import { Graph } from '@dolittle/design-system/molecules/Metrics/Graph';
-import { AlertBox } from '@dolittle/design-system/atoms/AlertBox/AlertBox';
-import { Button } from '@dolittle/design-system/atoms/Button';
+import { AlertBox, Button, Graph } from '@dolittle/design-system';
 
 import { ContainerStatusInfo, HttpResponsePodStatus } from '../../../api/api';
 
 import { Metric, useMetricsFromLast } from '../../../metrics/useMetrics';
-
 import { HealthStatusTable, HealthStatusTableStats } from './healthStatusTable';
 import { RestartMicroserviceDialog } from '../restartMicroserviceDialog';
 

--- a/Source/SelfService/Web/microservice/microserviceView/healthStatus/healthStatusTableColumns.tsx
+++ b/Source/SelfService/Web/microservice/microserviceView/healthStatus/healthStatusTableColumns.tsx
@@ -6,9 +6,9 @@ import React from 'react';
 import { Box } from '@mui/material';
 import { GridColDef, GridValueGetterParams, GridRenderCellParams } from '@mui/x-data-grid-pro';
 
-import { Summary } from '@dolittle/design-system/atoms/Metrics/Summary';
+import { Summary } from '@dolittle/design-system';
 
-import { formatTime, formatStartingDate } from '../../helpers/dateHelpers';
+import { formatTime, formatStartingDate } from '../../helpers';
 import { DownloadLogs } from '../../helpers/downloadHelpers';
 
 import { StatusFieldCell } from '../../microserviceStatus';

--- a/Source/SelfService/Web/microservice/microserviceView/healthStatus/healthStatusTableColumns.tsx
+++ b/Source/SelfService/Web/microservice/microserviceView/healthStatus/healthStatusTableColumns.tsx
@@ -8,8 +8,7 @@ import { GridColDef, GridValueGetterParams, GridRenderCellParams } from '@mui/x-
 
 import { Summary } from '@dolittle/design-system';
 
-import { formatTime, formatStartingDate } from '../../helpers';
-import { DownloadLogs } from '../../helpers/downloadHelpers';
+import { DownloadLogs, formatTime, formatStartingDate } from '../../helpers';
 
 import { StatusFieldCell } from '../../microserviceStatus';
 import { HealthStatusTableRow } from './healthStatusTable';

--- a/Source/SelfService/Web/microservice/microserviceView/microserviceView.tsx
+++ b/Source/SelfService/Web/microservice/microserviceView/microserviceView.tsx
@@ -12,7 +12,7 @@ import { HttpResponseApplication } from '../../api/application';
 
 import { Box, Typography } from '@mui/material';
 
-import { Tabs } from '@dolittle/design-system/atoms/Tabs/Tabs';
+import { Tabs } from '@dolittle/design-system';
 
 import { ConfigurationFilesSection } from './configurationFilesSection/configurationFilesSection';
 import { HealthStatus } from './healthStatus/healthStatus';

--- a/Source/SelfService/Web/microservice/microserviceView/restartMicroserviceDialog.tsx
+++ b/Source/SelfService/Web/microservice/microserviceView/restartMicroserviceDialog.tsx
@@ -5,7 +5,7 @@ import React, { useEffect } from 'react';
 
 import { useSnackbar } from 'notistack';
 
-import { ConfirmDialog } from '@dolittle/design-system/atoms/ConfirmDialog/ConfirmDialog';
+import { ConfirmDialog } from '@dolittle/design-system';
 
 import { restartMicroservice } from '../../api/api';
 

--- a/Source/SelfService/Web/microservice/microserviceView/terminal/terminalView.tsx
+++ b/Source/SelfService/Web/microservice/microserviceView/terminal/terminalView.tsx
@@ -3,7 +3,7 @@
 
 import React, { useMemo } from 'react';
 
-import { Terminal, TerminalConnect } from '@dolittle/design-system/atoms/Terminal';
+import { Terminal, TerminalConnect } from '@dolittle/design-system';
 
 import { connect as ttydConnect } from './ttyd';
 import { useTTYdUrl } from './useTerminal';
@@ -17,14 +17,10 @@ export type ViewProps = {
 export const TerminalView = ({ applicationId, environment, microserviceId }: ViewProps) => {
     const url = useTTYdUrl(applicationId, environment, microserviceId);
 
-    const connect = useMemo<TerminalConnect>(() =>
-        ({ columns, rows, signal }) => ttydConnect(url, columns, rows, signal)
-        , [url]);
+    const connect = useMemo<TerminalConnect>(() => ({ columns, rows, signal }) =>
+        ttydConnect(url, columns, rows, signal), [url]);
 
     return (
-        <Terminal
-            connect={connect}
-            sx={{ height: '70vh', }}
-        />
+        <Terminal connect={connect} sx={{ height: '70vh', }} />
     );
 };

--- a/Source/SelfService/Web/microservice/microserviceView/terminal/ttyd.ts
+++ b/Source/SelfService/Web/microservice/microserviceView/terminal/ttyd.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-import { InputMessages, OutputMessages, TerminalStreams } from '@dolittle/design-system/atoms/Terminal';
+import { InputMessages, OutputMessages, TerminalStreams } from '@dolittle/design-system';
 
 import { WebSocketConnection, WebSocketCloseInfo, WebSocketStream } from './websocket';
 
@@ -79,7 +79,7 @@ const transformInput = (stream: WritableStream<string>, close: (info?: WebSocket
         },
     });
 
-    transformer.readable.pipeTo(stream).catch(_ => {});
+    transformer.readable.pipeTo(stream).catch(_ => { });
     return transformer.writable;
 };
 
@@ -89,7 +89,7 @@ const transformOutput = (stream: ReadableStream<string>, closed: Promise<WebSock
             closed.then(_ => controller.terminate());
         },
         transform(chunk, controller) {
-            const cmd = chunk.slice(0,1);
+            const cmd = chunk.slice(0, 1);
             const data = chunk.slice(1);
 
             switch (cmd) {
@@ -108,13 +108,13 @@ const transformOutput = (stream: ReadableStream<string>, closed: Promise<WebSock
         },
     });
 
-    stream.pipeTo(transformer.writable).catch(_ => {});
+    stream.pipeTo(transformer.writable).catch(_ => { });
     return transformer.readable;
 };
 
 const encodeDecodeStrings = (connection: WebSocketConnection, signal: AbortSignal): { readable: ReadableStream<string>, writable: WritableStream<string> } => {
     const encoder = new TextEncoderStream();
-    encoder.readable.pipeTo(connection.writable, { signal }).catch(_ => {});
+    encoder.readable.pipeTo(connection.writable, { signal }).catch(_ => { });
     const writable = encoder.writable;
 
     const decoder = new TextDecoderStream();
@@ -132,7 +132,7 @@ const encodeDecodeStrings = (connection: WebSocketConnection, signal: AbortSigna
                 }
             },
         }))
-        .pipeTo(decoder.writable, { signal }).catch(_ => {});
+        .pipeTo(decoder.writable, { signal }).catch(_ => { });
     const readable = decoder.readable;
 
     return { readable, writable };

--- a/Source/SelfService/Web/microservice/podLogScreen.tsx
+++ b/Source/SelfService/Web/microservice/podLogScreen.tsx
@@ -3,9 +3,9 @@
 
 import React, { useState, useEffect } from 'react';
 
-import { LoadingSpinner } from '@dolittle/design-system/atoms/LoadingSpinner/LoadingSpinner';
-
 import { Typography } from '@mui/material';
+
+import { LoadingSpinner } from '@dolittle/design-system';
 
 import { getPodLogs, HttpResponsePodLog } from '../api/api';
 

--- a/Source/SelfService/Web/microservice/purchaseOrder/create.tsx
+++ b/Source/SelfService/Web/microservice/purchaseOrder/create.tsx
@@ -7,8 +7,7 @@ import { useHistory } from 'react-router-dom';
 import { Grid, Button, Typography } from '@mui/material';
 
 import { Guid } from '@dolittle/rudiments';
-import { Tabs } from '@dolittle/design-system/atoms/Tabs/Tabs';
-import { AlertBox } from '@dolittle/design-system/atoms/AlertBox/AlertBox';
+import { AlertBox, Tabs } from '@dolittle/design-system';
 
 import { savePurchaseOrderMicroservice } from '../../stores/microservice';
 import { HttpResponseApplication } from '../../api/application';

--- a/Source/SelfService/Web/microservice/purchaseOrder/view.tsx
+++ b/Source/SelfService/Web/microservice/purchaseOrder/view.tsx
@@ -7,9 +7,9 @@ import { useHistory, useLocation } from 'react-router-dom';
 import { useSnackbar } from 'notistack';
 import { useReadable } from 'use-svelte-store';
 
-import { Grid, IconButton, Typography, Divider, Box, } from '@mui/material';
-import { DataStateIcon } from './dataStateIcon';
+import { Box, Divider, Grid, IconButton, Typography } from '@mui/material';
 import EditIcon from '@mui/icons-material/Edit';
+import { DataStateIcon } from './dataStateIcon';
 
 import { Tabs } from '@dolittle/design-system';
 
@@ -22,10 +22,10 @@ import { DownloadButtons } from '../components/downloadButtons';
 import { HealthStatus } from '../microserviceView/healthStatus/healthStatus';
 
 type Props = {
-    applicationId: string
-    environment: string
-    microserviceId: string
-    podsData: HttpResponsePodStatus
+    applicationId: string;
+    environment: string;
+    microserviceId: string;
+    podsData: HttpResponsePodStatus;
 };
 
 const classes = {

--- a/Source/SelfService/Web/microservice/purchaseOrder/view.tsx
+++ b/Source/SelfService/Web/microservice/purchaseOrder/view.tsx
@@ -7,11 +7,11 @@ import { useHistory, useLocation } from 'react-router-dom';
 import { useSnackbar } from 'notistack';
 import { useReadable } from 'use-svelte-store';
 
-import { DataStateIcon } from './dataStateIcon';
 import { Grid, IconButton, Typography, Divider, Box, } from '@mui/material';
+import { DataStateIcon } from './dataStateIcon';
 import EditIcon from '@mui/icons-material/Edit';
 
-import { Tabs } from '@dolittle/design-system/atoms/Tabs/Tabs';
+import { Tabs } from '@dolittle/design-system';
 
 import { microservices, MicroserviceStore, savePurchaseOrderMicroservice } from '../../stores/microservice';
 import { MicroservicePurchaseOrder } from '../../api/index';

--- a/Source/SelfService/Web/screens/applicationsScreen/applicationsList.tsx
+++ b/Source/SelfService/Web/screens/applicationsScreen/applicationsList.tsx
@@ -5,9 +5,9 @@ import React from 'react';
 
 import { ShortInfoWithEnvironment } from '../../api/api';
 
-import { Button } from '@dolittle/design-system/atoms/Button/Button';
-
 import { List } from '@mui/material';
+
+import { Button } from '@dolittle/design-system';
 
 const styles = {
     list: {

--- a/Source/SelfService/Web/screens/applicationsScreen/applicationsScreen.tsx
+++ b/Source/SelfService/Web/screens/applicationsScreen/applicationsScreen.tsx
@@ -3,12 +3,13 @@
 
 import React, { useState, useEffect } from 'react';
 import { useHistory } from 'react-router-dom';
-import { useSnackbar } from 'notistack';
 
-import { Button } from '@dolittle/design-system/atoms/Button/Button';
+import { useSnackbar } from 'notistack';
 
 import { Box, Typography } from '@mui/material';
 import { AddCircle } from '@mui/icons-material';
+
+import { Button } from '@dolittle/design-system';
 
 import { ShortInfoWithEnvironment } from '../../api/api';
 import { LoginWrapper } from '../../layout/loginWrapper';
@@ -71,7 +72,7 @@ export const ApplicationsScreen = () => {
     return (
         <LoginWrapper>
             <Typography variant='h2' sx={styles}>
-                { applicationInfos.length > 0 ? 'Select Your Application & Environment' : 'There are no Applications' }
+                {applicationInfos.length > 0 ? 'Select Your Application & Environment' : 'There are no Applications'}
             </Typography>
 
             <Box sx={{ width: 1 }}>

--- a/Source/SelfService/Web/theme/button.tsx
+++ b/Source/SelfService/Web/theme/button.tsx
@@ -6,11 +6,12 @@ import React from 'react';
 import { SxProps } from '@mui/material/styles';
 import { Button as MuiButton } from '@mui/material';
 import AddIcon from '@mui/icons-material/Add';
+
 import { themeDark } from '@dolittle/design-system';
 
 type Props = {
     onClick?: (event: React.MouseEvent<HTMLElement>) => void;
-    disabled?: boolean
+    disabled?: boolean;
     children: React.ReactNode;
     withIcon?: boolean;
 };


### PR DESCRIPTION
## Summary

Created multible index.ts export files so it would be easier to import reusable code into components.

<img width="1060" alt="Screenshot 2022-12-27 at 18 13 02" src="https://user-images.githubusercontent.com/19160439/209693537-1759336b-e0ad-4707-9202-3f9f80cc7c04.png">

### Changed

- Combined component imports more together using the new export method.


