### PR TITLE
Fix deployment buildargs

### DIFF
--- a/.github/workflows/deploy-selfservice-web.yml
+++ b/.github/workflows/deploy-selfservice-web.yml
@@ -107,6 +107,8 @@ jobs:
           context: .
           file: ./${{ env.DOCKER_FILE }}
           tags: dolittle/self-service-web:${{ needs.changes.outputs.next-version }}
+          build-args: |
+            MUI_LICENSE_KEY_ARG=${{ secrets.MUI_LICENSE_KEY_STUDIO }}
 
 
       - name: Push latest tag to Docker Hub

--- a/Source/SelfService/Web/App.tsx
+++ b/Source/SelfService/Web/App.tsx
@@ -38,6 +38,7 @@ import { ContainerRegistryScreen } from './screens/containerRegistryScreen';
 import { M3ConnectorScreen } from './screens/m3connectorScreen';
 import { LogsScreen } from './screens/logsScreen';
 
+// Set license info for MUI
 LicenseInfo.setLicenseKey(process.env.MUI_LICENSE_KEY!);
 
 // Make all stacked snackbars with same width


### PR DESCRIPTION
## Summary

The build step "Push Semantic Image to Docker Hub" was missing the build-args attribute so this was never passed into the dockerisation, and thus the license key was never set.

### Fixed
  - deployment step for semantic version to include build-args

### Changed
 - made small change to self-service to force deployment