### PR TITLE
Big buttons organizing

### DIFF
--- a/Source/DesignSystem/.storybook/main.js
+++ b/Source/DesignSystem/.storybook/main.js
@@ -1,65 +1,66 @@
 const path = require('path');
 
 module.exports = {
-  stories: [
-    {
-        directory: '../atoms',
-        files: '**/*.stories.tsx',
-        titlePrefix: 'Atoms',
-    },
-    {
-        directory: '../molecules',
-        files: '**/*.stories.tsx',
-        titlePrefix: 'Molecules',
-    },
-  ],
-
-  addons: [
-    '@storybook/addon-links',
-    '@storybook/addon-essentials',
-    '@storybook/addon-interactions',
-    '@storybook/preset-create-react-app'
-  ],
-
-  framework: '@storybook/react',
-
-  core: {
-    builder: '@storybook/builder-webpack5'
-  },
-
-  staticDirs: [
-      '../public'
-  ],
-
-  webpackFinal: (config) => {
-    config.module.rules.push({
-      test: /\.(ts|tsx)?$/,
-      exclude: /node_modules/,
-      include: path.resolve(__dirname, "../"),
-      use: [
+    stories: [
         {
-          loader: require.resolve('babel-loader'),
-          options: {
-            presets: [
-              require('@babel/preset-typescript').default,
-              [require('@babel/preset-react').default, { runtime: 'automatic' }],
-              require('@babel/preset-env').default,
-            ],
-          },
+            directory: '../atoms',
+            files: '**/*.stories.tsx',
+            titlePrefix: 'Atoms',
         },
-      ],
-    })
+        {
+            directory: '../molecules',
+            files: '**/*.stories.tsx',
+            titlePrefix: 'Molecules',
+        },
+    ],
 
-    config.resolve.extensions.push('.ts', '.tsx')
+    addons: [
+        '@storybook/addon-links',
+        '@storybook/addon-essentials',
+        '@storybook/addon-interactions',
+        '@storybook/theming',
+        '@storybook/preset-create-react-app',
+    ],
 
-    config.module.rules.push({
-      test: /\.mjs$/,
-      include: /node_modules/,
-      type: 'javascript/auto',
-    })
+    framework: '@storybook/react',
 
-    config.resolve.extensions.push('.mjs')
+    core: {
+        builder: '@storybook/builder-webpack5'
+    },
 
-    return config
-  }
+    staticDirs: [
+        '../public'
+    ],
+
+    webpackFinal: (config) => {
+        config.module.rules.push({
+            test: /\.(ts|tsx)?$/,
+            exclude: /node_modules/,
+            include: path.resolve(__dirname, "../"),
+            use: [
+                {
+                    loader: require.resolve('babel-loader'),
+                    options: {
+                        presets: [
+                            require('@babel/preset-typescript').default,
+                            [require('@babel/preset-react').default, { runtime: 'automatic' }],
+                            require('@babel/preset-env').default,
+                        ],
+                    },
+                },
+            ],
+        })
+
+        config.resolve.extensions.push('.ts', '.tsx')
+
+        config.module.rules.push({
+            test: /\.mjs$/,
+            include: /node_modules/,
+            type: 'javascript/auto',
+        })
+
+        config.resolve.extensions.push('.mjs')
+
+        return config
+    }
 };

--- a/Source/DesignSystem/.storybook/manager.js
+++ b/Source/DesignSystem/.storybook/manager.js
@@ -1,0 +1,6 @@
+import { addons } from '@storybook/addons';
+import { themes } from '@storybook/theming';
+
+addons.setConfig({
+    theme: themes.dark,
+});

--- a/Source/DesignSystem/.storybook/manager.js
+++ b/Source/DesignSystem/.storybook/manager.js
@@ -3,4 +3,6 @@ import { themes } from '@storybook/theming';
 
 addons.setConfig({
     theme: themes.dark,
+    brandTitle: 'Dolittle Studio Styleguide',
+    brandUrl: 'https://www.dolittle.com/',
 });

--- a/Source/DesignSystem/.storybook/preview.js
+++ b/Source/DesignSystem/.storybook/preview.js
@@ -1,23 +1,30 @@
-import React from "react"
+import React from 'react';
+
 import '../theming/fonts';
 import { themeDark } from '../theming/theme';
+
+import { themes } from '@storybook/theming';
+
 import { ThemeProvider } from '@mui/material/styles';
 import { CssBaseline } from '@mui/material'
 
 export const decorators = [
-  Story => (
-    <ThemeProvider theme={themeDark}>
-      <CssBaseline/>
-      <Story />
-    </ThemeProvider>
-  ),
+    Story => (
+        <ThemeProvider theme={themeDark}>
+            <CssBaseline />
+            <Story />
+        </ThemeProvider>
+    ),
 ];
 
 export const parameters = {
-  controls: {
-    matchers: {
-      color: /(background|color)$/i,
-      date: /Date$/,
+    controls: {
+        matchers: {
+            color: /(background|color)$/i,
+            date: /Date$/,
+        },
     },
-  },
-}
+    docs: {
+        theme: themes.dark,
+    },
+};

--- a/Source/DesignSystem/.storybook/preview.js
+++ b/Source/DesignSystem/.storybook/preview.js
@@ -23,6 +23,7 @@ export const parameters = {
             color: /(background|color)$/i,
             date: /Date$/,
         },
