### PR TITLE
Add span component and role='none' to button

### DIFF
--- a/Source/DesignSystem/atoms/Button/Button.tsx
+++ b/Source/DesignSystem/atoms/Button/Button.tsx
@@ -65,6 +65,16 @@ export type ButtonProps = {
     endWithIcon?: ReactElement<SvgIconProps>;
 
     /**
+     * Role of the button. Default is button but for example if you want to use the button as a link you can set it to link.
+     *
+     * Role 'none' combined with component='span' is a hack for Dashlane browser extension to not interfere with the button
+     * and slow down the page.
+     * @default button
+     */
+    role?: 'button' | 'none';
+    component?: 'button' | 'span';
+
+    /**
      * Button type. Default is button but for example if you want to use the button as a submit button you can set it to submit.
      * @default button
      */
@@ -115,7 +125,9 @@ export type ButtonProps = {
  * @example
  * <Button label='Click me' variant='filled' isFullWidth startWithIcon={<AddCircle />} />
  */
-export const Button = ({ variant, label, disabled, secondary, size, isFullWidth, startWithIcon, endWithIcon, target, type, onClick, href, sx }: ButtonProps): ReactElement =>
+export const Button = (
+    { variant, label, disabled, secondary, size, isFullWidth, startWithIcon, endWithIcon, role, component, type, href, target, onClick, sx }: ButtonProps): ReactElement =>
+
     <MuiButton
         variant={variant === 'filled' ? 'contained' : variant || 'text'}
         disabled={disabled}
@@ -124,11 +136,14 @@ export const Button = ({ variant, label, disabled, secondary, size, isFullWidth,
         fullWidth={variant === 'fullwidth' || isFullWidth}
         startIcon={variant === 'danger' ? <ErrorRounded /> : startWithIcon}
         endIcon={endWithIcon}
-        type={type || 'button'}
-        onClick={onClick}
+        role={role}
+        //@ts-ignore
+        component={component}
+        type={type}
         href={href}
         //@ts-ignore
         target={target ? '_blank' : undefined}
+        onClick={onClick}
         sx={sx}
         disableElevation
     >

--- a/Source/SelfService/Web/logging/logLine.tsx
+++ b/Source/SelfService/Web/logging/logLine.tsx
@@ -107,7 +107,7 @@ export const LogLine = ({ line, showContextButton, loading, onClickShowLineConte
             {showContextButton === true && (
                 <Box sx={{ whiteSpace: 'nowrap', pr: 2, flexShrink: 0 }}>
                     <SkeletonWhenLoading loading={loading}>
-                        <Button label='Show' secondary sx={{ p: 0 }} onClick={event => onClickShowLineContext?.(timestamp, labels, event)} />
+                        <Button label='Show' secondary component='span' role='none' sx={{ p: 0 }} onClick={event => onClickShowLineContext?.(timestamp, labels, event)} />
                     </SkeletonWhenLoading>
                 </Box>
             )}


### PR DESCRIPTION
## Summary

To fix the problem with the Dashlane browser extension, I added component='span' and role='none' to the Button component.

<img width="521" alt="Screenshot 2023-01-03 at 15 16 51" src="https://user-images.githubusercontent.com/19160439/210365774-7dc02984-fc76-444a-b8f3-a0f512006e01.png">

Otherwise, Dashlane wanted to interact with the regular button component and significantly slowed down the 'live logs' page.

<img width="283" alt="Screenshot 2023-01-03 at 14 11 04" src="https://user-images.githubusercontent.com/19160439/210365748-8795db92-dca5-4654-988f-660da49502b7.png">

### Added

- Component props to Button.
- Role props to Button.
