### PR TITLE
add dev-container -definition

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,53 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/typescript-node
+{
+	"name": "Studio Website",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"image": "mcr.microsoft.com/devcontainers/typescript-node:0-16",
+	"features": {
+		"ghcr.io/devcontainers/features/docker-in-docker:2": {},
+		"ghcr.io/devcontainers/features/git:1": {},
+		"ghcr.io/devcontainers/features/github-cli:1": {},
+		"ghcr.io/eitsupi/devcontainer-features/jq-likes:1": {}
+	},
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"EditorConfig.EditorConfig",
+				"dbaeumer.vscode-eslint",
+				"GraphQL.vscode-graphql",
+				"GabrielNordeborn.vscode-graphiql-explorer",
+				"heaths.vscode-guid",
+				"pmneo.tsimporter",
+				"nsoult.typescript-imports-sort",
+				"DSKWRK.vscode-generate-getter-setter",
+				"aeschli.vscode-css-formatter",
+				"GitHub.vscode-pull-request-github",
+				"waderyan.gitblame",
+				"mhutchie.git-graph",
+				"hoovercj.vscode-power-mode",
+				"Gruntfuggly.todo-tree",
+				"GitHub.copilot",
+				"GitHub.copilot-nightly",
+				"cweijan.vscode-redis-client",
+				"kahole.magit",
+				"streetsidesoftware.code-spell-checker"
+			]
+		}
+	}
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "yarn install",
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,10 +1,10 @@
 {
 	"workbench.colorCustomizations": {
 		"activityBar.activeBackground": "#252731",
-		"activityBar.background": "#b33500",
+		"activityBar.background": "#252731",
 		"activityBar.foreground": "#e7e7e7",
 		"activityBar.inactiveForeground": "#e7e7e799",
-		"activityBarBadge.background": "#b0485a",
+		"activityBarBadge.background": "#a7384a",
 		"activityBarBadge.foreground": "#e7e7e7",
 		"commandCenter.border": "#e7e7e799",
 		"sash.hoverBorder": "#252731",
@@ -13,9 +13,9 @@
 		"statusBarItem.hoverBackground": "#252731",
 		"statusBarItem.remoteBackground": "#0f1014",
 		"statusBarItem.remoteForeground": "#e7e7e7",
-		"titleBar.activeBackground": "#a23101",
+		"titleBar.activeBackground": "#0f1014",
 		"titleBar.activeForeground": "#e7e7e7",
-		"titleBar.inactiveBackground": "#5e3828",
+		"titleBar.inactiveBackground": "#0f101499",
 		"titleBar.inactiveForeground": "#e7e7e799"
 	},
 	"peacock.remoteColor": "#0f1014"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,22 @@
+{
+	"workbench.colorCustomizations": {
+		"activityBar.activeBackground": "#252731",
+		"activityBar.background": "#b33500",
+		"activityBar.foreground": "#e7e7e7",
+		"activityBar.inactiveForeground": "#e7e7e799",
+		"activityBarBadge.background": "#b0485a",
+		"activityBarBadge.foreground": "#e7e7e7",
+		"commandCenter.border": "#e7e7e799",
+		"sash.hoverBorder": "#252731",
+		"statusBar.background": "#0f1014",
+		"statusBar.foreground": "#e7e7e7",
+		"statusBarItem.hoverBackground": "#252731",
+		"statusBarItem.remoteBackground": "#0f1014",
+		"statusBarItem.remoteForeground": "#e7e7e7",
+		"titleBar.activeBackground": "#a23101",
+		"titleBar.activeForeground": "#e7e7e7",
+		"titleBar.inactiveBackground": "#5e3828",
+		"titleBar.inactiveForeground": "#e7e7e799"
+	},
+	"peacock.remoteColor": "#0f1014"
+}


### PR DESCRIPTION
## Summary

Add dev-container -definition set up with node, typescript, yarn, and some vscode
extensions.

This is purely a developer-environment -thing, does not require deployment.

### Added

devcontainer.json