+        disable: true,
     },
     docs: {
         theme: themes.dark,

--- a/Source/DesignSystem/atoms/Button/Button.stories.tsx
+++ b/Source/DesignSystem/atoms/Button/Button.stories.tsx
@@ -26,8 +26,8 @@ metadata.parameters = {
 - *Outlined buttons* are reserved for login screens. The empty fill allows third-party icons to be used in their original styling. 
 - *Text buttons* are used for secondary actions, such as 'cancel' or to carry out an optional action within the page. They are commonly found in dialogs, cards or sometimes toolbars. Text buttons may use our primary main color or the inherit color of the page depending on whether or not the user’s attention should be drawn to the button or if the button needs to be distinguished from other content on the page. 
 `,
-        }
-    }
+        },
+    },
 };
 
 export default metadata;
@@ -38,7 +38,6 @@ export const Filled = createStory({
 });
 
 export const Text = createStory({
-    variant: 'text',
     label: 'Text Button',
 });
 
@@ -48,13 +47,11 @@ export const Outlined = createStory({
 });
 
 export const WithIcon = createStory({
-    variant: 'text',
     label: 'With Icon',
     startWithIcon: <EditRounded />,
 });
 
 export const DisabledWithIcon = createStory({
-    variant: 'text',
     label: 'Disabled Button with icon',
     disabled: true,
     startWithIcon: <EditRounded />,

--- a/Source/DesignSystem/atoms/Button/Button.stories.tsx
+++ b/Source/DesignSystem/atoms/Button/Button.stories.tsx
@@ -78,7 +78,7 @@ export const Outlined = createStory({
 
 export const Secondary = createStory({
     label: 'Secondary Button',
-    color: 'secondary',
+    secondary: true,
     startWithIcon: <AddCircle />,
 });
 

--- a/Source/DesignSystem/atoms/Button/Button.stories.tsx
+++ b/Source/DesignSystem/atoms/Button/Button.stories.tsx
@@ -30,6 +30,36 @@ metadata.parameters = {
     },
 };
 
+metadata.argTypes = {
+    startWithIcon: {
+        description: 'The icon to show before the label.',
+        control: false
+    },
+    endWithIcon: {
+        description: 'The icon to show after the label.',
+        control: false
+    },
+    isFullWidth: {
+        control: {
+            type: 'boolean',
+            default: false
+        }
+    },
+    onClick: {
+        description: 'The event handler for when the button is clicked.',
+        control: false
+    },
+    href: {
+        control: false
+    },
+    sx: {
+        control: false
+    },
+    children: {
+        control: false
+    }
+};
+
 export default metadata;
 
 export const Filled = createStory({
@@ -46,13 +76,41 @@ export const Outlined = createStory({
     label: 'Outlined Button',
 });
 
-export const WithIcon = createStory({
-    label: 'With Icon',
+export const Secondary = createStory({
+    label: 'Secondary Button',
+    color: 'secondary',
+    startWithIcon: <AddCircle />,
+});
+
+export const StartIcon = createStory({
+    label: 'With Start Icon',
     startWithIcon: <EditRounded />,
 });
 
-export const DisabledWithIcon = createStory({
-    label: 'Disabled Button with icon',
-    disabled: true,
-    startWithIcon: <EditRounded />,
+export const EndIcon = createStory({
+    label: 'With End Icon',
+    endWithIcon: <EditRounded />,
+});
+
+export const fullwidth = createStory({
+    variant: 'fullwidth',
+    label: 'Full Width Button',
+    startWithIcon: <AddCircle />,
+});
+
+// export const DisabledWithIcon = createStory({
+//     label: 'Disabled Button with icon',
+//     disabled: true,
+//     startWithIcon: <EditRounded />,
+// });
+
+export const WithLink = createStory({
+    label: 'With Link',
+    href: 'https://dolittle.io',
+    target: true,
+});
+
+export const Danger = createStory({
+    label: 'Danger Button',
+    variant: 'danger',
 });

--- a/Source/DesignSystem/atoms/Button/Button.tsx
+++ b/Source/DesignSystem/atoms/Button/Button.tsx
@@ -4,93 +4,130 @@
 import React, { MouseEventHandler, ReactElement } from 'react';
 
 import { Button as MuiButton, SvgIconProps, SxProps } from '@mui/material';
+import { ErrorRounded } from '@mui/icons-material';
+
+import { Link } from '../Link/Link';
 
 export type ButtonProps = {
     /**
-     * Required - button must contain text.
+     * Required. The text to display on the button.
      */
     label: string;
 
     /**
-     * Optional. The variant of the button.
-     * @default 'text'
+     * Button variants.
+     * 
+     * - fullwidth: Button with extra styling and take up the full width of its container.
+     * - danger: Danger buttons are seldom used and reserved for cases where the primary action is destructive such as deleting content.
+     * @default text
      */
-    variant?: 'filled' | 'text' | 'outlined';
+    variant?: 'filled' | 'text' | 'outlined' | 'fullwidth' | 'danger';
 
     /**
-     * Optional. Whether the button is disabled or not.
+     * Button can be disabled.
      * @default false
      */
     disabled?: boolean;
 
     /**
-     * Optional. The color of the button.
-     * @default 'primary'
+     * Set button color.
+     * @default primary
      */
-    color?: 'primary' | 'secondary' | 'error' | 'info' | 'success' | 'warning';
+    color?: 'primary' | 'secondary';
 
     /**
-     * Optional. The size of the button.
-     * Small is same size as medium as it is overridden in the Theme.
-     * @default 'small'
+     * Set button size.
+     * @default small
      */
-    size?: 'small' | 'medium' | 'large';
+    size?: 'small' | 'large';
 
     /**
-     * Optional. Whether the button should take up the full width of its container.
+     * Button that takes up the full width of its container.
      * @default false
      */
     isFullWidth?: boolean;
 
     /**
-     * An optional icon to start with. Supports only React svg icons.
+     * Add an icon to the start of the button. Support only React SVG icons.
      * @default undefined
+     * @type ReactElement<SvgIconProps>
      */
     startWithIcon?: ReactElement<SvgIconProps>;
 
     /**
-     * An optional icon to end with. Supports only React svg icons.
+     * Add an icon to the end of the button. Support only React SVG icons.
      * @default undefined
+     * @type ReactElement<SvgIconProps>
      */
     endWithIcon?: ReactElement<SvgIconProps>;
 
     /**
-     * Optional. The type of the button.
-     * @default 'button'
+     * Button type. Default is button but for example if you want to use the button as a submit button you can set it to submit.
+     * @default button
      */
     type?: 'button' | 'submit' | 'reset';
+
+    /**
+     * Add event handler for when the button is clicked.
+     * @default undefined
+     */
     onClick?: MouseEventHandler<HTMLButtonElement>;
 
     /**
-     * Optional. The sx prop for the button.
+     * Add a href to the button. If this is set the button will be rendered as an anchor tag.
+     * 
+     * Use it only if a link doesn't have a meaningful href.
+     * 
+     * Use Link {@link Link} component intead if href has a meaningful value for better accessibility.
+     */
+    href?: string;
+
+    /**
+     * Use with external links.
+     * 
+     * Set target to 'true' if you want the link to open in a new tab.
+     * @default false
+     * @type {boolean}
+     */
+    target?: boolean;
+
+    /**
+     * Add custom styling to the button.
      * @default undefined
+     * @type {{}}
      */
     sx?: SxProps;
+
+    /**
+     * Children is not a valid prop.
+     * @type - never
+     */
+    children?: never;
 };
 
 /**
- * A button component. Children is not a valid prop.
+ * A button component.
  * @param {...ButtonProps} props - The {@link ButtonProps}.
  * @returns {ReactElement} A new {@link Button} component.
  * @example
- * <Button label='Click me' disabled />
  * <Button label='Click me' variant='filled' isFullWidth startWithIcon={<AddCircle />} />
- * <Button label='Click me' type='submit' />
  */
-export const Button = ({ variant, label, disabled, color, size, isFullWidth, startWithIcon, endWithIcon, type, onClick, sx }: ButtonProps): ReactElement =>
+export const Button = ({ variant, label, disabled, color, size, isFullWidth, startWithIcon, endWithIcon, target, type, onClick, href, sx }: ButtonProps): ReactElement =>
     <MuiButton
         variant={variant === 'filled' ? 'contained' : variant || 'text'}
         disabled={disabled}
         color={color}
-        size={size ?? 'small'}
-        fullWidth={isFullWidth}
-        startIcon={startWithIcon}
+        size={size || 'small'}
+        fullWidth={variant === 'fullwidth' || isFullWidth}
+        startIcon={variant === 'danger' ? <ErrorRounded /> : startWithIcon}
         endIcon={endWithIcon}
-        type={type ?? 'button'}
+        type={type || 'button'}
         onClick={onClick}
+        href={href}
+        //@ts-ignore
+        target={target ? '_blank' : undefined}
         sx={sx}
         disableElevation
-        disableRipple
     >
         {label}
     </MuiButton>;

--- a/Source/DesignSystem/atoms/Button/Button.tsx
+++ b/Source/DesignSystem/atoms/Button/Button.tsx
@@ -128,7 +128,7 @@ export const Button = ({ variant, label, disabled, secondary, size, isFullWidth,
         onClick={onClick}
         href={href}
         //@ts-ignore
-        target={target ? '_blank' : false}
+        target={target ? '_blank' : undefined}
         sx={sx}
         disableElevation
     >

--- a/Source/DesignSystem/atoms/Button/Button.tsx
+++ b/Source/DesignSystem/atoms/Button/Button.tsx
@@ -14,7 +14,7 @@ export type ButtonProps = {
 
     /**
      * Button variants.
-     * 
+     *
      * - fullwidth: Button with extra styling and take up the full width of its container.
      * - danger: Danger buttons are seldom used and reserved for cases where the primary action is destructive such as deleting content.
      * @default text
@@ -29,10 +29,10 @@ export type ButtonProps = {
 
     /**
      * Set secondary button color.
-     * 
-     * Secondary button are reserved for less-pronounced actions, including those found in dialogs, cards, 
+     *
+     * Secondary button are reserved for less-pronounced actions, including those found in dialogs, cards,
      * and data charts and can include action items such as ‘learn more’ or ‘cancel’.
-     * 
+     *
      * Default primary button are for high emphasis and primary actions, such as a save button or a next button in a form.
      * @default false
      */
@@ -53,14 +53,14 @@ export type ButtonProps = {
     /**
      * Add an icon to the start of the button. Support only React SVG icons.
      * @default undefined
-     * @type ReactElement<SvgIconProps>
+     * @type {ReactElement<SvgIconProps>}
      */
     startWithIcon?: ReactElement<SvgIconProps>;
 
     /**
      * Add an icon to the end of the button. Support only React SVG icons.
      * @default undefined
-     * @type ReactElement<SvgIconProps>
+     * @type {ReactElement<SvgIconProps>}
      */
     endWithIcon?: ReactElement<SvgIconProps>;
 
@@ -78,19 +78,19 @@ export type ButtonProps = {
 
     /**
      * Add a href to the button. If this is set the button will be rendered as an anchor tag.
-     * 
+     *
      * Use it only if a link doesn't have a meaningful href.
-     * 
+     *
      * Use Link component intead if href has a meaningful value for better accessibility.
      */
     href?: string;
 
     /**
      * Use with external links.
-     * 
+     *
      * Set target to 'true' if you want the link to open in a new tab.
      * @default false
-     * @type boolean
+     * @type {boolean}
      */
     target?: boolean;
 
@@ -103,7 +103,7 @@ export type ButtonProps = {
 
     /**
      * Children is not a valid prop.
-     * @type - never
+     * @type {never}
      */
     children?: never;
 };

--- a/Source/DesignSystem/atoms/Button/Button.tsx
+++ b/Source/DesignSystem/atoms/Button/Button.tsx
@@ -6,22 +6,80 @@ import React, { MouseEventHandler, ReactElement } from 'react';
 import { Button as MuiButton, SvgIconProps, SxProps } from '@mui/material';
 
 export type ButtonProps = {
-    variant: 'filled' | 'text' | 'outlined';
+    /**
+     * Required - button must contain text.
+     */
     label: string;
+
+    /**
+     * Optional. The variant of the button.
+     * @default 'text'
+     */
+    variant?: 'filled' | 'text' | 'outlined';
+
+    /**
+     * Optional. Whether the button is disabled or not.
+     * @default false
+     */
     disabled?: boolean;
+
+    /**
+     * Optional. The color of the button.
+     * @default 'primary'
+     */
     color?: 'primary' | 'secondary' | 'error' | 'info' | 'success' | 'warning';
+
+    /**
+     * Optional. The size of the button.
+     * Small is same size as medium as it is overridden in the Theme.
+     * @default 'small'
+     */
     size?: 'small' | 'medium' | 'large';
+
+    /**
+     * Optional. Whether the button should take up the full width of its container.
+     * @default false
+     */
     isFullWidth?: boolean;
+
+    /**
+     * An optional icon to start with. Supports only React svg icons.
+     * @default undefined
+     */
     startWithIcon?: ReactElement<SvgIconProps>;
+
+    /**
+     * An optional icon to end with. Supports only React svg icons.
+     * @default undefined
+     */
     endWithIcon?: ReactElement<SvgIconProps>;
+
+    /**
+     * Optional. The type of the button.
+     * @default 'button'
+     */
     type?: 'button' | 'submit' | 'reset';
     onClick?: MouseEventHandler<HTMLButtonElement>;
+
+    /**
+     * Optional. The sx prop for the button.
+     * @default undefined
+     */
     sx?: SxProps;
 };
 
-export const Button = ({ variant, label, disabled, color, size, isFullWidth, startWithIcon, endWithIcon, type, onClick, sx }: ButtonProps) =>
+/**
+ * A button component. Children is not a valid prop.
+ * @param {...ButtonProps} props - The {@link ButtonProps}.
+ * @returns {ReactElement} A new {@link Button} component.
+ * @example
+ * <Button label='Click me' disabled />
+ * <Button label='Click me' variant='filled' isFullWidth startWithIcon={<AddCircle />} />
+ * <Button label='Click me' type='submit' />
+ */
+export const Button = ({ variant, label, disabled, color, size, isFullWidth, startWithIcon, endWithIcon, type, onClick, sx }: ButtonProps): ReactElement =>
     <MuiButton
-        variant={variant === 'filled' ? 'contained' : variant}
+        variant={variant === 'filled' ? 'contained' : variant || 'text'}
         disabled={disabled}
         color={color}
         size={size ?? 'small'}

--- a/Source/DesignSystem/atoms/Button/Button.tsx
+++ b/Source/DesignSystem/atoms/Button/Button.tsx
@@ -6,8 +6,6 @@ import React, { MouseEventHandler, ReactElement } from 'react';
 import { Button as MuiButton, SvgIconProps, SxProps } from '@mui/material';
 import { ErrorRounded } from '@mui/icons-material';
 
-import { Link } from '../Link/Link';
-
 export type ButtonProps = {
     /**
      * Required. The text to display on the button.
@@ -30,10 +28,15 @@ export type ButtonProps = {
     disabled?: boolean;
 
     /**
-     * Set button color.
-     * @default primary
+     * Set secondary button color.
+     * 
+     * Secondary button are reserved for less-pronounced actions, including those found in dialogs, cards, 
+     * and data charts and can include action items such as ‘learn more’ or ‘cancel’.
+     * 
+     * Default primary button are for high emphasis and primary actions, such as a save button or a next button in a form.
+     * @default false
      */
-    color?: 'primary' | 'secondary';
+    secondary?: boolean;
 
     /**
      * Set button size.
@@ -78,7 +81,7 @@ export type ButtonProps = {
      * 
      * Use it only if a link doesn't have a meaningful href.
      * 
-     * Use Link {@link Link} component intead if href has a meaningful value for better accessibility.
+     * Use Link component intead if href has a meaningful value for better accessibility.
      */
     href?: string;
 
@@ -87,7 +90,7 @@ export type ButtonProps = {
      * 
      * Set target to 'true' if you want the link to open in a new tab.
      * @default false
-     * @type {boolean}
+     * @type boolean
      */
     target?: boolean;
 
@@ -112,11 +115,11 @@ export type ButtonProps = {
  * @example
  * <Button label='Click me' variant='filled' isFullWidth startWithIcon={<AddCircle />} />
  */
-export const Button = ({ variant, label, disabled, color, size, isFullWidth, startWithIcon, endWithIcon, target, type, onClick, href, sx }: ButtonProps): ReactElement =>
+export const Button = ({ variant, label, disabled, secondary, size, isFullWidth, startWithIcon, endWithIcon, target, type, onClick, href, sx }: ButtonProps): ReactElement =>
     <MuiButton
         variant={variant === 'filled' ? 'contained' : variant || 'text'}
         disabled={disabled}
-        color={color}
+        color={secondary ? 'secondary' : 'primary'}
         size={size || 'small'}
         fullWidth={variant === 'fullwidth' || isFullWidth}
         startIcon={variant === 'danger' ? <ErrorRounded /> : startWithIcon}
@@ -125,7 +128,7 @@ export const Button = ({ variant, label, disabled, color, size, isFullWidth, sta
         onClick={onClick}
         href={href}
         //@ts-ignore
-        target={target ? '_blank' : undefined}
+        target={target ? '_blank' : false}
         sx={sx}
         disableElevation
     >

--- a/Source/DesignSystem/atoms/ConfirmDialog/ConfirmDialog.tsx
+++ b/Source/DesignSystem/atoms/ConfirmDialog/ConfirmDialog.tsx
@@ -50,7 +50,7 @@ export const ConfirmDialog = ({ isOpen, id, title, description, children, handle
         </DialogContent>
 
         <DialogActions sx={{ mr: 1 }}>
-            <Button onClick={handleCancel} label={cancelText} sx={{ color: 'text.primary' }} />
+            <Button onClick={handleCancel} label={cancelText} secondary />
             <Button onClick={handleConfirm} label={confirmText} />
         </DialogActions>
     </Dialog>;

--- a/Source/DesignSystem/atoms/ConfirmDialog/ConfirmDialog.tsx
+++ b/Source/DesignSystem/atoms/ConfirmDialog/ConfirmDialog.tsx
@@ -3,10 +3,10 @@
 
 import React from 'react';
 
-import { Button } from '../Button';
-
 import { IconButton, Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle } from '@mui/material';
 import { CloseRounded } from '@mui/icons-material';
+
+import { Button } from '@dolittle/design-system';
 
 export type ConfirmDialogProps = {
     id: string;
@@ -50,7 +50,7 @@ export const ConfirmDialog = ({ isOpen, id, title, description, children, handle
         </DialogContent>
 
         <DialogActions sx={{ mr: 1 }}>
-            <Button onClick={handleCancel} label={cancelText} variant='text' sx={{ color: 'text.primary' }} />
-            <Button onClick={handleConfirm} label={confirmText} variant='text' />
+            <Button onClick={handleCancel} label={cancelText} sx={{ color: 'text.primary' }} />
+            <Button onClick={handleConfirm} label={confirmText} />
         </DialogActions>
     </Dialog>;

--- a/Source/DesignSystem/atoms/DataTablePro/DataTablePro.stories.tsx
+++ b/Source/DesignSystem/atoms/DataTablePro/DataTablePro.stories.tsx
@@ -9,7 +9,7 @@ import { DeleteRounded, RefreshRounded } from '@mui/icons-material';
 
 import { DataTablePro, DataTableProProps } from './DataTablePro';
 
-import { Button } from '@dolittle/design-system/atoms/Button';
+import { Button } from '@dolittle/design-system';
 
 export default {
     parameters: {
@@ -42,13 +42,11 @@ const Template: ComponentStory<typeof DataTablePro> = ({ isRowCheckbox, disableR
     return (
         <Box>
             <Button
-                variant='text'
                 label='Reset'
                 startWithIcon={<RefreshRounded />}
                 disabled={rows.length === 3}
                 onClick={() => setRows(initialRows)} />
             <Button
-                variant='text'
                 label='Delete selected'
                 startWithIcon={<DeleteRounded />}
                 disabled={selectedRowIds.length === 0}

--- a/Source/DesignSystem/atoms/LoadingSpinner/LoadingSpinner.stories.tsx
+++ b/Source/DesignSystem/atoms/LoadingSpinner/LoadingSpinner.stories.tsx
@@ -7,6 +7,10 @@ import { LoadingSpinner } from './LoadingSpinner';
 
 const { metadata, createStory } = componentStories(LoadingSpinner);
 
+metadata.parameters = {
+    layout: 'centered',
+};
+
 export default metadata;
 
 export const Loading = createStory({});

--- a/Source/DesignSystem/atoms/Snackbar/Snackbar.stories.tsx
+++ b/Source/DesignSystem/atoms/Snackbar/Snackbar.stories.tsx
@@ -71,7 +71,7 @@ const Snackbar = () => {
         enqueueSnackbar(`Snackbar ${count}`, {
             action: (key) => (
                 <>
-                    <Button label='Undo' color='secondary' onClick={() =>
+                    <Button label='Undo' secondary onClick={() =>
                         enqueueSnackbar(`Snackbar with action buttons -  ${count} - Undone.`)
                     } />
 

--- a/Source/DesignSystem/atoms/Snackbar/Snackbar.stories.tsx
+++ b/Source/DesignSystem/atoms/Snackbar/Snackbar.stories.tsx
@@ -71,7 +71,7 @@ const Snackbar = () => {
         enqueueSnackbar(`Snackbar ${count}`, {
             action: (key) => (
                 <>
-                    <Button variant='text' label='Undo' color='secondary' onClick={() =>
+                    <Button label='Undo' color='secondary' onClick={() =>
                         enqueueSnackbar(`Snackbar with action buttons -  ${count} - Undone.`)
                     } />
 
@@ -84,7 +84,7 @@ const Snackbar = () => {
         });
     }, [count]);
 
-    return <Button variant='text' label='Open snackbars' onClick={buttonClicked} />;
+    return <Button label='Open snackbars' onClick={buttonClicked} />;
 };
 
 Snackbars.args = {

--- a/Source/DesignSystem/package.json
+++ b/Source/DesignSystem/package.json
@@ -33,12 +33,14 @@
         "@storybook/addon-essentials": "6.5.10",
         "@storybook/addon-interactions": "6.5.10",
         "@storybook/addon-links": "6.5.10",
+        "@storybook/addons": "6.5.15",
         "@storybook/builder-webpack5": "6.5.10",
         "@storybook/manager-webpack5": "6.5.10",
         "@storybook/node-logger": "6.5.10",
         "@storybook/preset-create-react-app": "4.1.2",
         "@storybook/react": "6.5.10",
         "@storybook/testing-library": "0.0.13",
+        "@storybook/theming": "6.5.15",
         "react-scripts": "5.0.1"
     }
 }

--- a/Source/DesignSystem/theming/theme.ts
+++ b/Source/DesignSystem/theming/theme.ts
@@ -238,9 +238,9 @@ const components: Components & DataGridProComponents = {
             {
                 props: { variant: 'danger' },
                 style: {
-                    color: '#202229',
+                    'color': '#202229',
                     // TODO: How to use the theme's palette here?
-                    backgroundColor: '#F66666',
+                    'backgroundColor': '#F66666',
                     '&:hover': {
                         backgroundColor: '#C55252',
                     },
@@ -253,9 +253,9 @@ const components: Components & DataGridProComponents = {
             {
                 props: { variant: 'fullwidth' },
                 style: {
-                    backgroundColor: 'rgba(140, 154, 248, 0.08)',
-                    color: '#8C9AF8',
-                    minHeight: 30,
+                    'backgroundColor': 'rgba(140, 154, 248, 0.08)',
+                    'color': '#8C9AF8',
+                    'minHeight': '30px',
                     '&:hover': {
                         backgroundColor: 'rgba(140, 154, 248, 0.15)'
                     }

--- a/Source/DesignSystem/theming/theme.ts
+++ b/Source/DesignSystem/theming/theme.ts
@@ -30,6 +30,13 @@ declare module '@mui/material/Typography' {
     }
 };
 
+declare module '@mui/material/Button' {
+    interface ButtonPropsVariantOverrides {
+        danger: true;
+        fullwidth: true;
+    }
+};
+
 export const typography: TypographyOptions = {
     fontFamily: '"Rubik", "Open sans", "Arial", sans-serif',
     fontWeightMedium: 400,
@@ -99,6 +106,7 @@ export const typography: TypographyOptions = {
     },
     button: {
         fontSize: '0.75rem', //12px
+        letterSpacing: '0.06em',
         fontWeight: 500,
     },
     monospace: {
@@ -225,7 +233,41 @@ const components: Components & DataGridProComponents = {
             sizeSmall: {
                 fontSize: '0.75rem',
             },
-        }
+        },
+        variants: [
+            {
+                props: { variant: 'danger' },
+                style: {
+                    color: '#202229',
+                    // TODO: How to use the theme's palette here?
+                    backgroundColor: '#F66666',
+                    '&:hover': {
+                        backgroundColor: '#C55252',
+                    },
+                    '&:disabled': {
+                        backgroundColor: palette?.text?.disabled,
+                        color: palette?.text?.secondary,
+                    },
+                },
+            },
+            {
+                props: { variant: 'fullwidth' },
+                style: {
+                    backgroundColor: 'rgba(140, 154, 248, 0.08)',
+                    color: '#8C9AF8',
+                    minHeight: 30,
+                    '&:hover': {
+                        backgroundColor: 'rgba(140, 154, 248, 0.15)'
+                    }
+                },
+            },
+            {
+                props: { color: 'secondary' },
+                style: {
+                    color: palette?.text?.secondary,
+                }
+            },
+        ],
     },
     MuiDataGrid: {
         styleOverrides: {

--- a/Source/DesignSystem/theming/theme.ts
+++ b/Source/DesignSystem/theming/theme.ts
@@ -264,7 +264,7 @@ const components: Components & DataGridProComponents = {
             {
                 props: { color: 'secondary' },
                 style: {
-                    color: palette?.text?.secondary,
+                    color: palette?.text?.primary,
                 }
             },
         ],

--- a/Source/SelfService/Web/application/create/create.tsx
+++ b/Source/SelfService/Web/application/create/create.tsx
@@ -93,7 +93,7 @@ export const Create = () => {
 
     const ActionButtons = () =>
         <>
-            <Button label='Cancel' onClick={handleCancel} sx={{ mr: 8, color: 'text.primary' }} />
+            <Button label='Cancel' secondary onClick={handleCancel} sx={{ mr: 8 }} />
             <Button label='Create' type='submit' />
         </>;
 

--- a/Source/SelfService/Web/application/create/create.tsx
+++ b/Source/SelfService/Web/application/create/create.tsx
@@ -99,14 +99,12 @@ export const Create = () => {
     const ActionButtons = () =>
         <Box>
             <Button
-                variant='text'
                 label='Cancel'
                 onClick={handleCancel}
                 sx={{ ...styles.actionButtons, mr: 8 }}
             />
 
             <Button
-                variant='text'
                 label='Create'
                 type='submit'
                 sx={{ ...styles.actionButtons, color: 'primary.main' }}

--- a/Source/SelfService/Web/application/create/create.tsx
+++ b/Source/SelfService/Web/application/create/create.tsx
@@ -14,7 +14,6 @@ import { createApplication, HttpApplicationRequest } from '../../api/application
 const styles = {
     title: {
         letterSpacing: '-0.5px',
-        lineHeight: '26px',
         mb: 11
     },
     secondaryTitle: {
@@ -28,10 +27,6 @@ const styles = {
             xs: 'column',
             sm: 'row'
         }
-    },
-    actionButtons: {
-        color: 'text.primary',
-        letterSpacing: '0.06em'
     }
 };
 
@@ -97,19 +92,10 @@ export const Create = () => {
     };
 
     const ActionButtons = () =>
-        <Box>
-            <Button
-                label='Cancel'
-                onClick={handleCancel}
-                sx={{ ...styles.actionButtons, mr: 8 }}
-            />
-
-            <Button
-                label='Create'
-                type='submit'
-                sx={{ ...styles.actionButtons, color: 'primary.main' }}
-            />
-        </Box>;
+        <>
+            <Button label='Cancel' onClick={handleCancel} sx={{ mr: 8, color: 'text.primary' }} />
+            <Button label='Create' type='submit' />
+        </>;
 
     return (
         <>

--- a/Source/SelfService/Web/logging/logFilter/activeFilters.tsx
+++ b/Source/SelfService/Web/logging/logFilter/activeFilters.tsx
@@ -1,53 +1,50 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-import { Chip, Typography } from '@mui/material';
 import React from 'react';
-import { ButtonText } from '../../theme/buttonText';
+
+import { Chip, Typography } from '@mui/material';
+
 import { LogFilterMicroservice, LogFilterObject } from './logFilterPanel';
+
+import { Button } from '@dolittle/design-system';
 
 export type ActiveFiltersProps = {
     filters: LogFilterObject;
-    updateFilters: (filters: LogFilterObject) => void
+    updateFilters: (filters: LogFilterObject) => void;
 };
 
-export const ActiveFilters = (props: ActiveFiltersProps) => {
+export const ActiveFilters = ({ updateFilters, filters }: ActiveFiltersProps) => {
 
     const clearFilters = () => {
-        props.updateFilters({ ...props.filters, searchTerms: [] });
+        updateFilters({ ...filters, searchTerms: [] });
     };
 
     const removeTerm = (term: string, index: number) => {
-        const terms = [...props.filters.searchTerms];
+        const terms = [...filters.searchTerms];
         terms.splice(index, 1);
-        props.updateFilters({
-            ...props.filters,
+        updateFilters({
+            ...filters,
             searchTerms: terms
         });
     };
 
     const removeMicroservice = (microservice: LogFilterMicroservice, index: number) => {
-        if (props.filters.microservice === undefined) return;
+        if (filters.microservice === undefined) return;
 
-        const microservices = [...props.filters.microservice];
+        const microservices = [...filters.microservice];
         microservices.splice(index, 1);
-        props.updateFilters({
-            ...props.filters,
+        updateFilters({
+            ...filters,
             microservice: microservices
         });
     };
 
     return (
         <>
-            <ButtonText
-                size='small'
-                disabled={props.filters.searchTerms.length === 0}
-                onClick={clearFilters}
-                buttonType='secondary'
-            >
-                Clear Filters
-            </ButtonText>
-            {props.filters.searchTerms.map((s, index) =>
+            <Button label='Clear Filters' disabled={filters.searchTerms.length === 0} secondary onClick={clearFilters} />
+
+            {filters.searchTerms.map((s, index) =>
                 <Chip
                     key={index}
                     label={`"${s}"`}
@@ -57,8 +54,10 @@ export const ActiveFilters = (props: ActiveFiltersProps) => {
                     sx={{ ml: 1 }}
                 />
             )}
+
             <Typography variant='body1' component='span' sx={{ mx: 2 }}>|</Typography>
-            {props.filters.microservice?.map((microservice, index) =>
+
+            {filters.microservice?.map((microservice, index) =>
                 <Chip
                     key={index}
                     label={microservice.name}
@@ -68,8 +67,9 @@ export const ActiveFilters = (props: ActiveFiltersProps) => {
                     sx={{ mr: 1 }}
                 />
             )}
+
             <Chip
-                label={props.filters.dateRange === 'live' ? 'Live logs' : 'Date range'}
+                label={filters.dateRange === 'live' ? 'Live logs' : 'Date range'}
                 color='primary'
                 size='small'
             />

--- a/Source/SelfService/Web/logging/logLine.tsx
+++ b/Source/SelfService/Web/logging/logLine.tsx
@@ -6,8 +6,9 @@ import { Box, Skeleton } from '@mui/material';
 import { format } from 'date-fns';
 
 import { ColoredLine, ColoredLineSection, TerminalColor } from './lineParsing';
-import { ButtonText } from '../theme/buttonText';
 import { DataLabels } from './loki/types';
+
+import { Button } from '@dolittle/design-system';
 
 const coloredLineSectionCss = (section: ColoredLineSection): React.CSSProperties => {
     let color = 'inherit',
@@ -83,78 +84,65 @@ export type LogLineProps = {
     ) => void;
 };
 
+type SkeletonWhenLoadingProps = {
+    loading?: boolean;
+    children: React.ReactNode
+};
+
 export const formatTimestamp = (timestamp: bigint): string => {
     const date = new Date(Number(timestamp / 1_000_000n));
     return format(date, 'yyyy-MM-dd HH:mm:ss');
 };
 
-const SkeletonWhenLoading = (props: { loading?: boolean; children: React.ReactNode }) =>
-    props.loading === true ? (
-        <Skeleton>{props.children}</Skeleton>
-    ) : (
-        <>{props.children}</>
-    );
+const SkeletonWhenLoading = ({ loading, children }: SkeletonWhenLoadingProps) =>
+    loading === true ? <Skeleton>{children}</Skeleton> : <>{children}</>;
 
-export const LogLine = (props: LogLineProps) => {
+export const LogLine = ({ line, showContextButton, loading, onClickShowLineContext, timestamp, labels }: LogLineProps) => {
     // TODO: The tab-width is dependent on styling. How do we make sure we don't change this?
-    const leadingWhitespace = props.line.leading.spaces + props.line.leading.tabs * 8;
+    const leadingWhitespace = line.leading.spaces + line.leading.tabs * 8;
     const leadingEmSpace = `${leadingWhitespace * 0.6}em`;
 
     return (
         <Box sx={{ display: 'flex' }}>
-            {props.showContextButton === true && (
+            {showContextButton === true && (
                 <Box sx={{ whiteSpace: 'nowrap', pr: 2, flexShrink: 0 }}>
-                    <SkeletonWhenLoading loading={props.loading}>
-                        <ButtonText
-                            size='small'
-                            buttonType='secondary'
-                            sx={{ p: 0 }}
-                            onClick={(event) =>
-                                props.onClickShowLineContext?.(
-                                    props.timestamp,
-                                    props.labels,
-                                    event
-                                )
-                            }
-                        >
-                            Show
-                        </ButtonText>
+                    <SkeletonWhenLoading loading={loading}>
+                        <Button label='Show' sx={{ p: 0, color: 'text.secondary' }} onClick={event => onClickShowLineContext?.(timestamp, labels, event)} />
                     </SkeletonWhenLoading>
                 </Box>
             )}
             <Box className='log-line-timestamp' sx={{ whiteSpace: 'nowrap', pr: 2, flexShrink: 0 }}>
-                <SkeletonWhenLoading loading={props.loading}>
-                    <span>[{formatTimestamp(props.timestamp)}]</span>
+                <SkeletonWhenLoading loading={loading}>
+                    <span>[{formatTimestamp(timestamp)}]</span>
                 </SkeletonWhenLoading>
             </Box>
             <Box
                 className='log-line-microservice'
                 sx={{ whiteSpace: 'nowrap', pr: 2, width: '7em', flexShrink: 0, textOverflow: 'ellipsis', overflow: 'hidden' }}
-                title={props.labels.microservice}
+                title={labels.microservice}
             >
-                <SkeletonWhenLoading loading={props.loading}>
-                    <span>{props.labels.microservice}</span>
+                <SkeletonWhenLoading loading={loading}>
+                    <span>{labels.microservice}</span>
                 </SkeletonWhenLoading>
             </Box>
             <Box
                 sx={{ flexGrow: 1 }}
                 style={
-                    leadingWhitespace > 0
-                        ? {
-                            paddingLeft: leadingEmSpace,
-                            textIndent: `-${leadingEmSpace}`,
-                        }
-                        : undefined
+                    leadingWhitespace > 0 ? {
+                        paddingLeft: leadingEmSpace,
+                        textIndent: `-${leadingEmSpace}`
+                    } :
+                        undefined
                 }
             >
-                {props.loading === true ? (
+                {loading === true ? (
                     <>
                         <Skeleton />
                         <Skeleton />
                         <Skeleton />
                     </>
                 ) : (
-                    props.line.sections.map((section, i) => (
+                    line.sections.map((section, i) => (
                         <span key={i} /*style={coloredLineSectionCss(section)}*/>
                             {section.text}
                         </span>

--- a/Source/SelfService/Web/logging/logLine.tsx
+++ b/Source/SelfService/Web/logging/logLine.tsx
@@ -107,7 +107,7 @@ export const LogLine = ({ line, showContextButton, loading, onClickShowLineConte
             {showContextButton === true && (
                 <Box sx={{ whiteSpace: 'nowrap', pr: 2, flexShrink: 0 }}>
                     <SkeletonWhenLoading loading={loading}>
-                        <Button label='Show' sx={{ p: 0, color: 'text.secondary' }} onClick={event => onClickShowLineContext?.(timestamp, labels, event)} />
+                        <Button label='Show' secondary sx={{ p: 0 }} onClick={event => onClickShowLineContext?.(timestamp, labels, event)} />
                     </SkeletonWhenLoading>
                 </Box>
             )}

--- a/Source/SelfService/Web/microservice/components/headArguments.tsx
+++ b/Source/SelfService/Web/microservice/components/headArguments.tsx
@@ -43,27 +43,29 @@ export const HeadArguments = ({ cmdArgs, setCmdArgs, disabled }: HeadArgumentsPr
                         label='CMD Argument'
                         value={arg}
                         disabled={disabled}
-                        onChange={(event) => handleChange(event, argIndex)}
+                        onChange={event => handleChange(event, argIndex)}
                         size='small'
                         variant='outlined'
                         sx={{ width: 220 }}
                     />
                     <Button
                         label='Remove'
+                        secondary
                         disabled={disabled}
                         startWithIcon={<DeleteRounded />}
                         onClick={() => handleRemoveArg(argIndex)}
-                        sx={{ color: 'text.primary', height: 29, ml: 2 }}
+                        sx={{ height: 29, ml: 2 }}
                     />
                 </Box>
             ))}
 
             <Button
                 label='Add CMD argument'
+                secondary
                 startWithIcon={<AddCircleRounded />}
                 disabled={disabled}
                 onClick={handleAddArg}
-                sx={{ justifyContent: 'start', mt: 2.5, color: 'text.primary' }}
+                sx={{ justifyContent: 'start', mt: 2.5 }}
             />
         </Box>
     );

--- a/Source/SelfService/Web/microservice/components/headArguments.tsx
+++ b/Source/SelfService/Web/microservice/components/headArguments.tsx
@@ -49,7 +49,6 @@ export const HeadArguments = ({ cmdArgs, setCmdArgs, disabled }: HeadArgumentsPr
                         sx={{ width: 220 }}
                     />
                     <Button
-                        variant='text'
                         label='Remove'
                         disabled={disabled}
                         startWithIcon={<DeleteRounded />}
@@ -60,7 +59,6 @@ export const HeadArguments = ({ cmdArgs, setCmdArgs, disabled }: HeadArgumentsPr
             ))}
 
             <Button
-                variant='text'
                 label='Add CMD argument'
                 startWithIcon={<AddCircleRounded />}
                 disabled={disabled}

--- a/Source/SelfService/Web/microservice/create/card.tsx
+++ b/Source/SelfService/Web/microservice/create/card.tsx
@@ -3,7 +3,9 @@
 
 import React from 'react';
 
-import { Button, Card, CardActions, CardContent, CardHeader, Link, Typography } from '@mui/material';
+import { Card, CardActions, CardContent, CardHeader, Typography } from '@mui/material';
+
+import { Button } from '@dolittle/design-system'
 
 const styles = {
     card: {
@@ -15,28 +17,19 @@ const styles = {
             background: 'linear-gradient(180deg, rgba(255, 255, 255, 0.09) 0%, rgba(255, 255, 255, 0.09) 100%), #191A21',
             boxShadow: '0px 2px 4px - 1px rgba(0, 0, 0, 0.2), 0px 4px 5px rgba(0, 0, 0, 0.14), 0px 1px 10px rgba(0, 0, 0, 0.12)'
         }
-    },
-    button: {
-        color: 'primary.main',
-        lineHeight: '1.375rem',
-        letterSpacing: '0.06em'
-    },
-    learnMoreLink: {
-        color: 'text.primary',
-        textDecoration: 'none'
     }
 };
 
 type SimpleCardProps = {
-    kind: string
-    name: string
-    description: string
-    onCreate: (kind: string) => void
+    kind: string;
+    name: string;
+    description: string;
+    onCreate: (kind: string) => void;
 };
 
 export const SimpleCard = ({ kind, name, description, onCreate }: SimpleCardProps) => {
 
-    const onClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    const handleDeploySelect = (event: React.MouseEvent<HTMLButtonElement>) => {
         event.stopPropagation();
         event.preventDefault();
         onCreate(kind);
@@ -51,17 +44,8 @@ export const SimpleCard = ({ kind, name, description, onCreate }: SimpleCardProp
             </CardContent>
 
             <CardActions>
-                <Button sx={styles.button}>
-                    <Link
-                        sx={{ ...styles.button, ...styles.learnMoreLink }}
-                        href='https://dolittle.io/docs/platform/requirements/'
-                        target='_blank'
-                    >
-                        Learn more
-                    </Link>
-                </Button>
-
-                <Button sx={styles.button} size="small" onClick={onClick}>Deploy</Button>
+                <Button label='Learn more' secondary href='https://dolittle.io/docs/platform/requirements/' target sx={{ mr: 2.25 }} />
+                <Button label='Deploy' onClick={handleDeploySelect} />
             </CardActions>
         </Card>
     );

--- a/Source/SelfService/Web/microservice/create/card.tsx
+++ b/Source/SelfService/Web/microservice/create/card.tsx
@@ -5,7 +5,7 @@ import React from 'react';
 
 import { Card, CardActions, CardContent, CardHeader, Typography } from '@mui/material';
 
-import { Button } from '@dolittle/design-system'
+import { Button } from '@dolittle/design-system';
 
 const styles = {
     card: {

--- a/Source/SelfService/Web/microservice/microservice.tsx
+++ b/Source/SelfService/Web/microservice/microservice.tsx
@@ -11,7 +11,7 @@ import { HttpResponseApplication } from '../api/application';
 import { useReadable } from 'use-svelte-store';
 import { canEditMicroservices, microservices } from '../stores/microservice';
 
-import { Paper, Typography } from '@mui/material';
+import { Typography } from '@mui/material';
 import { RocketLaunch } from '@mui/icons-material';
 
 import { Button, LoadingSpinner } from '@dolittle/design-system';

--- a/Source/SelfService/Web/microservice/microservice.tsx
+++ b/Source/SelfService/Web/microservice/microservice.tsx
@@ -68,13 +68,7 @@ export const Microservice = ({ environment, application }: MicroserviceProps) =>
 
     return (
         <>
-            {!hasEnvironments &&
-                <Button
-                    variant='text'
-                    label='Create New Environment'
-                    onClick={handleCreateEnvironment}
-                />
-            }
+            {!hasEnvironments && <Button label='Create New Environment' onClick={handleCreateEnvironment} />}
 
             <Typography variant='h1' sx={{ my: 2 }}>Microservices</Typography>
 
@@ -86,7 +80,6 @@ export const Microservice = ({ environment, application }: MicroserviceProps) =>
             {hasEnvironments && hasMicroservices &&
                 <Paper sx={{ mt: 2.125 }}>
                     <Button
-                        variant='text'
                         label='Deploy New Microservice'
                         startWithIcon={<RocketLaunch />}
                         isFullWidth

--- a/Source/SelfService/Web/microservice/microservice.tsx
+++ b/Source/SelfService/Web/microservice/microservice.tsx
@@ -78,14 +78,13 @@ export const Microservice = ({ environment, application }: MicroserviceProps) =>
             }
 
             {hasEnvironments && hasMicroservices &&
-                <Paper sx={{ mt: 2.125 }}>
-                    <Button
-                        label='Deploy New Microservice'
-                        startWithIcon={<RocketLaunch />}
-                        isFullWidth
-                        onClick={() => handleCreateMicroservice()}
-                    />
-                </Paper>
+                <Button
+                    label='Deploy New Microservice'
+                    variant='fullwidth'
+                    startWithIcon={<RocketLaunch />}
+                    onClick={() => handleCreateMicroservice()}
+                    sx={{ mt: 2.125 }}
+                />
             }
         </>
     );

--- a/Source/SelfService/Web/microservice/microserviceStatus.tsx
+++ b/Source/SelfService/Web/microservice/microserviceStatus.tsx
@@ -26,8 +26,7 @@ const styles = {
     },
     containerStatus: {
         ml: 3,
-        pointerEvents: 'none',
-        letterSpacing: '0.06em'
+        pointerEvents: 'none'
     }
 };
 
@@ -109,10 +108,11 @@ export const ContainerHealthStatus = ({ status }: ContainerHealthStatusProps) =>
 
     return (
         <Button
+            label={label}
             variant='filled'
             startWithIcon={icon}
             sx={{ ...styles.containerStatus, ...styles.text, backgroundColor }}
-            label={label} />
+        />
     );
 };
 

--- a/Source/SelfService/Web/microservice/microserviceView/configurationFilesSection/emptyDataTable.tsx
+++ b/Source/SelfService/Web/microservice/microserviceView/configurationFilesSection/emptyDataTable.tsx
@@ -11,20 +11,15 @@ import { Button } from '@dolittle/design-system';
 type EmptyDataTableProps = {
     title: string;
     description: string;
-    buttonText: string;
+    label: string;
     sx?: SxProps;
     handleOnClick: () => void;
 };
 
-export const EmptyDataTable = ({ title, description, buttonText, sx, handleOnClick }: EmptyDataTableProps) =>
+export const EmptyDataTable = ({ title, description, label, sx, handleOnClick }: EmptyDataTableProps) =>
     <Paper sx={{ p: 2, ...sx }}>
         <Typography variant='h2'>{title}</Typography>
         <Typography variant='body1' sx={{ my: 2 }}>{description}</Typography>
 
-        <Button
-            variant='fullwidth'
-            label={buttonText}
-            startWithIcon={<AddCircle />}
-            onClick={() => handleOnClick()}
-        />
+        <Button label={label} variant='fullwidth' startWithIcon={<AddCircle />} onClick={() => handleOnClick()} />
     </Paper>;

--- a/Source/SelfService/Web/microservice/microserviceView/configurationFilesSection/emptyDataTable.tsx
+++ b/Source/SelfService/Web/microservice/microserviceView/configurationFilesSection/emptyDataTable.tsx
@@ -22,18 +22,9 @@ export const EmptyDataTable = ({ title, description, buttonText, sx, handleOnCli
         <Typography variant='body1' sx={{ my: 2 }}>{description}</Typography>
 
         <Button
-            variant='filled'
+            variant='fullwidth'
             label={buttonText}
             startWithIcon={<AddCircle />}
-            isFullWidth
-            sx={{
-                'backgroundColor': 'rgba(140, 154, 248, 0.08)',
-                'color': 'primary.main',
-                'minHeight': 30,
-                '&:hover': {
-                    backgroundColor: 'rgba(140, 154, 248, 0.15)'
-                }
-            }}
             onClick={() => handleOnClick()}
         />
     </Paper>;

--- a/Source/SelfService/Web/microservice/microserviceView/configurationFilesSection/environmentVariablesSection/environmentVariableSection.tsx
+++ b/Source/SelfService/Web/microservice/microserviceView/configurationFilesSection/environmentVariablesSection/environmentVariableSection.tsx
@@ -239,7 +239,7 @@ export const EnvironmentVariablesSection = ({ applicationId, environment, micros
             >
                 <Box sx={{ mb: 2.875, button: { 'mr': 6.25, '&:last-of-type': { mr: 0 } } }}>
                     <Button
-                        label='Add Variable'
+                        label='Add new variable row'
                         startWithIcon={<AddCircle />}
                         disabled={disableAddButton}
                         onClick={handleEnvVariableAdd}

--- a/Source/SelfService/Web/microservice/microserviceView/configurationFilesSection/environmentVariablesSection/environmentVariableSection.tsx
+++ b/Source/SelfService/Web/microservice/microserviceView/configurationFilesSection/environmentVariablesSection/environmentVariableSection.tsx
@@ -239,28 +239,24 @@ export const EnvironmentVariablesSection = ({ applicationId, environment, micros
             >
                 <Box sx={{ mb: 2.875, button: { 'mr': 6.25, '&:last-of-type': { mr: 0 } } }}>
                     <Button
-                        variant='text'
                         label='Add Variable'
                         startWithIcon={<AddCircle />}
                         disabled={disableAddButton}
                         onClick={handleEnvVariableAdd}
                     />
                     <Button
-                        variant='text'
                         label='Delete Variable(s)'
                         disabled={!selectedRowIds.length || noEnvVariables}
                         startWithIcon={<DeleteRounded />}
                         onClick={handleEnvVariableDelete}
                     />
                     <Button
-                        variant='text'
                         label='Download secret env-variables yaml'
                         disabled={noSecretEnvVariables}
                         startWithIcon={<DownloadRounded />}
                         onClick={handleSecretEnvVariableDownload}
                     />
                     <Button
-                        variant='text'
                         label='Download env-variables yaml'
                         disabled={noPublicEnvVariables}
                         startWithIcon={<DownloadRounded />}

--- a/Source/SelfService/Web/microservice/microserviceView/configurationFilesSection/environmentVariablesSection/environmentVariableSection.tsx
+++ b/Source/SelfService/Web/microservice/microserviceView/configurationFilesSection/environmentVariablesSection/environmentVariableSection.tsx
@@ -265,7 +265,7 @@ export const EnvironmentVariablesSection = ({ applicationId, environment, micros
                     <EmptyDataTable
                         title='No environment variables yet...'
                         description={`To add your first environment variable, select 'add variable'. Provide a name, value and set its secrecy.`}
-                        buttonText='Add Variable'
+                        label='Add Variable'
                         handleOnClick={handleEnvVariableAdd} // TODO: Sometimes throws error when clicked
                         sx={{ mb: 8 }}
                     /> :

--- a/Source/SelfService/Web/microservice/microserviceView/configurationFilesSection/environmentVariablesSection/environmentVariableSection.tsx
+++ b/Source/SelfService/Web/microservice/microserviceView/configurationFilesSection/environmentVariablesSection/environmentVariableSection.tsx
@@ -37,12 +37,7 @@ const envVariableColumns: GridColDef<EnvironmentVariableTableRow>[] = [
         valueOptions: [{ value: true, label: 'Yes' }, { value: false, label: 'No' }],
         editable: true,
         renderCell: ({ value }) => (
-            <Button
-                variant='text'
-                label={value ? 'Yes' : 'No'}
-                sx={{ color: 'text.primary', width: 1, height: 1 }}
-                endWithIcon={<ArrowDropDown />}
-            />
+            <Button label={value ? 'Yes' : 'No'} secondary endWithIcon={<ArrowDropDown />} sx={{ width: 1, height: 1 }} />
         ),
         width: 90
     }
@@ -240,8 +235,8 @@ export const EnvironmentVariablesSection = ({ applicationId, environment, micros
                 <Box sx={{ mb: 2.875, button: { 'mr': 6.25, '&:last-of-type': { mr: 0 } } }}>
                     <Button
                         label='Add new variable row'
-                        startWithIcon={<AddCircle />}
                         disabled={disableAddButton}
+                        startWithIcon={<AddCircle />}
                         onClick={handleEnvVariableAdd}
                     />
                     <Button

--- a/Source/SelfService/Web/microservice/microserviceView/configurationFilesSection/filesSection/buttonGroup.tsx
+++ b/Source/SelfService/Web/microservice/microserviceView/configurationFilesSection/filesSection/buttonGroup.tsx
@@ -19,13 +19,11 @@ type ButtonGroupProps = {
 export const ButtonGroup = ({ filePrompt, deleteDisabled, downloadDisabled, handleDelete, handleDownload }: ButtonGroupProps) =>
     <Box sx={{ mb: 2.875, button: { 'mr': 6.25, '&:last-of-type': { mr: 0 } } }}>
         <Button
-            variant='text'
             label='Add File(s)'
             startWithIcon={<AddCircle />}
             onClick={filePrompt}
         />
         <Button
-            variant='text'
             label='Delete File(s)'
             disabled={deleteDisabled}
             startWithIcon={<DeleteRounded />}
@@ -33,7 +31,6 @@ export const ButtonGroup = ({ filePrompt, deleteDisabled, downloadDisabled, hand
         />
 
         <Button
-            variant='text'
             label={`Download Configuration Files Yaml`}
             disabled={downloadDisabled}
             startWithIcon={<DownloadRounded />}

--- a/Source/SelfService/Web/microservice/microserviceView/configurationFilesSection/filesSection/filesSection.tsx
+++ b/Source/SelfService/Web/microservice/microserviceView/configurationFilesSection/filesSection/filesSection.tsx
@@ -107,22 +107,7 @@ export const FilesSection = ({ applicationId, environment, microserviceName, mic
         const result = await updateConfigFile(applicationId, environment, microserviceId, formData);
 
         if (result.success) {
-            enqueueSnackbar(`'${file.name}' successfully added.`, {
-                action: (key) => (
-                    <>
-                        <Button label='Undo' color='secondary' aria-label='undo' onClick={async () => {
-                            await deleteConfigFile(applicationId, environment, microserviceId, file.name);
-
-                            fetchAndUpdateConfigFileNamesList();
-                            setRestartInfoBoxIsOpen(false);
-                            closeSnackbar(key);
-                        }} />
-                        <IconButton onClick={() => closeSnackbar(key)}>
-                            <CloseRounded aria-label='close' fontSize='small' sx={{ color: '#FFFFFF' }} />
-                        </IconButton>
-                    </>
-                )
-            });
+            enqueueSnackbar(`'${file.name}' successfully added.`);
 
             fetchAndUpdateConfigFileNamesList();
             setRestartInfoBoxIsOpen(true);
@@ -221,7 +206,7 @@ export const FilesSection = ({ applicationId, environment, microserviceName, mic
                     <EmptyDataTable
                         title='No configuration files yet...'
                         description={`To add your first configuration file, select 'add file'. You may select more than one at a time. Each file must be less than 3.145MB.`}
-                        buttonText='Add file(s)'
+                        label='Add file(s)'
                         handleOnClick={() => fileUploadRef.current?.showPrompt()}
                     />
                 }

--- a/Source/SelfService/Web/microservice/microserviceView/configurationFilesSection/filesSection/filesSection.tsx
+++ b/Source/SelfService/Web/microservice/microserviceView/configurationFilesSection/filesSection/filesSection.tsx
@@ -6,10 +6,8 @@ import React, { useEffect, useRef, useState } from 'react';
 import { useSnackbar } from 'notistack';
 
 import { GridSelectionModel } from '@mui/x-data-grid-pro';
-import { IconButton } from '@mui/material';
-import { CloseRounded } from '@mui/icons-material';
 
-import { Accordion, Button } from '@dolittle/design-system';
+import { Accordion } from '@dolittle/design-system';
 
 import { getConfigFilesNamesList, getServerUrlPrefix, updateConfigFile, deleteConfigFile } from '../../../../api/api';
 
@@ -33,7 +31,7 @@ type FilesSectionProps = {
 
 export const FilesSection = ({ applicationId, environment, microserviceName, microserviceId }: FilesSectionProps) => {
     const fileUploadRef = useRef<FileUploadFormRef>(null);
-    const { closeSnackbar, enqueueSnackbar } = useSnackbar();
+    const { enqueueSnackbar } = useSnackbar();
 
     const [filesPanelIsExpanded, setFilesPanelIsExpanded] = useState(true);
     const [configFileTableRows, setConfigFileTableRows] = useState<ConfigFilesTableRow[]>([]);

--- a/Source/SelfService/Web/microservice/microserviceView/configurationFilesSection/filesSection/filesSection.tsx
+++ b/Source/SelfService/Web/microservice/microserviceView/configurationFilesSection/filesSection/filesSection.tsx
@@ -110,7 +110,7 @@ export const FilesSection = ({ applicationId, environment, microserviceName, mic
             enqueueSnackbar(`'${file.name}' successfully added.`, {
                 action: (key) => (
                     <>
-                        <Button variant='text' label='Undo' color='secondary' aria-label='undo' onClick={async () => {
+                        <Button label='Undo' color='secondary' aria-label='undo' onClick={async () => {
                             await deleteConfigFile(applicationId, environment, microserviceId, file.name);
 
                             fetchAndUpdateConfigFileNamesList();

--- a/Source/SelfService/Web/microservice/microserviceView/configurationFilesSection/setupSection/setupSection.tsx
+++ b/Source/SelfService/Web/microservice/microserviceView/configurationFilesSection/setupSection/setupSection.tsx
@@ -156,7 +156,6 @@ export const SetupSection = ({ application, applicationId, environment, microser
                         <Tooltip title='Coming soon!' placement='top' arrow>
                             <span>
                                 <Button
-                                    variant='text'
                                     label='edit'
                                     disabled={formIsNotEditable}
                                     startWithIcon={<EditRounded />}
@@ -168,7 +167,6 @@ export const SetupSection = ({ application, applicationId, environment, microser
                         <Tooltip title='Coming soon!' placement='top' arrow>
                             <span>
                                 <Button
-                                    variant='text'
                                     label='save'
                                     disabled={formIsNotEditable}
                                     startWithIcon={<SaveRounded />}
@@ -178,14 +176,12 @@ export const SetupSection = ({ application, applicationId, environment, microser
                             </span>
                         </Tooltip>
                         <Button
-                            variant='text'
                             label='Restart Microservice'
                             startWithIcon={<RestartAltRounded />}
                             onClick={() => setRestartDialogIsOpen(true)}
                             sx={{ mr: 2.5 }}
                         />
                         <Button
-                            variant='text'
                             label='Delete Microservice'
                             startWithIcon={<DeleteRounded />}
                             onClick={() => setDeleteDialogIsOpen(true)}

--- a/Source/SelfService/Web/microservice/microserviceView/healthStatus/healthStatus.tsx
+++ b/Source/SelfService/Web/microservice/microserviceView/healthStatus/healthStatus.tsx
@@ -104,7 +104,6 @@ export const HealthStatus = ({ applicationId, environment, microserviceId, msNam
             />
 
             <Button
-                variant='text'
                 label='Restart Microservice'
                 startWithIcon={<RestartAltRounded />}
                 onClick={() => setRestartDialogIsOpen(true)}

--- a/Source/SelfService/Web/microservice/microserviceView/healthStatus/healthStatus.tsx
+++ b/Source/SelfService/Web/microservice/microserviceView/healthStatus/healthStatus.tsx
@@ -13,16 +13,6 @@ import { Metric, useMetricsFromLast } from '../../../metrics/useMetrics';
 import { HealthStatusTable, HealthStatusTableStats } from './healthStatusTable';
 import { RestartMicroserviceDialog } from '../restartMicroserviceDialog';
 
-const styles = {
-    restartBtn: {
-        lineHeight: '1.375rem',
-        letterSpacing: '0.06em',
-        display: 'flex',
-        mb: 2.5,
-        mt: 3.5
-    }
-};
-
 const computeStats = (metric: Metric | undefined, scale: number): HealthStatusTableStats | undefined => {
     if (metric === undefined) {
         return undefined;
@@ -107,7 +97,7 @@ export const HealthStatus = ({ applicationId, environment, microserviceId, msNam
                 label='Restart Microservice'
                 startWithIcon={<RestartAltRounded />}
                 onClick={() => setRestartDialogIsOpen(true)}
-                sx={styles.restartBtn}
+                sx={{ mb: 2.5, mt: 3.5 }}
             />
 
             {containerTables.length > 0

--- a/Source/SelfService/Web/microservice/noMicroservices.tsx
+++ b/Source/SelfService/Web/microservice/noMicroservices.tsx
@@ -3,25 +3,23 @@
 
 import React from 'react';
 
-import { Box, Button, Grid, Paper, Typography } from '@mui/material';
+import { Box, Grid, Paper, Typography } from '@mui/material';
 import { RocketLaunch } from '@mui/icons-material';
+
+import { Button } from '@dolittle/design-system';
 
 const styles = {
     deployButtonWrapper: {
         position: 'relative',
-        inlineSize: '413px',
-        blockSize: '174px',
+        width: '413px',
+        height: '174px',
         display: 'flex',
         alignItems: 'center',
         justifyContent: 'center'
     },
-    deployButton: {
-        inlineSize: '100%',
-        blockSize: '100%'
-    },
     dashedBorder: {
-        'inlineSize': '100%',
-        'blockSize': '100%',
+        'width': 1,
+        'height': 1,
         'position': 'absolute',
         'top': '-8px',
         'left': '-8px',
@@ -37,7 +35,7 @@ const styles = {
             border: '4px dashed #504D4D',
             borderRadius: '10px',
             boxSizing: 'border-box'
-        },
+        }
     }
 };
 
@@ -45,38 +43,27 @@ type NoMicroservicesProps = {
     onCreate: () => void;
 };
 
-export const NoMicroservices = ({ onCreate }: NoMicroservicesProps) => {
-    return (
-        <Grid
-            container
-            spacing={0}
-            direction='column'
-            alignItems='center'
-            justifyContent='center'
-            sx={{ minHeight: '80vh' }}
-        >
+export const NoMicroservices = ({ onCreate }: NoMicroservicesProps) =>
+    <Grid
+        container
+        spacing={0}
+        direction='column'
+        alignItems='center'
+        justifyContent='center'
+        sx={{ minHeight: '80vh' }}
+    >
+        <Typography variant='h2'>No microservices deployed yet...</Typography>
 
-            <Typography variant='h2' sx={{ lineHeight: '26px' }}>No microservices deployed yet...</Typography>
+        <Box component={Paper} mt={6.75} mb={5.75} sx={styles.deployButtonWrapper}>
+            <Box sx={styles.dashedBorder}></Box>
+            <Button label='Deploy new microservice' isFullWidth startWithIcon={<RocketLaunch />} onClick={onCreate} sx={{ height: 1 }} />
+        </Box>
 
-            <Box component={Paper} mt={6.75} mb={5.75} sx={styles.deployButtonWrapper}>
-                <Box sx={styles.dashedBorder}></Box>
-                <Button
-                    startIcon={<RocketLaunch />}
-                    sx={styles.deployButton}
-                    onClick={onCreate}
-                >
-                    Deploy NEW microservice
-                </Button>
-            </Box>
+        <Typography variant='body1' mb={2}>
+            After you deploy your first microservice it will appear here.
+        </Typography>
 
-            <Typography variant='body1' mb={2}>
-                After you deploy your first microservice it will appear here.
-            </Typography>
-
-            <Typography variant='body1'>
-                To deploy a new mircoservice click on the ‘deploy new microservice’ button or ‘deploy new’ tab at the top.
-            </Typography>
-
-        </Grid>
-    );
-};
+        <Typography variant='body1'>
+            To deploy a new mircoservice click on the 'deploy new microservice' button or 'deploy new' tab at the top.
+        </Typography>
+    </Grid>;

--- a/Source/SelfService/Web/microservice/noMicroservices.tsx
+++ b/Source/SelfService/Web/microservice/noMicroservices.tsx
@@ -64,6 +64,6 @@ export const NoMicroservices = ({ onCreate }: NoMicroservicesProps) =>
         </Typography>
 
         <Typography variant='body1'>
-            To deploy a new mircoservice click on the 'deploy new microservice' button or 'deploy new' tab at the top.
+            To deploy a new mircoservice click on the ‘deploy a microservice’ button or ‘deploy new’ tab at the top.
         </Typography>
     </Grid>;

--- a/Source/SelfService/Web/screens/adminScreen.tsx
+++ b/Source/SelfService/Web/screens/adminScreen.tsx
@@ -2,44 +2,37 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 import React from 'react';
-import {
-    Route,
-    Switch,
-    useHistory,
-} from 'react-router-dom';
+import { Route, Switch, useHistory, } from 'react-router-dom';
 
 import { Create as CreateCustomer } from '../customer/create';
 import { ViewAll as ViewAllCustomers } from '../customer/viewAll';
 import { View as ViewCustomer } from '../customer/view';
 import { View as ViewApplicationAccess } from '../admin/application/view';
-import { Button as ThemedButton } from '../theme/button';
 
-import {
-    LayoutWithSidebar,
-} from '../layout/layoutWithSidebar';
+import { LayoutWithSidebar } from '../layout/layoutWithSidebar';
+
 import { Typography } from '@mui/material';
 
-
+import { Button } from '@dolittle/design-system';
 
 export const Screen: React.FunctionComponent = () => {
     const history = useHistory();
     const nav = [];
 
-
     const welcome = (
         <>
             <Typography variant='h1' my={2}>Hello Admin</Typography>
-            <ThemedButton onClick={() => {
+            <Button label='Take me to the Customers' onClick={() => {
                 const href = `/admin/customers`;
                 history.push(href);
-            }}>Take me to the Customers</ThemedButton>
+            }}
+            />
         </>
     );
 
     return (
         <LayoutWithSidebar navigation={nav}>
             <Switch>
-
                 <Route exact path="/admin/customer/create">
                     <CreateCustomer />
                 </Route>
@@ -59,9 +52,7 @@ export const Screen: React.FunctionComponent = () => {
                 <Route exact path="/admin/">
                     {welcome}
                 </Route>
-
             </Switch>
-
-        </LayoutWithSidebar >
+        </LayoutWithSidebar>
     );
 };

--- a/Source/SelfService/Web/screens/applicationsScreen/actionButtons.tsx
+++ b/Source/SelfService/Web/screens/applicationsScreen/actionButtons.tsx
@@ -10,6 +10,6 @@ import { Button } from '@dolittle/design-system'
 
 export const ActionButtons = () =>
     <Box sx={{ mt: 12.5 }}>
-        <Button label='Select new customer' secondary startWithIcon={<ArrowBack />} href='/.auth/cookies/initiate' sx={{ mr: 8 }} />
+        <Button label='Back to tenant' secondary startWithIcon={<ArrowBack />} href='/.auth/cookies/initiate' sx={{ mr: 8 }} />
         <Button label='Log out' secondary href='/.auth/cookies/logout' />
     </Box>;

--- a/Source/SelfService/Web/screens/applicationsScreen/actionButtons.tsx
+++ b/Source/SelfService/Web/screens/applicationsScreen/actionButtons.tsx
@@ -3,27 +3,13 @@
 
 import React from 'react';
 
-import { Box, Button, Link, Theme } from '@mui/material';
+import { Box } from '@mui/material';
 import { ArrowBack } from '@mui/icons-material';
 
-const styles = {
-    letterSpacing: '0.059rem',
-    typography: 'body2',
-    fontWeight: 500,
-    mr: 8,
-    color: (theme: Theme) => theme.palette.text.primary
-};
+import { Button } from '@dolittle/design-system'
 
-export const ActionButtons = () => (
+export const ActionButtons = () =>
     <Box sx={{ mt: 12.5 }}>
-        <Link href='/.auth/cookies/initiate' sx={{ textDecoration: 'none' }}>
-            <Button startIcon={<ArrowBack />} sx={styles}>
-                Select new customer
-            </Button>
-        </Link>
-
-        <Link href={'/.auth/cookies/logout'} sx={{ textDecoration: 'none' }}>
-            <Button sx={styles}>Log Out</Button>
-        </Link>
-    </Box>
-);
+        <Button label='Select new customer' secondary startWithIcon={<ArrowBack />} href='/.auth/cookies/initiate' sx={{ mr: 8 }} />
+        <Button label='Log out' secondary href='/.auth/cookies/logout' />
+    </Box>;

--- a/Source/SelfService/Web/screens/applicationsScreen/actionButtons.tsx
+++ b/Source/SelfService/Web/screens/applicationsScreen/actionButtons.tsx
@@ -6,7 +6,7 @@ import React from 'react';
 import { Box } from '@mui/material';
 import { ArrowBack } from '@mui/icons-material';
 
-import { Button } from '@dolittle/design-system'
+import { Button } from '@dolittle/design-system';
 
 export const ActionButtons = () =>
     <Box sx={{ mt: 12.5 }}>

--- a/Source/SelfService/Web/screens/applicationsScreen/applicationsScreen.tsx
+++ b/Source/SelfService/Web/screens/applicationsScreen/applicationsScreen.tsx
@@ -76,17 +76,12 @@ export const ApplicationsScreen = () => {
             </Typography>
 
             <Box sx={{ width: 1 }}>
-                <Button
-                    label='Create new Application'
-                    startWithIcon={<AddCircle />}
-                    onClick={handleCreate}
-                />
+                <Button label='Create new Application' startWithIcon={<AddCircle />} onClick={handleCreate} />
             </Box>
 
             <ApplicationsList data={applicationInfos} onChoose={onEnvironmentChoose} />
 
             <ActionButtons />
-
         </LoginWrapper>
     );
 };

--- a/Source/SelfService/Web/screens/applicationsScreen/applicationsScreen.tsx
+++ b/Source/SelfService/Web/screens/applicationsScreen/applicationsScreen.tsx
@@ -44,7 +44,7 @@ export const ApplicationsScreen = () => {
             setCanCreateApplication(response.canCreateApplication);
             setApplicationInfos(response.applications);
             setLoaded(true);
-        }).catch((error) => {
+        }).catch(error => {
             console.log(error);
             enqueueSnackbar('Failed getting data from the server', { variant: 'error' });
         });
@@ -77,7 +77,6 @@ export const ApplicationsScreen = () => {
 
             <Box sx={{ width: 1 }}>
                 <Button
-                    variant='text'
                     label='Create new Application'
                     startWithIcon={<AddCircle />}
                     onClick={handleCreate}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2834,6 +2834,23 @@
     global "^4.4.0"
     regenerator-runtime "^0.13.7"
 
+"@storybook/addons@^6.5.15":
+  version "6.5.15"
+  resolved "https://registry.yarnpkg.com/@storybook/addons/-/addons-6.5.15.tgz#3c3fafbf3c9ce2182d652cb6682f6581ba6580e1"
+  integrity sha512-xT31SuSX+kYGyxCNK2nqL7WTxucs3rSmhiCLovJcUjYk+QquV3c2c53Ki7lwwdDbzfXFcNAe0HJ4hoTN4jhn0Q==
+  dependencies:
+    "@storybook/api" "6.5.15"
+    "@storybook/channels" "6.5.15"
+    "@storybook/client-logger" "6.5.15"
+    "@storybook/core-events" "6.5.15"
+    "@storybook/csf" "0.0.2--canary.4566f4d.1"
+    "@storybook/router" "6.5.15"
+    "@storybook/theming" "6.5.15"
+    "@types/webpack-env" "^1.16.0"
+    core-js "^3.8.2"
+    global "^4.4.0"
+    regenerator-runtime "^0.13.7"
+
 "@storybook/api@6.5.10":
   version "6.5.10"
   resolved "https://registry.yarnpkg.com/@storybook/api/-/api-6.5.10.tgz#215623844648f0da2ac646fdcdd1345c2e1a8490"
@@ -2869,6 +2886,29 @@
     "@storybook/router" "6.5.13"
     "@storybook/semver" "^7.3.2"
     "@storybook/theming" "6.5.13"
+    core-js "^3.8.2"
+    fast-deep-equal "^3.1.3"
+    global "^4.4.0"
+    lodash "^4.17.21"
+    memoizerific "^1.11.3"
+    regenerator-runtime "^0.13.7"
+    store2 "^2.12.0"
+    telejson "^6.0.8"
+    ts-dedent "^2.0.0"
+    util-deprecate "^1.0.2"
+
+"@storybook/api@6.5.15":
+  version "6.5.15"
+  resolved "https://registry.yarnpkg.com/@storybook/api/-/api-6.5.15.tgz#a189dac82a57ae9cfac43c887207b1075a2a2e96"
+  integrity sha512-BBE0KXKvj1/3jTghbIoWfrcDM0t+xO7EYtWWAXD6XlhGsZVD2Dy82Z52ONyLulMDRpMWl0OYy3h6A1YnFUH25w==
+  dependencies:
+    "@storybook/channels" "6.5.15"
+    "@storybook/client-logger" "6.5.15"
+    "@storybook/core-events" "6.5.15"
+    "@storybook/csf" "0.0.2--canary.4566f4d.1"
+    "@storybook/router" "6.5.15"
+    "@storybook/semver" "^7.3.2"
+    "@storybook/theming" "6.5.15"
     core-js "^3.8.2"
     fast-deep-equal "^3.1.3"
     global "^4.4.0"
@@ -3019,6 +3059,15 @@
     ts-dedent "^2.0.0"
     util-deprecate "^1.0.2"
 
+"@storybook/channels@6.5.15":
+  version "6.5.15"
+  resolved "https://registry.yarnpkg.com/@storybook/channels/-/channels-6.5.15.tgz#586681b6ec458124da084c39bc8c518d9e96b10b"
+  integrity sha512-gPpsBgirv2NCXbH4WbYqdkI0JLE96aiVuu7UEWfn9yu071pQ9CLHbhXGD9fSFNrfOkyBBY10ppSE7uCXw3Wexg==
+  dependencies:
+    core-js "^3.8.2"
+    ts-dedent "^2.0.0"
+    util-deprecate "^1.0.2"
+
 "@storybook/client-api@6.5.10":
   version "6.5.10"
   resolved "https://registry.yarnpkg.com/@storybook/client-api/-/client-api-6.5.10.tgz#0bc3f68ce014ce1ffd560472a893ba04be370f09"
@@ -3057,6 +3106,14 @@
   version "6.5.13"
   resolved "https://registry.yarnpkg.com/@storybook/client-logger/-/client-logger-6.5.13.tgz#83f332dd9bb4ff1696d16b0cc24561df90905264"
   integrity sha512-F2SMW3LWFGXLm2ENTwTitrLWJgmMXRf3CWQXdN2EbkNCIBHy5Zcbt+91K4OX8e2e5h9gjGfrdYbyYDYOoUCEfA==
+  dependencies:
+    core-js "^3.8.2"
+    global "^4.4.0"
+
+"@storybook/client-logger@6.5.15":
+  version "6.5.15"
+  resolved "https://registry.yarnpkg.com/@storybook/client-logger/-/client-logger-6.5.15.tgz#0d9878af893a3493b6ee108cc097ae1436d7da4d"
+  integrity sha512-0uyxKvodq+FycGv6aUwC1wUR6suXf2+7ywMFAOlYolI4UvNj8NyU/5AfgKT5XnxYAgPmoCiAjOE700TrfHrosw==
   dependencies:
     core-js "^3.8.2"
     global "^4.4.0"
@@ -3168,6 +3225,13 @@
   version "6.5.13"
   resolved "https://registry.yarnpkg.com/@storybook/core-events/-/core-events-6.5.13.tgz#a8c0cc92694f09981ca6501d5c5ef328db18db8a"
   integrity sha512-kL745tPpRKejzHToA3/CoBNbI+NPRVk186vGxXBmk95OEg0TlwgQExP8BnqEtLlRZMbW08e4+6kilc1M1M4N5w==
+  dependencies:
+    core-js "^3.8.2"
+
+"@storybook/core-events@6.5.15":
+  version "6.5.15"
+  resolved "https://registry.yarnpkg.com/@storybook/core-events/-/core-events-6.5.15.tgz#c12f645b50231c50eb9b26038aa67ab92b1ba24e"
+  integrity sha512-B1Ba6l5W7MeNclclqMMTMHgYgfdpB5SIhNCQFnzIz8blynzRhNFMdxvbAl6Je5G0S4xydYYd7Lno2kXQebs7HA==
   dependencies:
     core-js "^3.8.2"
 
@@ -3516,6 +3580,17 @@
     qs "^6.10.0"
     regenerator-runtime "^0.13.7"
 
+"@storybook/router@6.5.15":
+  version "6.5.15"
+  resolved "https://registry.yarnpkg.com/@storybook/router/-/router-6.5.15.tgz#bf01d35bdd4603bf188629a6578489e313a312fd"
+  integrity sha512-9t8rI8t7/Krolau29gsdjdbRQ66orONIyP0efp0EukVgv6reNFzb/U14ARrl0uHys6Tl5Xyece9FoakQUdn8Kg==
+  dependencies:
+    "@storybook/client-logger" "6.5.15"
+    core-js "^3.8.2"
+    memoizerific "^1.11.3"
+    qs "^6.10.0"
+    regenerator-runtime "^0.13.7"
+
 "@storybook/semver@^7.3.2":
   version "7.3.2"
   resolved "https://registry.yarnpkg.com/@storybook/semver/-/semver-7.3.2.tgz#f3b9c44a1c9a0b933c04e66d0048fcf2fa10dac0"
@@ -3606,6 +3681,16 @@
   integrity sha512-oif5NGFAUQhizo50r+ctw2hZNLWV4dPHai+L/gFvbaSeRBeHSNkIcMoZ2FlrO566HdGZTDutYXcR+xus8rI28g==
   dependencies:
     "@storybook/client-logger" "6.5.13"
+    core-js "^3.8.2"
+    memoizerific "^1.11.3"
+    regenerator-runtime "^0.13.7"
+
+"@storybook/theming@6.5.15", "@storybook/theming@^6.5.15":
+  version "6.5.15"
+  resolved "https://registry.yarnpkg.com/@storybook/theming/-/theming-6.5.15.tgz#048461b37ad0c29dc8d91a065a6bf1c90067524c"
+  integrity sha512-pgdW0lVZKKXQ4VhIfLHycMmwFSVOY7vLTKnytag4Y8Yz+aXm0bwDN/QxPntFzDH47F1Rcy2ywNnvty8ooDTvuA==
+  dependencies:
+    "@storybook/client-logger" "6.5.15"
     core-js "^3.8.2"
     memoizerific "^1.11.3"
     regenerator-runtime "^0.13.7"


### PR DESCRIPTION
## Summary

Add Dark theme to the Storybook as it fits better with Studio.
Added jsDocs for Button component.
Created custom button variant 'danger' for cases where the primary action is destructive such as deleting content.
Created cutom button variant 'fullwidth' that makes button as wide, as its container. Used mostly in Data Table Grids when there is no rows yet.

<img width="1096" alt="Screenshot 2023-01-02 at 12 11 10" src="https://user-images.githubusercontent.com/19160439/210259819-f41b25e9-77c5-4dba-8942-fe54f2872afc.png">

### Added

- Dark theme to Storybook. Components didn't had good contrast with white background.
- Custom button variants: 'danger' and 'fullwith'.
- Secondary color variant to button.

### Changed

- Button default variant to 'text'.
- Renamed button that adds new environment variable file.
- Renamed button that takes back to tenant.

### Removed

- Actions on the Storybook Canvas. This is still to be discussed but removed for a better user experience.
