### PR TITLE
Upgrade react router

### DIFF
--- a/Source/DesignSystem/atoms/Button/Button.stories.tsx
+++ b/Source/DesignSystem/atoms/Button/Button.stories.tsx
@@ -18,17 +18,17 @@ export default {
             description: {
                 component: `A button triggers an event or action. Its label should let the user know what will happen next.
 
-**Styling:** Buttons come in three style variations. All variations can be used with or without icons to help lift the UI and 
+**Styling:** Buttons come in three style variations. All variations can be used with or without icons to help lift the UI and
 quickly visually communicate to the user what the button will do.
 
-- *Filled buttons* are reserved for primary actions. They should be used to call attention to an action on a form or to 
-highlight the strongest call to action on the page. Filled buttons should appear only once per container (not including the 
-application header or in a modal dialog). Not every screen requires a primary action, or filled button. Filled buttons use our primary main color. 
-- *Outlined buttons* are reserved for login screens. The empty fill allows third-party icons to be used in their original styling. 
-- *Text buttons* are used for secondary actions, such as 'cancel' or to carry out an optional action within the page. 
-They are commonly found in dialogs, cards or sometimes toolbars. Text buttons may use our primary main color or the inherit color 
-of the page depending on whether or not the user's attention should be drawn to the button or if the button needs to be distinguished 
-from other content on the page. 
+- *Filled buttons* are reserved for primary actions. They should be used to call attention to an action on a form or to
+highlight the strongest call to action on the page. Filled buttons should appear only once per container (not including the
+application header or in a modal dialog). Not every screen requires a primary action, or filled button. Filled buttons use our primary main color.
+- *Outlined buttons* are reserved for login screens. The empty fill allows third-party icons to be used in their original styling.
+- *Text buttons* are used for secondary actions, such as 'cancel' or to carry out an optional action within the page.
+They are commonly found in dialogs, cards or sometimes toolbars. Text buttons may use our primary main color or the inherit color
+of the page depending on whether or not the user's attention should be drawn to the button or if the button needs to be distinguished
+from other content on the page.
 `,
             },
         },
@@ -157,6 +157,19 @@ export const UseAsLink = () => (
     </>
 );
 UseAsLink.decorators = [Story => <Box sx={{ '& a': { mr: 3 } }}>{Story()}</Box>];
+UseAsLink.parameters = {
+    docs: {
+        description: {
+            story: `To use this with an external library like react router, you need to override the component and any additional props needed
+            ${'```'}
+import { Link } from 'react-router-dom'
+<Button {...props} overrides={{ component:Link, to:'/some/path'}} />
+            ${'```'}
+            `
+        },
+    }
+};
+
 
 export const Fullwidth = () => (
     <Button label='full width button with custom style' variant='fullwidth' startWithIcon={<AddCircle />} />

--- a/Source/DesignSystem/atoms/Button/Button.tsx
+++ b/Source/DesignSystem/atoms/Button/Button.tsx
@@ -3,7 +3,7 @@
 
 import React, { ReactElement } from 'react';
 
-import { Button as MuiButton, SvgIconProps, SxProps } from '@mui/material';
+import { Button as MuiButton, ExtendButtonBase, ButtonTypeMap, SvgIconProps, SxProps } from '@mui/material';
 
 /**
  * The props for a {@link Button} component.
@@ -108,6 +108,13 @@ export type ButtonProps = {
      * @default undefined
      */
     sx?: SxProps;
+
+    /**
+     * The overrides prop gives you access to the underlying MuiButtonProps object, overriding the styles defined by the component and Material-UI.
+     * @default undefined
+     */
+    overrides?: Partial<ExtendButtonBase<ButtonTypeMap>>;
+
 };
 
 /**
@@ -118,7 +125,7 @@ export type ButtonProps = {
  * <Button label='Click me' variant='filled' isFullWidth startWithIcon={<AddCircle />} />
  */
 export const Button = (
-    { label, variant, color, startWithIcon, endWithIcon, isFullWidth, disabled, type, href, target, ariaLabel, component, role, onClick, sx }: ButtonProps): ReactElement =>
+    { label, variant, color, startWithIcon, endWithIcon, isFullWidth, disabled, type, href, target, ariaLabel, component, role, onClick, sx, overrides }: ButtonProps): ReactElement =>
 
     <MuiButton
         variant={variant === 'filled' ? 'contained' : variant}
@@ -137,6 +144,7 @@ export const Button = (
         sx={sx}
         rel={target ? 'noopener noreferrer' : undefined}
         disableFocusRipple
+        {...overrides}
     >
         {label}
     </MuiButton>;

--- a/Source/SelfService/Web/App.tsx
+++ b/Source/SelfService/Web/App.tsx
@@ -112,10 +112,10 @@ export const App = () => {
                                     } />
 
                                     {/* TODO Pav: remove custom RouteNotFound https://reactrouter.com/en/main/upgrading/v5#upgrade-to-react-router-v6 */}
-                                    <RouteNotFound
+                                    {/* <RouteNotFound
                                         redirectUrl='/applications'
                                         auto={true}
-                                    />
+                                    /> */}
                                 </Routes>
                             </SnackbarProvider>
                         </Box>

--- a/Source/SelfService/Web/App.tsx
+++ b/Source/SelfService/Web/App.tsx
@@ -2,7 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 import React from 'react';
-import { Route, BrowserRouter, useLocation, Switch } from 'react-router-dom';
+import { Route, BrowserRouter, useLocation, Routes } from 'react-router-dom';
 import { QueryParamProvider } from 'use-query-params';
 
 import { SnackbarProvider } from 'notistack';
@@ -87,7 +87,7 @@ export const App = () => {
                             >
                                 <BrowserRouter basename={uriWithAppPrefix('')}>
                                     <QueryParamProvider ReactRouterRoute={Route}>
-                                        <Switch>
+                                        <Routes>
                                             <Route exact path='/login'>
                                                 <LoginScreen />
                                             </Route>
@@ -138,7 +138,7 @@ export const App = () => {
                                                 redirectUrl='/applications'
                                                 auto={true}
                                             />
-                                        </Switch>
+                                        </Routes>
                                     </QueryParamProvider>
                                 </BrowserRouter>
                             </SnackbarProvider>

--- a/Source/SelfService/Web/App.tsx
+++ b/Source/SelfService/Web/App.tsx
@@ -2,8 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 import React from 'react';
-import { Route, BrowserRouter, useLocation, Routes } from 'react-router-dom';
-import { QueryParamProvider } from 'use-query-params';
+import { Route, useLocation, Routes } from 'react-router-dom';
 
 import { SnackbarProvider } from 'notistack';
 
@@ -85,43 +84,39 @@ export const App = () => {
                                     default: null
                                 }}
                             >
-                                <BrowserRouter basename={uriWithAppPrefix('')}>
-                                    <QueryParamProvider ReactRouterRoute={Route}>
-                                        <Routes>
-                                            <Route path='/login' element={<LoginScreen />} />
+                                <Routes>
+                                    <Route path='/login' element={<LoginScreen />} />
 
-                                            <Route path='/backups/application/:applicationId/*' element={<BackupsScreen />} />
+                                    <Route path='/backups/application/:applicationId/*' element={<BackupsScreen />} />
 
-                                            <Route path='/applications' element={<ApplicationsScreen />} />
+                                    <Route path='/applications' element={<ApplicationsScreen />} />
 
-                                            <Route path='/application/*' element={<ApplicationScreen />} />
+                                    <Route path='/application/*' element={<ApplicationScreen />} />
 
-                                            <Route path='/microservices/application/:applicationId/:environment/*' element={<MicroservicesScreen />} />
+                                    <Route path='/microservices/application/:applicationId/:environment/*' element={<MicroservicesScreen />} />
 
-                                            <Route path='/documentation/application/:applicationId/:environment/*' element={<DocumentationScreen />} />
+                                    <Route path='/documentation/application/:applicationId/:environment/*' element={<DocumentationScreen />} />
 
-                                            <Route path='/containerregistry/application/:applicationId/:environment/*' element={<ContainerRegistryScreen />} />
+                                    <Route path='/containerregistry/application/:applicationId/:environment/*' element={<ContainerRegistryScreen />} />
 
-                                            <Route path='/m3connector/application/:applicationId/*' element={<M3ConnectorScreen />} />
+                                    <Route path='/m3connector/application/:applicationId/*' element={<M3ConnectorScreen />} />
 
-                                            <Route path='/logs/application/:applicationId/:environment' element={<LogsScreen />} />
+                                    <Route path='/logs/application/:applicationId/:environment' element={<LogsScreen />} />
 
-                                            <Route path='/admin/*' element={<AdminScreen />} />
+                                    <Route path='/admin/*' element={<AdminScreen />} />
 
-                                            <Route path='/problem' element={
-                                                <LayoutWithSidebar navigation={[]}>
-                                                    <DieAndRestart />
-                                                </LayoutWithSidebar>
-                                            } />
+                                    <Route path='/problem' element={
+                                        <LayoutWithSidebar navigation={[]}>
+                                            <DieAndRestart />
+                                        </LayoutWithSidebar>
+                                    } />
 
-                                            {/* TODO Pav: remove custom RouteNotFound https://reactrouter.com/en/main/upgrading/v5#upgrade-to-react-router-v6 */}
-                                            <RouteNotFound
-                                                redirectUrl='/applications'
-                                                auto={true}
-                                            />
-                                        </Routes>
-                                    </QueryParamProvider>
-                                </BrowserRouter>
+                                    {/* TODO Pav: remove custom RouteNotFound https://reactrouter.com/en/main/upgrading/v5#upgrade-to-react-router-v6 */}
+                                    <RouteNotFound
+                                        redirectUrl='/applications'
+                                        auto={true}
+                                    />
+                                </Routes>
                             </SnackbarProvider>
                         </Box>
                     </GlobalContextProvider>

--- a/Source/SelfService/Web/App.tsx
+++ b/Source/SelfService/Web/App.tsx
@@ -88,52 +88,33 @@ export const App = () => {
                                 <BrowserRouter basename={uriWithAppPrefix('')}>
                                     <QueryParamProvider ReactRouterRoute={Route}>
                                         <Routes>
-                                            <Route exact path='/login'>
-                                                <LoginScreen />
-                                            </Route>
+                                            <Route path='/login' element={<LoginScreen />} />
 
-                                            <Route path='/backups/application/:applicationId'>
-                                                <BackupsScreen />
-                                            </Route>
+                                            <Route path='/backups/application/:applicationId/*' element={<BackupsScreen />} />
 
-                                            <Route exact path='/applications'>
-                                                <ApplicationsScreen />
-                                            </Route>
+                                            <Route path='/applications' element={<ApplicationsScreen />} />
 
-                                            <Route path='/application/'>
-                                                <ApplicationScreen />
-                                            </Route>
+                                            <Route path='/application/*' element={<ApplicationScreen />} />
 
-                                            <Route path='/microservices/application/:applicationId/:environment'>
-                                                <MicroservicesScreen />
-                                            </Route>
+                                            <Route path='/microservices/application/:applicationId/:environment/*' element={<MicroservicesScreen />} />
 
-                                            <Route path='/documentation/application/:applicationId/:environment'>
-                                                <DocumentationScreen />
-                                            </Route>
+                                            <Route path='/documentation/application/:applicationId/:environment/*' element={<DocumentationScreen />} />
 
-                                            <Route path='/containerregistry/application/:applicationId/:environment'>
-                                                <ContainerRegistryScreen />
-                                            </Route>
+                                            <Route path='/containerregistry/application/:applicationId/:environment/*' element={<ContainerRegistryScreen />} />
 
-                                            <Route path='/m3connector/application/:applicationId'>
-                                                <M3ConnectorScreen />
-                                            </Route>
+                                            <Route path='/m3connector/application/:applicationId/*' element={<M3ConnectorScreen />} />
 
-                                            <Route path='/logs/application/:applicationId/:environment'>
-                                                <LogsScreen />
-                                            </Route>
+                                            <Route path='/logs/application/:applicationId/:environment' element={<LogsScreen />} />
 
-                                            <Route path='/admin/'>
-                                                <AdminScreen />
-                                            </Route>
+                                            <Route path='/admin/*' element={<AdminScreen />} />
 
-                                            <Route exact path='/problem'>
+                                            <Route path='/problem' element={
                                                 <LayoutWithSidebar navigation={[]}>
                                                     <DieAndRestart />
                                                 </LayoutWithSidebar>
-                                            </Route>
+                                            } />
 
+                                            {/* TODO Pav: remove custom RouteNotFound https://reactrouter.com/en/main/upgrading/v5#upgrade-to-react-router-v6 */}
                                             <RouteNotFound
                                                 redirectUrl='/applications'
                                                 auto={true}

--- a/Source/SelfService/Web/App.tsx
+++ b/Source/SelfService/Web/App.tsx
@@ -2,7 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 import React from 'react';
-import { Route, useLocation, Routes } from 'react-router-dom';
+import { Route, Routes, Navigate } from 'react-router-dom';
 
 import { SnackbarProvider } from 'notistack';
 
@@ -18,7 +18,6 @@ import { Snackbar } from '@dolittle/design-system/atoms/Snackbar/Snackbar';
 
 import { useViewportResize } from './utils/useViewportResize';
 
-import { uriWithAppPrefix } from './store';
 import { GlobalContextProvider } from './stores/notifications';
 
 import { RouteNotFound } from './components/notfound';
@@ -45,18 +44,6 @@ const snackbarStyles = { '& .notistack-SnackbarContainer>*': { width: 1 } };
 
 export const App = () => {
     useViewportResize();
-
-    const { pathname } = useLocation();
-    // Little hack to force redirect
-    if (['', '/', uriWithAppPrefix('/')].includes(pathname)) {
-        // It is possible to know that the user just picked a customer
-        // We could signal this to the applications page
-        // This could then redirect, if the
-        // We could offer redirect back to last page?
-        // Referer https://dolittle.studio/.auth/select-tenant?login_challenge=c84329905dd7402bb45377dc8e1006c9
-        window.location.href = uriWithAppPrefix('/applications');
-        return null;
-    };
 
     return (
         <>
@@ -85,6 +72,8 @@ export const App = () => {
                                 }}
                             >
                                 <Routes>
+                                    <Route path='/' element={<Navigate to='/applications' />} />
+
                                     <Route path='/login' element={<LoginScreen />} />
 
                                     <Route path='/backups/application/:applicationId/*' element={<BackupsScreen />} />
@@ -110,12 +99,7 @@ export const App = () => {
                                             <DieAndRestart />
                                         </LayoutWithSidebar>
                                     } />
-
-                                    {/* TODO Pav: remove custom RouteNotFound https://reactrouter.com/en/main/upgrading/v5#upgrade-to-react-router-v6 */}
-                                    {/* <RouteNotFound
-                                        redirectUrl='/applications'
-                                        auto={true}
-                                    /> */}
+                                    <Route path='*' element={<RouteNotFound redirectUrl='/applications' auto={true} />} />
                                 </Routes>
                             </SnackbarProvider>
                         </Box>

--- a/Source/SelfService/Web/admin/application/view.tsx
+++ b/Source/SelfService/Web/admin/application/view.tsx
@@ -24,6 +24,10 @@ export const View: React.FunctionComponent<any> = (props) => {
 
     const { customerId, applicationId } = useParams<ViewParams>();
 
+    if(!customerId || !applicationId) {
+        return null;
+    }
+
     const [loaded, setLoaded] = useState(false);
     const [fetchDataError, setFetchDataError] = useState(false);
     const [accessInfo, setAccessInfo] = useState({} as HttpResponseApplicationAccess);

--- a/Source/SelfService/Web/admin/application/view.tsx
+++ b/Source/SelfService/Web/admin/application/view.tsx
@@ -3,7 +3,7 @@
 
 import React, { useEffect, useState } from 'react';
 
-import { useParams, useHistory } from 'react-router-dom';
+import { useParams, useNavigate } from 'react-router-dom';
 
 import { useSnackbar } from 'notistack';
 
@@ -19,7 +19,7 @@ type ViewParams = {
 };
 
 export const View: React.FunctionComponent<any> = (props) => {
-    const history = useHistory();
+    const navigate = useNavigate();
     const { enqueueSnackbar } = useSnackbar();
 
     const { customerId, applicationId } = useParams<ViewParams>();
@@ -56,7 +56,7 @@ export const View: React.FunctionComponent<any> = (props) => {
                 <p>Failed to fetch data</p>
                 <ButtonText onClick={async () => {
                     const href = `/admin/customers`;
-                    history.push(href);
+                    navigate(href);
                 }}>Back to customers</ButtonText>
             </>
         );
@@ -109,7 +109,7 @@ export const View: React.FunctionComponent<any> = (props) => {
             <Typography variant='h1' my={2}>Customer {customer.name}</Typography>
             <ButtonText onClick={async () => {
                 const href = `/admin/customer/${customerId}`;
-                history.push(href);
+                navigate(href);
             }}>Back to customer</ButtonText>
 
 

--- a/Source/SelfService/Web/application/applicationsChanger.tsx
+++ b/Source/SelfService/Web/application/applicationsChanger.tsx
@@ -91,8 +91,13 @@ export const ApplicationsChanger: React.FunctionComponent<Props> = (props) => {
         // TODO: We just slap on any search querystring here, so it will be reused after the environment switch. We might want to do this more properly later?
         // Like sending in extra params to this changer perhaps?
         // This was done mainly to support keeping the filters in the LogsScreen.tsx.
-        const href = uriWithoutBasePathPrefix(`${parts[0]}/${newApplication}${parts[1]}${location.search}`);
-        navigate(href);
+        const href = `${parts[0]}/${newApplication}${parts[1]}${location.search}`;
+
+        // TODO: We need to force a page reload here because the store does not differentiate microservices across environments.
+        // This means that all "dev" microservices will be shown as the user browses across applications.
+        // const href = uriWithoutBasePathPrefix(`${parts[0]}/${newApplication}${parts[1]}${location.search}`);
+        // navigate(href); // TODO: Make the app support this instead of a page reload.
+        window.location.href = href;
     };
 
     // TODO How can we fix the popper or the arrow to appear in the first menu item

--- a/Source/SelfService/Web/application/applicationsChanger.tsx
+++ b/Source/SelfService/Web/application/applicationsChanger.tsx
@@ -2,7 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 import React from 'react';
-import { useHistory } from 'react-router-dom';
+import { useNavigate, useLocation } from 'react-router-dom';
 import FormControl from '@mui/material/FormControl';
 import Select, { SelectChangeEvent } from '@mui/material/Select';
 import MenuItem from '@mui/material/MenuItem';
@@ -38,7 +38,8 @@ const styles = {
     } as SxProps,
 };
 export const ApplicationsChanger: React.FunctionComponent<Props> = (props) => {
-    const history = useHistory();
+    const navigate = useNavigate();
+    const location = useLocation();
     const { setCurrentApplicationId, setCurrentEnvironment } =
         useGlobalContext();
     const applications = props!.applications;
@@ -73,7 +74,7 @@ export const ApplicationsChanger: React.FunctionComponent<Props> = (props) => {
 
         if (newApplication === 'createNew') {
             const href = '/application/create';
-            history.push(href);
+            navigate(href);
             return;
         }
 
@@ -89,7 +90,7 @@ export const ApplicationsChanger: React.FunctionComponent<Props> = (props) => {
         // TODO: We just slap on any search querystring here, so it will be reused after the environment switch. We might want to do this more properly later?
         // Like sending in extra params to this changer perhaps?
         // This was done mainly to support keeping the filters in the LogsScreen.tsx.
-        const href = `${parts[0]}/${newApplication}${parts[1]}${history.location.search}`;
+        const href = `${parts[0]}/${newApplication}${parts[1]}${location.search}`;
 
         // We use window here, as its a hack to get around the selfservice being duplicated
         window.location.href = href;

--- a/Source/SelfService/Web/application/applicationsChanger.tsx
+++ b/Source/SelfService/Web/application/applicationsChanger.tsx
@@ -92,8 +92,7 @@ export const ApplicationsChanger: React.FunctionComponent<Props> = (props) => {
         // This was done mainly to support keeping the filters in the LogsScreen.tsx.
         const href = `${parts[0]}/${newApplication}${parts[1]}${location.search}`;
 
-        // We use window here, as its a hack to get around the selfservice being duplicated
-        window.location.href = href;
+        navigate(href);
     };
 
     // TODO How can we fix the popper or the arrow to appear in the first menu item

--- a/Source/SelfService/Web/application/applicationsChanger.tsx
+++ b/Source/SelfService/Web/application/applicationsChanger.tsx
@@ -12,6 +12,7 @@ import { SxProps } from '@mui/material';
 
 import { ShortInfoWithEnvironment } from '../api/api';
 import { useGlobalContext } from '../stores/notifications';
+import { uriWithoutBasePathPrefix } from '../store';
 
 type Props = {
     applications: ShortInfoWithEnvironment[];
@@ -90,8 +91,7 @@ export const ApplicationsChanger: React.FunctionComponent<Props> = (props) => {
         // TODO: We just slap on any search querystring here, so it will be reused after the environment switch. We might want to do this more properly later?
         // Like sending in extra params to this changer perhaps?
         // This was done mainly to support keeping the filters in the LogsScreen.tsx.
-        const href = `${parts[0]}/${newApplication}${parts[1]}${location.search}`;
-
+        const href = uriWithoutBasePathPrefix(`${parts[0]}/${newApplication}${parts[1]}${location.search}`);
         navigate(href);
     };
 

--- a/Source/SelfService/Web/application/building.tsx
+++ b/Source/SelfService/Web/application/building.tsx
@@ -2,7 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 import React, { useEffect, useState } from 'react';
-import { useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 
 import { isApplicationOnline } from '../api/application';
 
@@ -12,9 +12,10 @@ import { ArrowBack } from '@mui/icons-material';
 import { AlertBox, AlertBoxErrorMessage, Button, LoadingSpinner } from '@dolittle/design-system';
 
 export const Building = () => {
+    const navigate = useNavigate();
     const { applicationId } = useParams() as any;
 
-    const [isLoading, setIsLoadig] = useState(false);
+    const [isLoading, setIsLoading] = useState(false);
 
     useEffect(() => {
         checkApplicationStatus()
@@ -25,8 +26,8 @@ export const Building = () => {
         const result = await isApplicationOnline(applicationId);
 
         if (result.status === 200) {
-            window.location.href = `/applications/`;
-            setIsLoadig(true);
+            navigate(`/applications/`);
+            setIsLoading(true);
         }
     };
 

--- a/Source/SelfService/Web/application/building.tsx
+++ b/Source/SelfService/Web/application/building.tsx
@@ -9,7 +9,8 @@ import { isApplicationOnline } from '../api/application';
 import { Box, List, ListItem, Typography } from '@mui/material';
 import { ArrowBack } from '@mui/icons-material';
 
-import { AlertBox, AlertBoxErrorMessage, Button, LoadingSpinner } from '@dolittle/design-system';
+import { AlertBox, AlertBoxErrorMessage, LoadingSpinner } from '@dolittle/design-system';
+import { ButtonLink } from '../components/buttonLink';
 
 export const Building = () => {
     const navigate = useNavigate();
@@ -35,7 +36,13 @@ export const Building = () => {
         return (
             <Box sx={{ width: 1 }}>
                 <AlertBox title='Could not create application' message={<AlertBoxErrorMessage />} severity='error' />
-                <Button label='Go back to applications page' color='subtle' startWithIcon={<ArrowBack />} href='/applications/' sx={{ mt: 4 }} />
+                <ButtonLink
+                    label='Go back to applications page'
+                    color='subtle'
+                    startWithIcon={<ArrowBack />}
+                    sx={{ mt: 4 }}
+                    href='/applications'
+                />
             </Box>
         );
     };

--- a/Source/SelfService/Web/application/create/actionButtons.tsx
+++ b/Source/SelfService/Web/application/create/actionButtons.tsx
@@ -3,10 +3,16 @@
 
 import React from 'react';
 
+import { useHref } from 'react-router-dom';
 import { Button } from '@dolittle/design-system';
 
-export const ActionButtons = () =>
-    <>
-        <Button label='Cancel' color='subtle' href='/applications' sx={{ mr: 8 }} />
-        <Button label='Create' type='submit' />
-    </>;
+export const ActionButtons = () => {
+    const applicationsHref = useHref('/applications/');
+
+    return (
+        <>
+            <Button label='Cancel' color='subtle' href={applicationsHref} sx={{ mr: 8 }} />
+            <Button label='Create' type='submit' />
+        </>
+    );
+};

--- a/Source/SelfService/Web/application/create/create.tsx
+++ b/Source/SelfService/Web/application/create/create.tsx
@@ -2,7 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 import React, { useState } from 'react';
-import { useHistory } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 
 import { Typography } from '@mui/material';
 
@@ -29,7 +29,7 @@ type CreateApplicationParameters = {
 };
 
 export const Create = () => {
-    const history = useHistory();
+    const navigate = useNavigate();
 
     const [errorOnCreatingApp, setErrorOnCreatingApp] = useState(false);
     const [loading, setLoading] = useState(false);
@@ -58,7 +58,7 @@ export const Create = () => {
         try {
             await createApplication(request);
             const href = `/application/building/${request.id}`;
-            history.push(href);
+            navigate(href);
 
             setLoading(false);
             setErrorOnCreatingApp(false);

--- a/Source/SelfService/Web/backup/viewCard.tsx
+++ b/Source/SelfService/Web/backup/viewCard.tsx
@@ -2,7 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 import React from 'react';
-import { useHistory } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 
 import { CommandBar, ICommandBarItemProps } from '@fluentui/react/lib/CommandBar';
 import {
@@ -27,7 +27,7 @@ const conversationTileClass = mergeStyles({ height: 182, paddingLeft: 10 });
 
 
 export const ViewCard: React.FunctionComponent<Props> = (props) => {
-    const history = useHistory();
+    const navigate = useNavigate();
     const { setCurrentEnvironment, setCurrentApplicationId } = useGlobalContext();
     const _props = props!;
     const application = _props.application;
@@ -52,7 +52,7 @@ export const ViewCard: React.FunctionComponent<Props> = (props) => {
                 setCurrentApplicationId(application.id);
                 setCurrentEnvironment(environment);
                 const href = `/backups/application/${application.id}/${environment}/list`;
-                history.push(href);
+                navigate(href);
             }
         }
     ];

--- a/Source/SelfService/Web/components/breadCrumbWithRedirect.tsx
+++ b/Source/SelfService/Web/components/breadCrumbWithRedirect.tsx
@@ -3,7 +3,7 @@
 
 import React from 'react';
 
-import { useHistory } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 
 export type BreadcrumbWithRedirectProps = {
     url: string;
@@ -11,12 +11,12 @@ export type BreadcrumbWithRedirectProps = {
 };
 
 export const BreadcrumbWithRedirect: React.FunctionComponent<BreadcrumbWithRedirectProps> = (props) => {
-    const history = useHistory();
+    const navigate = useNavigate();
     return (
         <span onClick={(event: React.MouseEvent<HTMLElement>) => {
             event.stopPropagation();
             console.log('Redirect', props!.url);
-            history.push(props!.url);
+            navigate(props!.url);
         }}> {props!.name}</span >
     );
 };

--- a/Source/SelfService/Web/components/buttonLink.tsx
+++ b/Source/SelfService/Web/components/buttonLink.tsx
@@ -1,0 +1,22 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import React from 'react';
+import { Link as RouterLink } from 'react-router-dom';
+import { Button, ButtonProps } from '@dolittle/design-system';
+
+export type ButtonLinkProps = ButtonProps & {
+    href: string
+};
+
+export const ButtonLink = ({ href, ...props }: ButtonLinkProps) => {
+    return (
+        <Button
+            {...props}
+            overrides={{
+                to: href,
+                component: RouterLink,
+            }}
+        />
+    );
+};

--- a/Source/SelfService/Web/components/dieAndRestart.tsx
+++ b/Source/SelfService/Web/components/dieAndRestart.tsx
@@ -2,7 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 import React, { useEffect } from 'react';
-import { useHistory, Link as RouterLink } from 'react-router-dom';
+import { useNavigate, Link as RouterLink } from 'react-router-dom';
 import { Link, Box, Typography } from '@mui/material';
 import { useGlobalContext } from '../stores/notifications';
 

--- a/Source/SelfService/Web/components/notfound.tsx
+++ b/Source/SelfService/Web/components/notfound.tsx
@@ -2,7 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 import React from 'react';
-import { Route, useHistory, Link as RouterLink } from 'react-router-dom';
+import { Route, useNavigate, Link as RouterLink } from 'react-router-dom';
 import Link from '@mui/material/Link';
 import { Typography } from '@mui/material';
 
@@ -13,9 +13,9 @@ type Props = {
 };
 
 export const RouteNotFound: React.FunctionComponent<Props> = (props) => {
-    const history = useHistory();
+    const navigate = useNavigate();
     if (props!.auto) {
-        history.push(props!.redirectUrl);
+        navigate(props!.redirectUrl);
         return null;
     }
 

--- a/Source/SelfService/Web/components/notfound.tsx
+++ b/Source/SelfService/Web/components/notfound.tsx
@@ -2,32 +2,26 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 import React from 'react';
-import { Route, useNavigate, Link as RouterLink } from 'react-router-dom';
+import { Link as RouterLink, Navigate } from 'react-router-dom';
 import Link from '@mui/material/Link';
 import { Typography } from '@mui/material';
 
 
-type Props = {
+type RouteNotFoundProps = {
     redirectUrl: string
     auto?: boolean
 };
 
-export const RouteNotFound: React.FunctionComponent<Props> = (props) => {
-    const navigate = useNavigate();
-    if (props!.auto) {
-        navigate(props!.redirectUrl);
-        return null;
-    }
-
+export const RouteNotFound: React.FunctionComponent<RouteNotFoundProps> = (props) => {
     return (
         <>
-            <Route element={
-                <>
-                    <Typography variant='h1' my={2}>We are unable to find this link</Typography><Link component={RouterLink} to={props!.redirectUrl}>
-                        Link
-                    </Link>
+            {props.auto
+                ? <Navigate to={props.redirectUrl} replace={true} />
+                : <>
+                    <Typography variant='h1' my={2}>We are unable to find this link</Typography>
+                    <Link component={RouterLink} to={props.redirectUrl}>Link</Link>
                 </>
-            } />
+            }
         </>
     );
 };

--- a/Source/SelfService/Web/components/notfound.tsx
+++ b/Source/SelfService/Web/components/notfound.tsx
@@ -21,12 +21,13 @@ export const RouteNotFound: React.FunctionComponent<Props> = (props) => {
 
     return (
         <>
-            <Route>
-                <Typography variant='h1' my={2}>We are unable to find this link</Typography>
-                <Link component={RouterLink} to={props!.redirectUrl}>
-                    Link
-                </Link>
-            </Route>
+            <Route element={
+                <>
+                    <Typography variant='h1' my={2}>We are unable to find this link</Typography><Link component={RouterLink} to={props!.redirectUrl}>
+                        Link
+                    </Link>
+                </>
+            } />
         </>
     );
 };

--- a/Source/SelfService/Web/components/pickEnvironment.tsx
+++ b/Source/SelfService/Web/components/pickEnvironment.tsx
@@ -3,7 +3,7 @@
 import React from 'react';
 import Modal from '@mui/material/Modal';
 import { Box, Typography } from '@mui/material';
-import { useHistory, generatePath } from 'react-router-dom';
+import { useNavigate, generatePath } from 'react-router-dom';
 import { ShortInfoWithEnvironment } from '../api/api';
 import { HttpResponseApplication } from '../api/application';
 import { List } from '@fluentui/react/lib/List';
@@ -55,7 +55,7 @@ export const isEnvironmentValidFromUri = (applications: ShortInfoWithEnvironment
 
 export const PickEnvironment: React.FunctionComponent<Props> = (props) => {
     const { setCurrentEnvironment, setCurrentApplicationId } = useGlobalContext();
-    const history = useHistory();
+    const navigate = useNavigate();
     const _props = props!;
     const application = _props.application;
 
@@ -86,7 +86,7 @@ export const PickEnvironment: React.FunctionComponent<Props> = (props) => {
                 setCurrentEnvironment(application.environment);
                 setCurrentApplicationId(application.id);
                 handleClose();
-                history.push(href);
+                navigate(href);
             }}
                 underline>
                 {application.name} {application.environment}

--- a/Source/SelfService/Web/containerregistry/container.tsx
+++ b/Source/SelfService/Web/containerregistry/container.tsx
@@ -67,7 +67,7 @@ export const ContainerRegistryContainer: React.FunctionComponent<Props> = (props
 
                     <Route path="/welcome" element={<Welcome applicationId={applicationId} />} />
 
-                    <Route path="/tags/:image+" element={<Tags url={containerRegistryImages.url} applicationId={applicationId} />} />
+                    <Route path="/tags/:image" element={<Tags url={containerRegistryImages.url} applicationId={applicationId} />} />
                 </Routes>
             </div>
         </>

--- a/Source/SelfService/Web/containerregistry/container.tsx
+++ b/Source/SelfService/Web/containerregistry/container.tsx
@@ -2,7 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 import React, { useEffect, useState } from 'react';
-import { useHistory, Routes, Route } from 'react-router-dom';
+import { useNavigate, Routes, Route } from 'react-router-dom';
 import { HttpResponseApplication } from '../api/application';
 
 import { View as Tags } from './tags';
@@ -18,7 +18,7 @@ type Props = {
 };
 
 export const ContainerRegistryContainer: React.FunctionComponent<Props> = (props) => {
-    const history = useHistory();
+    const navigate = useNavigate();
     const _props = props!;
     const application = _props.application;
     const applicationId = application.id;
@@ -51,7 +51,7 @@ export const ContainerRegistryContainer: React.FunctionComponent<Props> = (props
     // Force redirect if no images to the welcome screen
     if (!hasImages && !window.location.pathname.endsWith('/overview/welcome')) {
         const href = `/containerregistry/application/${applicationId}/${environment}/overview/welcome`;
-        history.push(href);
+        navigate(href);
         return null;
     }
 

--- a/Source/SelfService/Web/containerregistry/container.tsx
+++ b/Source/SelfService/Web/containerregistry/container.tsx
@@ -63,16 +63,11 @@ export const ContainerRegistryContainer: React.FunctionComponent<Props> = (props
 
             <div>
                 <Routes>
-                    <Route exact path="/containerregistry/application/:applicationId/:environment/overview/welcome" >
-                        <Welcome applicationId={applicationId} />
-                    </Route>
+                    <Route path="/" element={<Images applicationId={applicationId} environment={environment} data={containerRegistryImages} />} />
 
-                    <Route exact path="/containerregistry/application/:applicationId/:environment/overview" >
-                        <Images applicationId={applicationId} environment={environment} data={containerRegistryImages} />
-                    </Route>
-                    <Route path="/containerregistry/application/:applicationId/:environment/overview/tags/:image+">
-                        <Tags url={containerRegistryImages.url} applicationId={applicationId} />
-                    </Route>
+                    <Route path="/welcome" element={<Welcome applicationId={applicationId} />} />
+
+                    <Route path="/tags/:image+" element={<Tags url={containerRegistryImages.url} applicationId={applicationId} />} />
                 </Routes>
             </div>
         </>

--- a/Source/SelfService/Web/containerregistry/container.tsx
+++ b/Source/SelfService/Web/containerregistry/container.tsx
@@ -2,7 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 import React, { useEffect, useState } from 'react';
-import { useHistory, Switch, Route } from 'react-router-dom';
+import { useHistory, Routes, Route } from 'react-router-dom';
 import { HttpResponseApplication } from '../api/application';
 
 import { View as Tags } from './tags';
@@ -62,7 +62,7 @@ export const ContainerRegistryContainer: React.FunctionComponent<Props> = (props
             </div>
 
             <div>
-                <Switch>
+                <Routes>
                     <Route exact path="/containerregistry/application/:applicationId/:environment/overview/welcome" >
                         <Welcome applicationId={applicationId} />
                     </Route>
@@ -73,7 +73,7 @@ export const ContainerRegistryContainer: React.FunctionComponent<Props> = (props
                     <Route path="/containerregistry/application/:applicationId/:environment/overview/tags/:image+">
                         <Tags url={containerRegistryImages.url} applicationId={applicationId} />
                     </Route>
-                </Switch>
+                </Routes>
             </div>
         </>
     );

--- a/Source/SelfService/Web/containerregistry/images.tsx
+++ b/Source/SelfService/Web/containerregistry/images.tsx
@@ -2,7 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 import React from 'react';
-import { useHistory } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 
 import {
     Table, TableContainer, TableHead,
@@ -19,7 +19,7 @@ type Props = {
 };
 
 export const View: React.FunctionComponent<Props> = (props) => {
-    const history = useHistory();
+    const navigate = useNavigate();
     const _props = props!;
     const containerRegistryImages = _props.data;
     const applicationId = _props.applicationId;
@@ -44,7 +44,7 @@ export const View: React.FunctionComponent<Props> = (props) => {
                                     onClick={(event) => {
                                         event.preventDefault();
                                         const href = `/containerregistry/application/${applicationId}/${environment}/overview/tags/${row.name}`;
-                                        history.push(href);
+                                        navigate(href);
                                     }}
                                     sx={{
                                         '&:hover': {

--- a/Source/SelfService/Web/containerregistry/tags.tsx
+++ b/Source/SelfService/Web/containerregistry/tags.tsx
@@ -23,6 +23,11 @@ type ViewParams = {
 export const View: React.FunctionComponent<Props> = (props) => {
     const _props = props!;
     const { image } = useParams<ViewParams>();
+
+    if(!image) {
+        return null;
+    }
+
     const applicationId = _props.applicationId;
 
     const [loaded, setLoaded] = useState(false);

--- a/Source/SelfService/Web/customer/create.tsx
+++ b/Source/SelfService/Web/customer/create.tsx
@@ -2,7 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 import React from 'react';
-import { useHistory } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 
 import { useSnackbar } from 'notistack';
 
@@ -53,7 +53,7 @@ const styles = {
 
 
 export const Create = () => {
-    const history = useHistory();
+    const navigate = useNavigate();
     const { enqueueSnackbar } = useSnackbar();
 
     const steps = [
@@ -130,7 +130,7 @@ export const Create = () => {
                                             label='Back'
                                             onClick={() => {
                                                 const href = `/admin/customers`;
-                                                history.push(href);
+                                                navigate(href);
                                             }}
                                         />
 

--- a/Source/SelfService/Web/customer/view.tsx
+++ b/Source/SelfService/Web/customer/view.tsx
@@ -56,6 +56,10 @@ export const View: React.FunctionComponent<any> = (props) => {
     const { enqueueSnackbar } = useSnackbar();
 
     const { customerId } = useParams<ViewParams>();
+    if (!customerId) {
+        return null;
+    }
+
     //const [configLoaded, setConfigLoaded] = useState(false);
     const [customerLoaded, setCustomerLoaded] = useState(false);
     const [config, setConfig] = useState({} as Studio);

--- a/Source/SelfService/Web/customer/view.tsx
+++ b/Source/SelfService/Web/customer/view.tsx
@@ -2,7 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 import React, { useEffect, useState } from 'react';
-import { useParams, useHistory } from 'react-router-dom';
+import { useParams, useNavigate } from 'react-router-dom';
 
 import { useSnackbar } from 'notistack';
 import { getCustomer, CustomerDetailed } from '../api/customer';
@@ -52,7 +52,7 @@ type ViewParams = {
 };
 
 export const View: React.FunctionComponent<any> = (props) => {
-    const history = useHistory();
+    const navigate = useNavigate();
     const { enqueueSnackbar } = useSnackbar();
 
     const { customerId } = useParams<ViewParams>();
@@ -155,7 +155,7 @@ export const View: React.FunctionComponent<any> = (props) => {
                             <ButtonText
                                 onClick={() => {
                                     const href = `/admin/customer/${customerId}/application/${application.id}/user/access`;
-                                    history.push(href);
+                                    navigate(href);
                                 }}
                             >
                                 View Access

--- a/Source/SelfService/Web/customer/viewAll.tsx
+++ b/Source/SelfService/Web/customer/viewAll.tsx
@@ -5,7 +5,7 @@ import React, {
     useEffect,
     useState
 } from 'react';
-import { useHistory } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { useSnackbar } from 'notistack';
 import { getCustomers, Customers } from '../api/customer';
 import { ButtonText } from '../theme/buttonText';
@@ -17,7 +17,7 @@ type Props = {
 };
 
 export const ViewAll: React.FunctionComponent<Props> = (props) => {
-    const history = useHistory();
+    const navigate = useNavigate();
     const { enqueueSnackbar } = useSnackbar();
 
     const [loaded, setLoaded] = useState(false);
@@ -44,7 +44,7 @@ export const ViewAll: React.FunctionComponent<Props> = (props) => {
             <ButtonText
                 onClick={() => {
                     const href = `/admin/customer/create`;
-                    history.push(href);
+                    navigate(href);
                 }}>
                 Create new Customer
             </ButtonText>
@@ -58,7 +58,7 @@ export const ViewAll: React.FunctionComponent<Props> = (props) => {
                         <ButtonText
                             onClick={() => {
                                 const href = `/admin/customer/${customer.id}`;
-                                history.push(href);
+                                navigate(href);
                             }}
                         >
                             {customer.name} ({customer.id})

--- a/Source/SelfService/Web/documentation/container.tsx
+++ b/Source/SelfService/Web/documentation/container.tsx
@@ -58,13 +58,13 @@ export const DocumentationContainerScreen: React.FunctionComponent<Props> = (pro
 
 
                 <Routes>
-                    <Route exact path="/documentation/application/:applicationId/:environment/overview" >
+                    <Route path="/overview" element={
                         <ul >
                             <li>
                                 <a href="#" onClick={(event) => {
                                     event.preventDefault();
                                     const href = `/documentation/application/${applicationId}/${environment}/container-registry-info`;
-                                    history.push(href);
+                                    navigate(href);
                                 }}>
                                     Container Registry Info
                                 </a>
@@ -73,7 +73,7 @@ export const DocumentationContainerScreen: React.FunctionComponent<Props> = (pro
                                 <a href="#" onClick={(event) => {
                                     event.preventDefault();
                                     const href = `/documentation/application/${applicationId}/${environment}/verify-kubernetes-access`;
-                                    history.push(href);
+                                    navigate(href);
                                 }}>
                                     Verify access to kubernetes
                                 </a>
@@ -82,50 +82,48 @@ export const DocumentationContainerScreen: React.FunctionComponent<Props> = (pro
                                 <a href="#" onClick={(event) => {
                                     event.preventDefault();
                                     const href = `/documentation/application/${applicationId}/${environment}/ci-cd/azure-pipelines`;
-                                    history.push(href);
+                                    navigate(href);
                                 }}>
                                     Setup Azure Pipelines
                                 </a>
                             </li>
                         </ul>
-                    </Route>
+                    } />
 
-                    <Route exact path="/documentation/application/:applicationId/:environment/container-registry-info">
-                        <Link onClick={() => {
-                            const href = `/documentation/application/${applicationId}/${environment}/overview`;
-                            history.push(href);
-                        }}>
-                            Back
-                        </Link>
-                        <Typography variant='h1' my={2}>Container Registry Info</Typography>
-                        <AccessContainerRegistry info={$info} />
-                    </Route>
+                    <Route path="/container-registry-info" element={
+                        <>
+                            <Link onClick={() => {
+                                const href = `/documentation/application/${applicationId}/${environment}/overview`;
+                                navigate(href);
+                            }}>
+                                Back
+                            </Link><Typography variant='h1' my={2}>Container Registry Info</Typography><AccessContainerRegistry info={$info} />
+                        </>
+                    } />
 
-                    <Route exact path="/documentation/application/:applicationId/:environment/verify-kubernetes-access">
-                        <Link onClick={() => {
-                            const href = `/documentation/application/${applicationId}/${environment}/overview`;
-                            history.push(href);
-                        }}>
-                            Back
-                        </Link>
-                        <Typography variant='h1' my={2}>Verify access to kubernetes</Typography>
-                        <VerifyKubernetesAccess info={$info} environment={environment} />
-                    </Route>
+                    <Route path="/verify-kubernetes-access" element={
+                        <>
+                            <Link onClick={() => {
+                                const href = `/documentation/application/${applicationId}/${environment}/overview`;
+                                navigate(href);
+                            }}>
+                                Back
+                            </Link><Typography variant='h1' my={2}>Verify access to kubernetes</Typography><VerifyKubernetesAccess info={$info} environment={environment} />
+                        </>
+                    } />
 
-                    <Route exact path="/documentation/application/:applicationId/:environment/ci-cd/azure-pipelines">
-                        <Link onClick={() => {
-                            const href = `/documentation/application/${applicationId}/${environment}/overview`;
-                            history.push(href);
-                        }}>
-                            Back
-                        </Link>
-                        <Typography variant='h1' my={2}>Setup Azure Pipelines</Typography>
-                        <SetupAzurePipelines info={$info} />
-                    </Route>
+                    <Route path="/ci-cd/azure-pipelines" element={
+                        <>
+                            <Link onClick={() => {
+                                const href = `/documentation/application/${applicationId}/${environment}/overview`;
+                                navigate(href);
+                            }}>
+                                Back
+                            </Link><Typography variant='h1' my={2}>Setup Azure Pipelines</Typography><SetupAzurePipelines info={$info} />
+                        </>
+                    } />
 
-                    <Route>
-                        <Typography variant='h1' my={2}>Something has gone wrong: documentation</Typography>
-                    </Route>
+                    <Route element={<Typography variant='h1' my={2}>Something has gone wrong: documentation</Typography>} />
                 </Routes>
             </div>
         </>

--- a/Source/SelfService/Web/documentation/container.tsx
+++ b/Source/SelfService/Web/documentation/container.tsx
@@ -14,6 +14,7 @@ import { Doc as VerifyKubernetesAccess } from './verifyKubernetesAccess';
 import { Doc as AccessContainerRegistry } from './accessContainerRegistry';
 import { Doc as SetupAzurePipelines } from './cicd/setupAzurePipelines';
 import { Typography } from '@mui/material';
+import { RouteNotFound } from '../components/notfound';
 
 type Props = {
     environment: string
@@ -124,6 +125,8 @@ export const DocumentationContainerScreen: React.FunctionComponent<Props> = (pro
                     } />
 
                     <Route element={<Typography variant='h1' my={2}>Something has gone wrong: documentation</Typography>} />
+
+                    <Route path='*' element={<RouteNotFound redirectUrl='overview' auto={true} />} />
                 </Routes>
             </div>
         </>

--- a/Source/SelfService/Web/documentation/container.tsx
+++ b/Source/SelfService/Web/documentation/container.tsx
@@ -2,7 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 import React, { useEffect, useState } from 'react';
-import { Route, useHistory, Switch } from 'react-router-dom';
+import { Route, useHistory, Routes } from 'react-router-dom';
 import { Link } from '@fluentui/react';
 import { HttpResponseApplication } from '../api/application';
 
@@ -57,7 +57,7 @@ export const DocumentationContainerScreen: React.FunctionComponent<Props> = (pro
             <div className="documentation">
 
 
-                <Switch>
+                <Routes>
                     <Route exact path="/documentation/application/:applicationId/:environment/overview" >
                         <ul >
                             <li>
@@ -126,7 +126,7 @@ export const DocumentationContainerScreen: React.FunctionComponent<Props> = (pro
                     <Route>
                         <Typography variant='h1' my={2}>Something has gone wrong: documentation</Typography>
                     </Route>
-                </Switch>
+                </Routes>
             </div>
         </>
     );

--- a/Source/SelfService/Web/documentation/container.tsx
+++ b/Source/SelfService/Web/documentation/container.tsx
@@ -2,7 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 import React, { useEffect, useState } from 'react';
-import { Route, useHistory, Routes } from 'react-router-dom';
+import { Route, useNavigate, Routes } from 'react-router-dom';
 import { Link } from '@fluentui/react';
 import { HttpResponseApplication } from '../api/application';
 
@@ -21,7 +21,7 @@ type Props = {
 };
 
 export const DocumentationContainerScreen: React.FunctionComponent<Props> = (props) => {
-    const history = useHistory();
+    const navigate = useNavigate();
     const _props = props!;
     const application = _props.application;
     const applicationId = application.id;

--- a/Source/SelfService/Web/index.tsx
+++ b/Source/SelfService/Web/index.tsx
@@ -8,12 +8,18 @@ import { QueryParamProvider } from 'use-query-params';
 import { ReactRouter6Adapter } from 'use-query-params/adapters/react-router-6';
 
 import { App } from './App';
-import { uriWithAppPrefix } from './store';
+import { uriWithBasePathPrefix } from './store';
+
+// Little hack to force redirect on localhost
+// can be removed if we move away from basePath
+if (['', '/'].includes(window.location.pathname)) {
+    window.location.href = uriWithBasePathPrefix('/');
+};
 
 const container = document.getElementById('root');
 const root = createRoot(container!);
 root.render(
-    <BrowserRouter basename={uriWithAppPrefix('')} >
+    <BrowserRouter basename={uriWithBasePathPrefix('')} >
         <QueryParamProvider adapter={ReactRouter6Adapter}>
             <App />
         </QueryParamProvider>

--- a/Source/SelfService/Web/index.tsx
+++ b/Source/SelfService/Web/index.tsx
@@ -10,12 +10,6 @@ import { ReactRouter6Adapter } from 'use-query-params/adapters/react-router-6';
 import { App } from './App';
 import { uriWithBasePathPrefix } from './store';
 
-// Little hack to force redirect on localhost
-// can be removed if we move away from basePath
-if (['', '/'].includes(window.location.pathname)) {
-    window.location.href = uriWithBasePathPrefix('/');
-};
-
 const container = document.getElementById('root');
 const root = createRoot(container!);
 root.render(

--- a/Source/SelfService/Web/index.tsx
+++ b/Source/SelfService/Web/index.tsx
@@ -4,13 +4,18 @@
 import React from 'react';
 import { createRoot } from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
+import { QueryParamProvider } from 'use-query-params';
+import { ReactRouter6Adapter } from 'use-query-params/adapters/react-router-6';
 
 import { App } from './App';
+import { uriWithAppPrefix } from './store';
 
 const container = document.getElementById('root');
 const root = createRoot(container!);
 root.render(
-    <BrowserRouter>
-        <App />
+    <BrowserRouter basename={uriWithAppPrefix('')} >
+        <QueryParamProvider adapter={ReactRouter6Adapter}>
+            <App />
+        </QueryParamProvider>
     </BrowserRouter>
 );

--- a/Source/SelfService/Web/layout/breadcrumbs.tsx
+++ b/Source/SelfService/Web/layout/breadcrumbs.tsx
@@ -2,7 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 import React from 'react';
-import { useNavigate, useMatch } from 'react-router-dom';
+import { useNavigate, useMatch, Link as RouterLink } from 'react-router-dom';
 
 import { Link, Breadcrumbs, Stack } from '@mui/material';
 import { ChevronRight } from '@mui/icons-material';
@@ -26,20 +26,17 @@ type Props = {
 };
 
 export const BreadCrumbContainer = (props: Props) => {
-    const navigate = useNavigate();
 
-    const crumbs = props!.routes.filter((route) => useMatch(route.path) ? route : false);
+    const crumbs = props!.routes.filter((route) => useMatch({path: route.path, end: false}) ? route : false);
 
     const breadcrumbs = crumbs.map((item, index) => {
         const links = [
             <Link
+                component={RouterLink}
                 key={index}
-                href={item.to}
+                to={item.to}
                 sx={styles}
-                onClick={(event: React.MouseEvent<HTMLAnchorElement>) => {
-                    event.preventDefault();
-                    navigate(item.to);
-                }}>
+            >
                 {item.name}
             </Link >
         ];

--- a/Source/SelfService/Web/layout/breadcrumbs.tsx
+++ b/Source/SelfService/Web/layout/breadcrumbs.tsx
@@ -2,7 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 import React from 'react';
-import { useNavigate, useRouteMatch } from 'react-router-dom';
+import { useNavigate, useMatch } from 'react-router-dom';
 
 import { Link, Breadcrumbs, Stack } from '@mui/material';
 import { ChevronRight } from '@mui/icons-material';
@@ -28,7 +28,7 @@ type Props = {
 export const BreadCrumbContainer = (props: Props) => {
     const navigate = useNavigate();
 
-    const crumbs = props!.routes.filter((route) => useRouteMatch(route.path) ? route : false);
+    const crumbs = props!.routes.filter((route) => useMatch(route.path) ? route : false);
 
     const breadcrumbs = crumbs.map((item, index) => {
         const links = [

--- a/Source/SelfService/Web/layout/breadcrumbs.tsx
+++ b/Source/SelfService/Web/layout/breadcrumbs.tsx
@@ -2,7 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 import React from 'react';
-import { useHistory, useRouteMatch } from 'react-router-dom';
+import { useNavigate, useRouteMatch } from 'react-router-dom';
 
 import { Link, Breadcrumbs, Stack } from '@mui/material';
 import { ChevronRight } from '@mui/icons-material';
@@ -26,7 +26,7 @@ type Props = {
 };
 
 export const BreadCrumbContainer = (props: Props) => {
-    const history = useHistory();
+    const navigate = useNavigate();
 
     const crumbs = props!.routes.filter((route) => useRouteMatch(route.path) ? route : false);
 
@@ -38,7 +38,7 @@ export const BreadCrumbContainer = (props: Props) => {
                 sx={styles}
                 onClick={(event: React.MouseEvent<HTMLAnchorElement>) => {
                     event.preventDefault();
-                    history.push(item.to);
+                    navigate(item.to);
                 }}>
                 {item.name}
             </Link >

--- a/Source/SelfService/Web/layout/layoutWithSidebar.tsx
+++ b/Source/SelfService/Web/layout/layoutWithSidebar.tsx
@@ -103,7 +103,7 @@ export const NavigationListItemButton = ({ navigationMenuItem, navigate, ...prop
         />);
 };
 
-export const getMenuWithApplication = (history: NavigateFunction, application: HttpResponseApplication, environment: string): ReactNode => {
+export const getMenuWithApplication = (navigate: NavigateFunction, application: HttpResponseApplication, environment: string): ReactNode => {
     const applicationId = application.id;
 
     const hasConnector = application.environments.find(_environment => _environment.connections.m3Connector);
@@ -154,5 +154,5 @@ export const getMenuWithApplication = (history: NavigateFunction, application: H
         });
     }
 
-    return getDefaultMenuWithItems(history, mainNavigationItems, secondaryNavigationItems);
+    return getDefaultMenuWithItems(navigate, mainNavigationItems, secondaryNavigationItems);
 };

--- a/Source/SelfService/Web/layout/layoutWithSidebar.tsx
+++ b/Source/SelfService/Web/layout/layoutWithSidebar.tsx
@@ -2,9 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 import React, { ReactNode } from 'react';
-import { History, LocationState } from 'history';
-
 import './layout.scss';
+import { NavigateFunction } from 'react-router-dom';
 
 import { HttpResponseApplication } from '../api/application';
 
@@ -29,7 +28,8 @@ export type NavigationMenuItem = {
 };
 
 export type NavigationListItemButtonProps = ListItemButtonBaseProps & {
-    navigationMenuItem: NavigationMenuItem, history: History<LocationState>
+    navigationMenuItem: NavigationMenuItem,
+    navigate: NavigateFunction //TODO PAV: Does this still need to be passed in, or can it use a hook to resolve?
 };
 
 export const LayoutWithSidebar = ({ navigation, children }: LayoutWithSidebarProps) =>
@@ -46,14 +46,14 @@ export const LayoutWithSidebar = ({ navigation, children }: LayoutWithSidebarPro
         </div>
     </div>;
 
-export const getDefaultMenuWithItems = (history: History<LocationState>, mainNavigationItems: any[], secondaryNavigationItems: any[]): ReactNode =>
+export const getDefaultMenuWithItems = (navigate: NavigateFunction, mainNavigationItems: any[], secondaryNavigationItems: any[]): ReactNode =>
     <>
         <List sx={{ p: 0, m: 0 }}>
             {mainNavigationItems.map(navigationItem => (
                 <NavigationListItemButton
                     key={navigationItem.name}
                     navigationMenuItem={navigationItem}
-                    history={history}
+                    navigate={navigate}
                 >
                     <ListItemIcon sx={{ mr: '1rem', minWidth: 0, color: 'text.secondary' }}>
                         {navigationItem.icon}
@@ -66,7 +66,7 @@ export const getDefaultMenuWithItems = (history: History<LocationState>, mainNav
         </List>
         <List sx={{ p: 0, m: 0, position: 'fixed', bottom: 0 }}>
             {secondaryNavigationItems.map(link => (
-                <NavigationListItemButton key={link.name} navigationMenuItem={link} history={history}>
+                <NavigationListItemButton key={link.name} navigationMenuItem={link} navigate={navigate}>
                     <ListItemIcon sx={{ mr: '1rem', minWidth: 0, color: 'text.secondary' }}>
                         {link.icon}
                     </ListItemIcon>
@@ -78,7 +78,7 @@ export const getDefaultMenuWithItems = (history: History<LocationState>, mainNav
         </List>
     </>;
 
-export const NavigationListItemButton = ({ navigationMenuItem, history, ...props }: NavigationListItemButtonProps) => {
+export const NavigationListItemButton = ({ navigationMenuItem, navigate, ...props }: NavigationListItemButtonProps) => {
     const defaultProps: ListItemButtonBaseProps = {
         disableGutters: true,
         selected: window.location.href.includes(navigationMenuItem.href),
@@ -97,13 +97,13 @@ export const NavigationListItemButton = ({ navigationMenuItem, history, ...props
             onClick={event => {
                 event.preventDefault();
                 const href = navigationMenuItem.href;
-                navigationMenuItem.forceReload ? window.location.href = href : history.push(href);
+                navigationMenuItem.forceReload ? window.location.href = href : navigate(href);
             }}
             {...props}
         />);
 };
 
-export const getMenuWithApplication = (history: History<LocationState>, application: HttpResponseApplication, environment: string): ReactNode => {
+export const getMenuWithApplication = (history: NavigateFunction, application: HttpResponseApplication, environment: string): ReactNode => {
     const applicationId = application.id;
 
     const hasConnector = application.environments.find(_environment => _environment.connections.m3Connector);

--- a/Source/SelfService/Web/m3connector/container.tsx
+++ b/Source/SelfService/Web/m3connector/container.tsx
@@ -16,19 +16,15 @@ type ContainerProps = {
     application: HttpResponseApplication;
 };
 
+// TODO PAV: Is this component even needed? Can this be moved to the parent component directly?
 export const Container = ({ application }: ContainerProps) =>
     <>
         <Typography variant='h1' my={2}>M3 Connector</Typography>
         <Routes>
-            <Route exact path="/m3connector/application/:applicationId/overview">
-                <Overview application={application} />
-            </Route>
-            <Route exact path="/m3connector/application/:applicationId/:environment/setup">
-                <Setup application={application} />
-            </Route>
+            <Route path="/overview" element={<Overview application={application} />} />
 
-            <Route exact path="/m3connector/application/:applicationId/:environment/details">
-                <Details applicationId={application.id} />
-            </Route>
+            <Route path="/setup" element={<Setup application={application} />} />
+
+            <Route path="/details" element={<Details applicationId={application.id} />} />
         </Routes>
     </>;

--- a/Source/SelfService/Web/m3connector/container.tsx
+++ b/Source/SelfService/Web/m3connector/container.tsx
@@ -23,8 +23,8 @@ export const Container = ({ application }: ContainerProps) =>
         <Routes>
             <Route path="/overview" element={<Overview application={application} />} />
 
-            <Route path="/setup" element={<Setup application={application} />} />
+            <Route path="/:environment/setup" element={<Setup application={application} />} />
 
-            <Route path="/details" element={<Details applicationId={application.id} />} />
+            <Route path="/:environment/details" element={<Details applicationId={application.id} />} />
         </Routes>
     </>;

--- a/Source/SelfService/Web/m3connector/container.tsx
+++ b/Source/SelfService/Web/m3connector/container.tsx
@@ -3,7 +3,7 @@
 
 import React from 'react';
 
-import { Switch, Route } from 'react-router-dom';
+import { Routes, Route } from 'react-router-dom';
 import { HttpResponseApplication } from '../api/application';
 
 import { View as Overview } from './overview';
@@ -19,7 +19,7 @@ type ContainerProps = {
 export const Container = ({ application }: ContainerProps) =>
     <>
         <Typography variant='h1' my={2}>M3 Connector</Typography>
-        <Switch>
+        <Routes>
             <Route exact path="/m3connector/application/:applicationId/overview">
                 <Overview application={application} />
             </Route>
@@ -30,5 +30,5 @@ export const Container = ({ application }: ContainerProps) =>
             <Route exact path="/m3connector/application/:applicationId/:environment/details">
                 <Details applicationId={application.id} />
             </Route>
-        </Switch>
+        </Routes>
     </>;

--- a/Source/SelfService/Web/m3connector/details.tsx
+++ b/Source/SelfService/Web/m3connector/details.tsx
@@ -19,6 +19,9 @@ export const View: React.FunctionComponent<Props> = (props) => {
     const _props = props!;
     const applicationId = _props.applicationId;
     const { environment } = useParams<ViewParams>();
+    if(!environment){
+        return null;
+    }
 
     const [loaded, setLoaded] = useState(false);
     const [data, setData] = useState({} as M3ConnectorData);

--- a/Source/SelfService/Web/m3connector/overview.tsx
+++ b/Source/SelfService/Web/m3connector/overview.tsx
@@ -3,7 +3,7 @@
 
 import React from 'react';
 import { HttpResponseApplication } from '../api/application';
-import { useHistory } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { ButtonText } from '../theme/buttonText';
 import { Typography } from '@mui/material';
 
@@ -17,7 +17,7 @@ type EnvironmentInfo = {
 };
 
 export const View: React.FunctionComponent<Props> = (props) => {
-    const history = useHistory();
+    const navigate = useNavigate();
     const _props = props!;
     const application = _props.application;
     const applicationId = application.id;
@@ -41,7 +41,7 @@ export const View: React.FunctionComponent<Props> = (props) => {
                         const href = row.connected ?
                             `/m3connector/application/${applicationId}/${environment}/details` :
                             `/m3connector/application/${applicationId}/${environment}/setup`;
-                        history.push(href);
+                        navigate(href);
                     }}>{row.connected ? 'View Details' : 'Setup'}</ButtonText>
                 </>
             ))

--- a/Source/SelfService/Web/m3connector/setup.tsx
+++ b/Source/SelfService/Web/m3connector/setup.tsx
@@ -3,7 +3,7 @@
 
 import React from 'react';
 import { HttpResponseApplication } from '../api/application';
-import { useParams, useHistory } from 'react-router-dom';
+import { useParams, useNavigate } from 'react-router-dom';
 import { ButtonText } from '../theme/buttonText';
 
 type Props = {
@@ -15,7 +15,7 @@ type ViewParams = {
 };
 
 export const View: React.FunctionComponent<Props> = (props) => {
-    const history = useHistory();
+    const navigate = useNavigate();
     const { environment } = useParams<ViewParams>();
     const _props = props!;
     const application = _props.application;
@@ -36,7 +36,7 @@ export const View: React.FunctionComponent<Props> = (props) => {
                 <p>Already setup</p>
                 <ButtonText onClick={async () => {
                     const href = `/m3connector/application/${applicationId}/${environment}/details`;
-                    history.push(href);
+                    navigate(href);
                 }}>View Details</ButtonText>
             </>
         );

--- a/Source/SelfService/Web/microservice/deployMicroservice/deployMicroservice.tsx
+++ b/Source/SelfService/Web/microservice/deployMicroservice/deployMicroservice.tsx
@@ -2,7 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 import React, { useState } from 'react';
-import { useHistory } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 
 import { useSnackbar } from 'notistack';
 
@@ -52,7 +52,7 @@ type DeployMicroserviceProps = {
 
 export const DeployMicroservice = ({ application, environment }: DeployMicroserviceProps) => {
     const { enqueueSnackbar } = useSnackbar();
-    const history = useHistory();
+    const navigate = useNavigate();
 
     const [isLoading, setIsLoading] = useState(false);
     const [showM3ConnectorInfo, setShowM3ConnectorInfo] = useState(false);
@@ -110,7 +110,7 @@ export const DeployMicroservice = ({ application, environment }: DeployMicroserv
         try {
             await saveSimpleMicroservice(newMicroservice);
             const href = `/microservices/application/${application.id}/${environment}/view/${newMicroservice.dolittle.microserviceId}`;
-            history.push(href);
+            navigate(href);
         } catch (e: unknown) {
             const message = (e instanceof Error) ? e.message : 'Something went wrong when saving microservice.';
             enqueueSnackbar(message, { variant: 'error' });

--- a/Source/SelfService/Web/microservice/deployableMicroservicesList.tsx
+++ b/Source/SelfService/Web/microservice/deployableMicroservicesList.tsx
@@ -3,7 +3,7 @@
 
 // TODO validate the data
 import React, { useEffect, useState } from 'react';
-import { useHistory, useLocation } from 'react-router';
+import { useNavigate, useLocation } from 'react-router';
 
 import { Grid, Typography } from '@mui/material';
 
@@ -26,7 +26,7 @@ type DeployableMicroservicesListProps = {
 };
 
 export const DeployableMicroservicesList = ({ environment, application }: DeployableMicroservicesListProps) => {
-    const history = useHistory();
+    const navigate = useNavigate();
     const location = useLocation();
 
     const searchParams = new URLSearchParams(location.search);
@@ -47,7 +47,7 @@ export const DeployableMicroservicesList = ({ environment, application }: Deploy
 
     const onCreate = (kind: string) => {
         searchParams.set('kind', kind);
-        history.replace({ pathname: location.pathname, search: searchParams.toString() });
+        navigate({ pathname: location.pathname, search: searchParams.toString() }, { replace: true });
         setMicroserviceTypeState(kind);
     };
 

--- a/Source/SelfService/Web/microservice/microserviceDetails/configurationFilesSection/setupSection/setupSection.tsx
+++ b/Source/SelfService/Web/microservice/microserviceDetails/configurationFilesSection/setupSection/setupSection.tsx
@@ -2,7 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 import React, { useState } from 'react';
-import { useHistory } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 
 import { useSnackbar } from 'notistack';
 
@@ -56,7 +56,7 @@ type SetupSectionProps = {
 
 export const SetupSection = ({ application, applicationId, environment, microserviceId, currentMicroservice }: SetupSectionProps) => {
     const { enqueueSnackbar } = useSnackbar();
-    const history = useHistory();
+    const navigate = useNavigate();
 
     const microserviceInfo = currentMicroservice.edit?.extra;
     const environmentInfo = application.environments.find(env => env.name === environment)!;
@@ -97,7 +97,7 @@ export const SetupSection = ({ application, applicationId, environment, microser
 
         enqueueSnackbar(`Microservice '${currentMicroservice.name}' has been deleted.`);
         const href = `/microservices/application/${applicationId}/${environment}/overview`;
-        history.push(href);
+        navigate(href);
     };
 
     return (

--- a/Source/SelfService/Web/microservice/microservices/microservices.tsx
+++ b/Source/SelfService/Web/microservice/microservices/microservices.tsx
@@ -45,7 +45,7 @@ export const Microservice = ({ environment, application }: MicroserviceProps) =>
     useEffect(() => {
         setHasMicroservices(filteredMicroservices.length > 0);
         setLoading(false);
-    }, []);
+    }, [filteredMicroservices]);
 
     const handleCreateMicroservice = () => {
         if (!canEdit) {

--- a/Source/SelfService/Web/microservice/microservices/microservices.tsx
+++ b/Source/SelfService/Web/microservice/microservices/microservices.tsx
@@ -2,7 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 import React, { useEffect, useState } from 'react';
-import { useHistory } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 
 import { useSnackbar } from 'notistack';
 
@@ -25,7 +25,7 @@ type MicroserviceProps = {
 };
 
 export const Microservice = ({ environment, application }: MicroserviceProps) => {
-    const history = useHistory();
+    const navigate = useNavigate();
     const { enqueueSnackbar } = useSnackbar();
     const $microservices = useReadable(microservices) as MicroserviceObject[];
 
@@ -55,13 +55,13 @@ export const Microservice = ({ environment, application }: MicroserviceProps) =>
 
         sessionStorage.setItem('microserviceCreate', 'true');
         const href = `/microservices/application/${application.id}/${environment}/create`;
-        history.push(href);
+        navigate(href);
     };
 
     const handleCreateEnvironment = () => {
         // TODO How to stop this if automation disabled, currently on the environment level
         const href = `/environment/application/${application.id}/create`;
-        history.push(href);
+        navigate(href);
     };
 
     if (loading) return <LoadingSpinner />;

--- a/Source/SelfService/Web/microservice/microservices/microservicesTable.tsx
+++ b/Source/SelfService/Web/microservice/microservices/microservicesTable.tsx
@@ -2,7 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 import React, { useCallback, useEffect, useState } from 'react';
-import { useHistory } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 
 import { getPodStatus, MicroserviceInfo } from '../../api/api';
 import { HttpResponseApplication } from '../../api/application';
@@ -50,7 +50,7 @@ type MicroserviceTableProps = {
 };
 
 export const MicroserviceTable = ({ application, environment, microservices }: MicroserviceTableProps) => {
-    const history = useHistory();
+    const navigate = useNavigate();
     const [microserviceRows, setMicroserviceRows] = useState<(MicroserviceObject | undefined)[]>([]);
     const [loadingRows, setLoadingRows] = useState(true);
 
@@ -130,7 +130,7 @@ export const MicroserviceTable = ({ application, environment, microservices }: M
 
     const onTableRowClick = (microserviceId: string) => {
         const href = `/microservices/application/${application.id}/${environment}/view/${microserviceId}`;
-        history.push(href);
+        navigate(href);
     };
 
     return (

--- a/Source/SelfService/Web/microservice/microservices/microservicesTable.tsx
+++ b/Source/SelfService/Web/microservice/microservices/microservicesTable.tsx
@@ -70,6 +70,7 @@ export const MicroserviceTable = ({ application, environment, microservices }: M
             } as MicroserviceObject;
         })).then(data => {
             setMicroserviceRows(data);
+        }).finally(() => {
             setLoadingRows(false);
         });
 

--- a/Source/SelfService/Web/microservice/microservices/microservicesTable.tsx
+++ b/Source/SelfService/Web/microservice/microservices/microservicesTable.tsx
@@ -60,6 +60,7 @@ export const MicroserviceTable = ({ application, environment, microservices }: M
     }, [application.id, environment]);
 
     useEffect(() => {
+        setLoadingRows(true);
         Promise.all(microservices.map(async microservice => {
             const status = await getMicroserviceStatus(microservice.id);
 
@@ -71,7 +72,8 @@ export const MicroserviceTable = ({ application, environment, microservices }: M
             setMicroserviceRows(data);
             setLoadingRows(false);
         });
-    }, []);
+
+    }, [microservices]);
 
     // TODO: This is a hack to get the sorting to work. We need to fix this.
     const customUrlFieldSort = (v1, v2, param1, param2) => {

--- a/Source/SelfService/Web/microservice/overview.tsx
+++ b/Source/SelfService/Web/microservice/overview.tsx
@@ -2,7 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 import React, { useEffect, useState } from 'react';
-import { useHistory } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { useReadable } from 'use-svelte-store';
 
 import { Typography } from '@mui/material';
@@ -22,7 +22,7 @@ type OverviewProps = {
 
 export const Overview = ({ application, microserviceId, environment }: OverviewProps) => {
     const $microservices = useReadable(microservices) as any;
-    const history = useHistory();
+    const navigate = useNavigate();
 
     const [loaded, setLoaded] = useState(false);
 
@@ -40,7 +40,7 @@ export const Overview = ({ application, microserviceId, environment }: OverviewP
 
     if (!currentMicroservice) {
         const href = `/microservices/application/${application.id}/${environment}/overview`;
-        history.push(href);
+        navigate(href);
         return null;
     }
 

--- a/Source/SelfService/Web/microservice/rawDataLog/config/editConfig.tsx
+++ b/Source/SelfService/Web/microservice/rawDataLog/config/editConfig.tsx
@@ -7,7 +7,7 @@
 // TODO change action button from create to save
 
 import React from 'react';
-import { useHistory } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 
 import { Stack } from '@fluentui/react/lib/Stack';
 import { Config } from './config';
@@ -25,7 +25,7 @@ type Props = {
 };
 
 export const EditConfig: React.FunctionComponent<Props> = (props) => {
-    const history = useHistory();
+    const navigate = useNavigate();
     const _props = props!;
     const application = _props.application;
     const environment = _props.environment;
@@ -34,7 +34,7 @@ export const EditConfig: React.FunctionComponent<Props> = (props) => {
     const onSave = async (ms: MicroserviceRawDataLogIngestor): Promise<void> => {
         const data = await saveRawDataLogIngestorMicroservice(ms);
         const href = `/microservices/application/${application.id}/${environment}/overview`;
-        history.push(href);
+        navigate(href);
     };
 
     return (

--- a/Source/SelfService/Web/microservice/rawDataLog/view.tsx
+++ b/Source/SelfService/Web/microservice/rawDataLog/view.tsx
@@ -2,7 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 import React, { useState } from 'react';
-import { useHistory } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { useReadable } from 'use-svelte-store';
 
 import { Stack } from '@fluentui/react/lib/Stack';
@@ -27,7 +27,7 @@ type Props = {
 
 export const View: React.FunctionComponent<Props> = (props) => {
     const $microservices = useReadable(microservices) as any;
-    const history = useHistory();
+    const navigate = useNavigate();
     const _props = props!;
     const applicationId = _props.applicationId;
     const microserviceId = _props.microserviceId;
@@ -38,7 +38,7 @@ export const View: React.FunctionComponent<Props> = (props) => {
     const currentMicroservice: MicroserviceStore = $microservices.find(ms => ms.id === microserviceId && ms.environment === environment);
     if (!currentMicroservice) {
         const href = `/microservices/application/${applicationId}/${environment}/overview`;
-        history.push(href);
+        navigate(href);
         return null;
     }
 

--- a/Source/SelfService/Web/microservice/rawDataLog/webhooks.tsx
+++ b/Source/SelfService/Web/microservice/rawDataLog/webhooks.tsx
@@ -2,7 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 import React, { useState } from 'react';
-import { useHistory } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 
 import { Stack } from '@fluentui/react/lib/Stack';
 import { DetailsList, DetailsListLayoutMode, IColumn, CheckboxVisibility } from '@fluentui/react/lib/DetailsList';
@@ -35,7 +35,7 @@ const defaultWebhook = {
 export const Webhooks: React.FunctionComponent<Props> = (props) => {
     // TODO update microservice
     // TODO bubble up changes here
-    const history = useHistory();
+    const navigate = useNavigate();
     const _props = props!;
     const microservice = _props.microservice;
     const [showWebhookEditor, setShowWebhookEditor] = useState(false);

--- a/Source/SelfService/Web/package.json
+++ b/Source/SelfService/Web/package.json
@@ -29,7 +29,7 @@
         "react-markdown": "7.1.0",
         "remark-gfm": "3.0.1",
         "rxjs": "7.5.6",
-        "use-query-params": "1.2.3",
+        "use-query-params": "2.1.2",
         "use-react-router-breadcrumbs": "2.0.2"
     },
     "devDependencies": {

--- a/Source/SelfService/Web/screens/adminScreen.tsx
+++ b/Source/SelfService/Web/screens/adminScreen.tsx
@@ -2,7 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 import React from 'react';
-import { Route, Routes, useHistory, } from 'react-router-dom';
+import { Route, Routes, useNavigate, } from 'react-router-dom';
 
 import { Create as CreateCustomer } from '../customer/create';
 import { ViewAll as ViewAllCustomers } from '../customer/viewAll';
@@ -16,7 +16,7 @@ import { Typography } from '@mui/material';
 import { Button } from '@dolittle/design-system';
 
 export const Screen: React.FunctionComponent = () => {
-    const history = useHistory();
+    const navigate = useNavigate();
     const nav = [];
 
     const welcome = (
@@ -24,7 +24,7 @@ export const Screen: React.FunctionComponent = () => {
             <Typography variant='h1' my={2}>Hello Admin</Typography>
             <Button label='Take me to the Customers' onClick={() => {
                 const href = `/admin/customers`;
-                history.push(href);
+                navigate(href);
             }}
             />
         </>

--- a/Source/SelfService/Web/screens/adminScreen.tsx
+++ b/Source/SelfService/Web/screens/adminScreen.tsx
@@ -2,7 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 import React from 'react';
-import { Route, Switch, useHistory, } from 'react-router-dom';
+import { Route, Routes, useHistory, } from 'react-router-dom';
 
 import { Create as CreateCustomer } from '../customer/create';
 import { ViewAll as ViewAllCustomers } from '../customer/viewAll';
@@ -32,7 +32,7 @@ export const Screen: React.FunctionComponent = () => {
 
     return (
         <LayoutWithSidebar navigation={nav}>
-            <Switch>
+            <Routes>
                 <Route exact path="/admin/customer/create">
                     <CreateCustomer />
                 </Route>
@@ -52,7 +52,7 @@ export const Screen: React.FunctionComponent = () => {
                 <Route exact path="/admin/">
                     {welcome}
                 </Route>
-            </Switch>
+            </Routes>
         </LayoutWithSidebar>
     );
 };

--- a/Source/SelfService/Web/screens/adminScreen.tsx
+++ b/Source/SelfService/Web/screens/adminScreen.tsx
@@ -33,25 +33,16 @@ export const Screen: React.FunctionComponent = () => {
     return (
         <LayoutWithSidebar navigation={nav}>
             <Routes>
-                <Route exact path="/admin/customer/create">
-                    <CreateCustomer />
-                </Route>
+                <Route path="/" element={welcome} />
 
-                <Route exact path="/admin/customers">
-                    <ViewAllCustomers />
-                </Route>
+                <Route path="/customers" element={<ViewAllCustomers />} />
 
-                <Route exact path="/admin/customer/:customerId">
-                    <ViewCustomer />
-                </Route>
+                <Route path="/customer/create" element={<CreateCustomer />} />
 
-                <Route exact path="/admin/customer/:customerId/application/:applicationId/user/access">
-                    <ViewApplicationAccess />
-                </Route>
+                <Route path="/customer/:customerId" element={<ViewCustomer />} />
 
-                <Route exact path="/admin/">
-                    {welcome}
-                </Route>
+                <Route path="/customer/:customerId/application/:applicationId/user/access" element={<ViewApplicationAccess />} />
+
             </Routes>
         </LayoutWithSidebar>
     );

--- a/Source/SelfService/Web/screens/applicationScreen.tsx
+++ b/Source/SelfService/Web/screens/applicationScreen.tsx
@@ -2,7 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 import React, { useEffect, useState } from 'react';
-import { Route, Switch } from 'react-router-dom';
+import { Route, Routes } from 'react-router-dom';
 import { useSnackbar } from 'notistack';
 
 import { ShortInfoWithEnvironment } from '../api/api';
@@ -44,7 +44,7 @@ export const ApplicationScreen: React.FunctionComponent = () => {
 
     return (
         <LoginWrapper>
-            <Switch>
+            <Routes>
                 <Route exact path="/application/create">
                     <Create />
                 </Route>
@@ -52,7 +52,7 @@ export const ApplicationScreen: React.FunctionComponent = () => {
                 <Route exact path="/application/building/:applicationId">
                     <Building />
                 </Route>
-            </Switch>
-        </LoginWrapper>
+            </Routes>
+        </LoginWrapper >
     );
 };

--- a/Source/SelfService/Web/screens/applicationScreen.tsx
+++ b/Source/SelfService/Web/screens/applicationScreen.tsx
@@ -45,13 +45,9 @@ export const ApplicationScreen: React.FunctionComponent = () => {
     return (
         <LoginWrapper>
             <Routes>
-                <Route exact path="/application/create">
-                    <Create />
-                </Route>
+                <Route path="/create" element={<Create />} />
 
-                <Route exact path="/application/building/:applicationId">
-                    <Building />
-                </Route>
+                <Route path="/building/:applicationId" element={<Building />} />
             </Routes>
         </LoginWrapper >
     );

--- a/Source/SelfService/Web/screens/applicationsScreen/applicationsScreen.tsx
+++ b/Source/SelfService/Web/screens/applicationsScreen/applicationsScreen.tsx
@@ -2,7 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 import React, { useState, useEffect } from 'react';
-import { useHistory } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 
 import { useSnackbar } from 'notistack';
 
@@ -20,7 +20,7 @@ import { HttpResponseApplications, getApplications } from '../../api/application
 import { ApplicationsList } from './applicationsList';
 
 export const ApplicationsScreen = () => {
-    const history = useHistory();
+    const navigate = useNavigate();
     const { enqueueSnackbar } = useSnackbar();
 
     const [applicationInfos, setApplicationInfos] = useState([] as ShortInfoWithEnvironment[]);
@@ -49,7 +49,7 @@ export const ApplicationsScreen = () => {
         const { environment, id } = application;
         setCurrentEnvironment(environment);
         const href = `/microservices/application/${id}/${environment}/overview`;
-        history.push(href);
+        navigate(href);
     };
 
     const handleApplicationCreate = () => {
@@ -59,7 +59,7 @@ export const ApplicationsScreen = () => {
         }
 
         const href = '/application/create';
-        history.push(href);
+        navigate(href);
     };
 
     return (

--- a/Source/SelfService/Web/screens/backupsScreen.tsx
+++ b/Source/SelfService/Web/screens/backupsScreen.tsx
@@ -4,7 +4,7 @@
 import React, { useEffect, useState } from 'react';
 import {
     Route,
-    Switch,
+    Routes,
     useHistory,
     generatePath
 } from 'react-router-dom';
@@ -93,7 +93,7 @@ export const BackupsScreen: React.FunctionComponent<Props> = (props) => {
                         <BreadCrumbContainer routes={routes} />
                     </div>
                 </div>
-                <Switch>
+                <Routes>
                     <Route exact path="/backups/application/:applicationId/overview">
                         <div className="serv">
                             <ul>
@@ -111,7 +111,7 @@ export const BackupsScreen: React.FunctionComponent<Props> = (props) => {
                     <Route>
                         <Typography variant='h1' my={2}>Something has gone wrong: backups</Typography>
                     </Route>
-                </Switch>
+                </Routes>
             </LayoutWithSidebar>
         </>
     );

--- a/Source/SelfService/Web/screens/backupsScreen.tsx
+++ b/Source/SelfService/Web/screens/backupsScreen.tsx
@@ -5,7 +5,7 @@ import React, { useEffect, useState } from 'react';
 import {
     Route,
     Routes,
-    useHistory,
+    useNavigate,
     generatePath
 } from 'react-router-dom';
 
@@ -23,7 +23,7 @@ type Props = {
 };
 
 export const BackupsScreen: React.FunctionComponent<Props> = (props) => {
-    const history = useHistory();
+    const navigate = useNavigate();
     const { currentEnvironment } = useGlobalContext();
 
     const routeApplicationProps = useRouteApplicationParams();
@@ -38,7 +38,7 @@ export const BackupsScreen: React.FunctionComponent<Props> = (props) => {
             const applicationData = values[0];
             if (!applicationData?.id) {
                 const href = `/problem`;
-                history.push(href);
+                navigate(href);
                 return;
             }
 
@@ -59,7 +59,7 @@ export const BackupsScreen: React.FunctionComponent<Props> = (props) => {
         );
     }
     const environments = application.environments;
-    const nav = getMenuWithApplication(history, application, currentEnvironment);
+    const nav = getMenuWithApplication(navigate, application, currentEnvironment);
 
     const routes = [
         {

--- a/Source/SelfService/Web/screens/backupsScreen.tsx
+++ b/Source/SelfService/Web/screens/backupsScreen.tsx
@@ -94,7 +94,7 @@ export const BackupsScreen: React.FunctionComponent<Props> = (props) => {
                     </div>
                 </div>
                 <Routes>
-                    <Route exact path="/backups/application/:applicationId/overview">
+                    <Route path="/overview" element={
                         <div className="serv">
                             <ul>
                                 {environments.map((environment) => {
@@ -104,13 +104,11 @@ export const BackupsScreen: React.FunctionComponent<Props> = (props) => {
                                 })}
                             </ul>
                         </div>
-                    </Route>
-                    <Route exact path="/backups/application/:applicationId/:environment/list">
+                    } />
+                    <Route path="/:environment/list" element={
                         <ListView application={application} environment={currentEnvironment} />
-                    </Route>
-                    <Route>
-                        <Typography variant='h1' my={2}>Something has gone wrong: backups</Typography>
-                    </Route>
+                    } />
+                    <Route element={<Typography variant='h1' my={2}>Something has gone wrong: backups</Typography>} />
                 </Routes>
             </LayoutWithSidebar>
         </>

--- a/Source/SelfService/Web/screens/containerRegistryScreen.tsx
+++ b/Source/SelfService/Web/screens/containerRegistryScreen.tsx
@@ -5,7 +5,7 @@ import React, { useEffect, useState } from 'react';
 import {
     Route,
     useHistory,
-    Switch,
+    Routes,
     generatePath
 } from 'react-router-dom';
 
@@ -99,12 +99,12 @@ export const ContainerRegistryScreen: React.FunctionComponent = withRouteApplica
         <LayoutWithSidebar navigation={nav}>
             <TopNavBar routes={routes} applications={applications} applicationId={currentApplicationId} environment={currentEnvironment} />
 
-            <Switch>
+            <Routes>
                 <Route path="/containerregistry/application/:applicationId/:environment/overview">
                     <ContainerRegistryContainer application={application} environment={currentEnvironment} />
                 </Route>
                 <RouteNotFound redirectUrl={redirectUrl} />
-            </Switch>
+            </Routes>
         </LayoutWithSidebar >
     );
 });

--- a/Source/SelfService/Web/screens/containerRegistryScreen.tsx
+++ b/Source/SelfService/Web/screens/containerRegistryScreen.tsx
@@ -4,7 +4,7 @@
 import React, { useEffect, useState } from 'react';
 import {
     Route,
-    useHistory,
+    useNavigate,
     Routes,
     generatePath
 } from 'react-router-dom';
@@ -29,7 +29,7 @@ import { Typography } from '@mui/material';
 
 
 export const ContainerRegistryScreen: React.FunctionComponent = withRouteApplicationState(({ routeApplicationParams }) => {
-    const history = useHistory();
+    const navigate = useNavigate();
     const currentEnvironment = routeApplicationParams.environment;
     const currentApplicationId = routeApplicationParams.applicationId;
 
@@ -50,7 +50,7 @@ export const ContainerRegistryScreen: React.FunctionComponent = withRouteApplica
             const applicationData = values[1];
             if (!applicationData?.id) {
                 const href = `/problem`;
-                history.push(href);
+                navigate(href);
                 return;
             }
 
@@ -86,7 +86,7 @@ export const ContainerRegistryScreen: React.FunctionComponent = withRouteApplica
         );
     }
 
-    const nav = getMenuWithApplication(history, application, currentEnvironment);
+    const nav = getMenuWithApplication(navigate, application, currentEnvironment);
 
     const routes = [];
 

--- a/Source/SelfService/Web/screens/containerRegistryScreen.tsx
+++ b/Source/SelfService/Web/screens/containerRegistryScreen.tsx
@@ -90,11 +90,6 @@ export const ContainerRegistryScreen: React.FunctionComponent = withRouteApplica
 
     const routes = [];
 
-    const redirectUrl = generatePath('/containerregistry/application/:applicationId/:environment/overview', {
-        applicationId: currentApplicationId,
-        environment: currentEnvironment,
-    });
-
     return (
         <LayoutWithSidebar navigation={nav}>
             <TopNavBar routes={routes} applications={applications} applicationId={currentApplicationId} environment={currentEnvironment} />
@@ -103,8 +98,9 @@ export const ContainerRegistryScreen: React.FunctionComponent = withRouteApplica
                 <Route
                     path="/overview/*"
                     element={<ContainerRegistryContainer application={application} environment={currentEnvironment} />} />
-                {/* TODO PAV: Remove RouteNotFound */}
-                {/* <RouteNotFound redirectUrl={redirectUrl} /> */}
+
+                <Route path='*' element={<RouteNotFound redirectUrl={'overview'} auto={true} />} />
+
             </Routes>
         </LayoutWithSidebar >
     );

--- a/Source/SelfService/Web/screens/containerRegistryScreen.tsx
+++ b/Source/SelfService/Web/screens/containerRegistryScreen.tsx
@@ -104,7 +104,7 @@ export const ContainerRegistryScreen: React.FunctionComponent = withRouteApplica
                     path="/overview/*"
                     element={<ContainerRegistryContainer application={application} environment={currentEnvironment} />} />
                 {/* TODO PAV: Remove RouteNotFound */}
-                <RouteNotFound redirectUrl={redirectUrl} />
+                {/* <RouteNotFound redirectUrl={redirectUrl} /> */}
             </Routes>
         </LayoutWithSidebar >
     );

--- a/Source/SelfService/Web/screens/containerRegistryScreen.tsx
+++ b/Source/SelfService/Web/screens/containerRegistryScreen.tsx
@@ -100,9 +100,10 @@ export const ContainerRegistryScreen: React.FunctionComponent = withRouteApplica
             <TopNavBar routes={routes} applications={applications} applicationId={currentApplicationId} environment={currentEnvironment} />
 
             <Routes>
-                <Route path="/containerregistry/application/:applicationId/:environment/overview">
-                    <ContainerRegistryContainer application={application} environment={currentEnvironment} />
-                </Route>
+                <Route
+                    path="/overview/*"
+                    element={<ContainerRegistryContainer application={application} environment={currentEnvironment} />} />
+                {/* TODO PAV: Remove RouteNotFound */}
                 <RouteNotFound redirectUrl={redirectUrl} />
             </Routes>
         </LayoutWithSidebar >

--- a/Source/SelfService/Web/screens/documentationScreen.tsx
+++ b/Source/SelfService/Web/screens/documentationScreen.tsx
@@ -4,7 +4,7 @@
 import React, { useEffect, useState } from 'react';
 import {
     Route,
-    useHistory,
+    useNavigate,
     Routes,
     generatePath
 } from 'react-router-dom';
@@ -34,7 +34,7 @@ import { Typography } from '@mui/material';
 
 
 export const DocumentationScreen: React.FunctionComponent = withRouteApplicationState(({ routeApplicationParams }) => {
-    const history = useHistory();
+    const navigate = useNavigate();
     const { setNotification } = useGlobalContext();
     const currentEnvironment = routeApplicationParams.environment;
     const currentApplicationId = routeApplicationParams.applicationId;
@@ -56,7 +56,7 @@ export const DocumentationScreen: React.FunctionComponent = withRouteApplication
             const applicationData = values[1];
             if (!applicationData?.id) {
                 const href = `/problem`;
-                history.push(href);
+                navigate(href);
                 return;
             }
 
@@ -93,7 +93,7 @@ export const DocumentationScreen: React.FunctionComponent = withRouteApplication
         );
     }
 
-    const nav = getMenuWithApplication(history, application, currentEnvironment);
+    const nav = getMenuWithApplication(navigate, application, currentEnvironment);
 
     const routes = [
         {

--- a/Source/SelfService/Web/screens/documentationScreen.tsx
+++ b/Source/SelfService/Web/screens/documentationScreen.tsx
@@ -140,7 +140,7 @@ export const DocumentationScreen: React.FunctionComponent = withRouteApplication
             <TopNavBar routes={routes} applications={applications} applicationId={currentApplicationId} environment={currentEnvironment} />
 
             <Routes>
-                <Route path="*" element={<DocumentationContainerScreen application={application} environment={currentEnvironment} />} />
+                <Route path='/*' element={<DocumentationContainerScreen application={application} environment={currentEnvironment} />} />
             </Routes>
         </LayoutWithSidebar >
     );

--- a/Source/SelfService/Web/screens/documentationScreen.tsx
+++ b/Source/SelfService/Web/screens/documentationScreen.tsx
@@ -5,7 +5,7 @@ import React, { useEffect, useState } from 'react';
 import {
     Route,
     useHistory,
-    Switch,
+    Routes,
     generatePath
 } from 'react-router-dom';
 
@@ -139,12 +139,12 @@ export const DocumentationScreen: React.FunctionComponent = withRouteApplication
         <LayoutWithSidebar navigation={nav}>
             <TopNavBar routes={routes} applications={applications} applicationId={currentApplicationId} environment={currentEnvironment} />
 
-            <Switch>
+            <Routes>
                 <Route path="/documentation/application/:applicationId/:environment">
                     <DocumentationContainerScreen application={application} environment={currentEnvironment} />
                 </Route>
                 <RouteNotFound redirectUrl={redirectUrl} />
-            </Switch>
+            </Routes>
         </LayoutWithSidebar >
     );
 });

--- a/Source/SelfService/Web/screens/documentationScreen.tsx
+++ b/Source/SelfService/Web/screens/documentationScreen.tsx
@@ -140,9 +140,9 @@ export const DocumentationScreen: React.FunctionComponent = withRouteApplication
             <TopNavBar routes={routes} applications={applications} applicationId={currentApplicationId} environment={currentEnvironment} />
 
             <Routes>
-                <Route path="/documentation/application/:applicationId/:environment">
-                    <DocumentationContainerScreen application={application} environment={currentEnvironment} />
-                </Route>
+                <Route path="*" element={<DocumentationContainerScreen application={application} environment={currentEnvironment} />} />
+
+                {/* TODO PAV: Remove RouteNotFound */}
                 <RouteNotFound redirectUrl={redirectUrl} />
             </Routes>
         </LayoutWithSidebar >

--- a/Source/SelfService/Web/screens/documentationScreen.tsx
+++ b/Source/SelfService/Web/screens/documentationScreen.tsx
@@ -141,9 +141,6 @@ export const DocumentationScreen: React.FunctionComponent = withRouteApplication
 
             <Routes>
                 <Route path="*" element={<DocumentationContainerScreen application={application} environment={currentEnvironment} />} />
-
-                {/* TODO PAV: Remove RouteNotFound */}
-                {/* <RouteNotFound redirectUrl={redirectUrl} /> */}
             </Routes>
         </LayoutWithSidebar >
     );

--- a/Source/SelfService/Web/screens/documentationScreen.tsx
+++ b/Source/SelfService/Web/screens/documentationScreen.tsx
@@ -143,7 +143,7 @@ export const DocumentationScreen: React.FunctionComponent = withRouteApplication
                 <Route path="*" element={<DocumentationContainerScreen application={application} environment={currentEnvironment} />} />
 
                 {/* TODO PAV: Remove RouteNotFound */}
-                <RouteNotFound redirectUrl={redirectUrl} />
+                {/* <RouteNotFound redirectUrl={redirectUrl} /> */}
             </Routes>
         </LayoutWithSidebar >
     );

--- a/Source/SelfService/Web/screens/loginScreen.tsx
+++ b/Source/SelfService/Web/screens/loginScreen.tsx
@@ -3,11 +3,13 @@
 
 import React from 'react';
 import { PrimaryButton } from '@fluentui/react/lib/Button';
+import {useNavigate} from 'react-router-dom';
 
 export const LoginScreen: React.FunctionComponent = () => {
+    const navigate = useNavigate();
     return (
         <>
-            <PrimaryButton text="Login" onClick={() => window.location.href = '/'} />
+            <PrimaryButton text="Login" onClick={() => navigate('/')} />
             <div className="with-sidebar">
                 <div>
                     <div className="sidebar">

--- a/Source/SelfService/Web/screens/logsScreen.tsx
+++ b/Source/SelfService/Web/screens/logsScreen.tsx
@@ -2,7 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 import React, { useEffect, useState } from 'react';
-import { useHistory } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 
 import { Box, Typography } from '@mui/material';
 
@@ -29,7 +29,7 @@ import { withRouteApplicationState } from './withRouteApplicationState';
 const DAY = 86_400_000_000_000n;
 
 export const LogsScreen: React.FunctionComponent = withRouteApplicationState(({ routeApplicationParams }) => {
-    const history = useHistory();
+    const navigate = useNavigate();
     const { setNotification } = useGlobalContext();
     const currentEnvironment = routeApplicationParams.environment;
     const currentApplicationId = routeApplicationParams.applicationId;
@@ -64,7 +64,7 @@ export const LogsScreen: React.FunctionComponent = withRouteApplicationState(({ 
 
             if (!applicationData?.id) {
                 const href = `/problem`;
-                history.push(href);
+                navigate(href);
                 return;
             }
 
@@ -100,7 +100,7 @@ export const LogsScreen: React.FunctionComponent = withRouteApplicationState(({ 
         );
     }
 
-    const nav = getMenuWithApplication(history, application, currentEnvironment);
+    const nav = getMenuWithApplication(navigate, application, currentEnvironment);
 
     return (
         <LayoutWithSidebar navigation={nav}>

--- a/Source/SelfService/Web/screens/m3connectorScreen.tsx
+++ b/Source/SelfService/Web/screens/m3connectorScreen.tsx
@@ -4,7 +4,7 @@
 import React, { useEffect, useState } from 'react';
 import {
     Route,
-    Switch,
+    Routes,
     useHistory,
 } from 'react-router-dom';
 
@@ -70,11 +70,11 @@ export const M3ConnectorScreen: React.FunctionComponent<Props> = (props) => {
                         <BreadCrumbContainer routes={routes} />
                     </div>
                 </div>
-                <Switch>
+                <Routes>
                     <Route path="/m3connector/application/:applicationId">
                         <Container application={application} />
                     </Route>
-                </Switch>
+                </Routes>
             </LayoutWithSidebar>
         </>
     );

--- a/Source/SelfService/Web/screens/m3connectorScreen.tsx
+++ b/Source/SelfService/Web/screens/m3connectorScreen.tsx
@@ -71,9 +71,9 @@ export const M3ConnectorScreen: React.FunctionComponent<Props> = (props) => {
                     </div>
                 </div>
                 <Routes>
-                    <Route path="/m3connector/application/:applicationId">
-                        <Container application={application} />
-                    </Route>
+                    <Route
+                        path="*"
+                        element={<Container application={application} />} />
                 </Routes>
             </LayoutWithSidebar>
         </>

--- a/Source/SelfService/Web/screens/m3connectorScreen.tsx
+++ b/Source/SelfService/Web/screens/m3connectorScreen.tsx
@@ -72,7 +72,7 @@ export const M3ConnectorScreen: React.FunctionComponent<Props> = (props) => {
                 </div>
                 <Routes>
                     <Route
-                        path="*"
+                        path='/*'
                         element={<Container application={application} />} />
                 </Routes>
             </LayoutWithSidebar>

--- a/Source/SelfService/Web/screens/m3connectorScreen.tsx
+++ b/Source/SelfService/Web/screens/m3connectorScreen.tsx
@@ -5,7 +5,7 @@ import React, { useEffect, useState } from 'react';
 import {
     Route,
     Routes,
-    useHistory,
+    useNavigate,
 } from 'react-router-dom';
 
 import { getApplication, HttpResponseApplication } from '../api/application';
@@ -22,7 +22,7 @@ type Props = {
 };
 
 export const M3ConnectorScreen: React.FunctionComponent<Props> = (props) => {
-    const history = useHistory();
+    const navigate = useNavigate();
     const { currentEnvironment } = useGlobalContext();
 
     const routeApplicationProps = useRouteApplicationParams();
@@ -37,7 +37,7 @@ export const M3ConnectorScreen: React.FunctionComponent<Props> = (props) => {
             const applicationData = values[0];
             if (!applicationData?.id) {
                 const href = `/problem`;
-                history.push(href);
+                navigate(href);
                 return;
             }
 
@@ -58,7 +58,7 @@ export const M3ConnectorScreen: React.FunctionComponent<Props> = (props) => {
         );
     }
 
-    const nav = getMenuWithApplication(history, application, currentEnvironment);
+    const nav = getMenuWithApplication(navigate, application, currentEnvironment);
 
     const routes = [];
 

--- a/Source/SelfService/Web/screens/microservicesScreen.tsx
+++ b/Source/SelfService/Web/screens/microservicesScreen.tsx
@@ -165,7 +165,7 @@ export const MicroservicesScreen = withRouteApplicationState(({ routeApplication
                     element={<MicroserviceViewScreen application={application} environment={currentEnvironment} />} />
 
                 {/* TODO PAV: Remove RouteNotFound */}
-                <RouteNotFound redirectUrl={redirectUrl} />
+                {/* <RouteNotFound redirectUrl={redirectUrl} /> */}
             </Routes>
         </LayoutWithSidebar>
     );

--- a/Source/SelfService/Web/screens/microservicesScreen.tsx
+++ b/Source/SelfService/Web/screens/microservicesScreen.tsx
@@ -143,10 +143,6 @@ export const MicroservicesScreen = withRouteApplicationState(({ routeApplication
     ];
 
 
-    const redirectUrl = generatePath('/microservices/application/:applicationId/:environment/overview', {
-        applicationId: currentApplicationId,
-        environment: currentEnvironment,
-    });
 
     return (
         <LayoutWithSidebar navigation={nav}>
@@ -164,8 +160,8 @@ export const MicroservicesScreen = withRouteApplicationState(({ routeApplication
                     path="/view/:microserviceId"
                     element={<MicroserviceViewScreen application={application} environment={currentEnvironment} />} />
 
-                {/* TODO PAV: Remove RouteNotFound */}
-                {/* <RouteNotFound redirectUrl={redirectUrl} /> */}
+                <Route path='*' element={<RouteNotFound redirectUrl={'overview'} auto={true} />} />
+
             </Routes>
         </LayoutWithSidebar>
     );

--- a/Source/SelfService/Web/screens/microservicesScreen.tsx
+++ b/Source/SelfService/Web/screens/microservicesScreen.tsx
@@ -152,18 +152,19 @@ export const MicroservicesScreen = withRouteApplicationState(({ routeApplication
         <LayoutWithSidebar navigation={nav}>
             <TopNavBar routes={routes} applications={applications} applicationId={currentApplicationId} environment={currentEnvironment} />
             <Routes>
-                <Route exact path="/microservices/application/:applicationId/:environment/overview">
-                    <Microservice application={application} environment={currentEnvironment} />
-                </Route>
+                <Route
+                    path="/overview"
+                    element={<Microservice application={application} environment={currentEnvironment} />} />
 
-                <Route exact path="/microservices/application/:applicationId/:environment/create">
-                    <MicroserviceNewScreen application={application} environment={currentEnvironment} />
-                </Route>
+                <Route
+                    path="/create"
+                    element={<MicroserviceNewScreen application={application} environment={currentEnvironment} />} />
 
-                <Route exact path="/microservices/application/:applicationId/:environment/view/:microserviceId">
-                    <MicroserviceViewScreen application={application} environment={currentEnvironment} />
-                </Route>
+                <Route
+                    path="/view/:microserviceId"
+                    element={<MicroserviceViewScreen application={application} environment={currentEnvironment} />} />
 
+                {/* TODO PAV: Remove RouteNotFound */}
                 <RouteNotFound redirectUrl={redirectUrl} />
             </Routes>
         </LayoutWithSidebar>

--- a/Source/SelfService/Web/screens/microservicesScreen.tsx
+++ b/Source/SelfService/Web/screens/microservicesScreen.tsx
@@ -2,7 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 import React, { useEffect, useState } from 'react';
-import { Route, useHistory, Routes, generatePath } from 'react-router-dom';
+import { Route, useNavigate, Routes, generatePath } from 'react-router-dom';
 
 import { ShortInfoWithEnvironment, HttpResponseMicroservices, getMicroservices } from '../api/api';
 import { HttpResponseApplication, getApplications, getApplication, HttpResponseApplications } from '../api/application';
@@ -28,7 +28,7 @@ import { withRouteApplicationState } from './withRouteApplicationState';
 import { Typography } from '@mui/material';
 
 export const MicroservicesScreen = withRouteApplicationState(({ routeApplicationParams }) => {
-    const history = useHistory();
+    const navigate = useNavigate();
     const { setNotification } = useGlobalContext();
     const currentEnvironment = routeApplicationParams.environment;
     const currentApplicationId = routeApplicationParams.applicationId;
@@ -52,7 +52,7 @@ export const MicroservicesScreen = withRouteApplicationState(({ routeApplication
 
             if (!applicationData?.id) {
                 const href = `/problem`;
-                history.push(href);
+                navigate(href);
                 return;
             }
 
@@ -92,7 +92,7 @@ export const MicroservicesScreen = withRouteApplicationState(({ routeApplication
         );
     }
 
-    const nav = getMenuWithApplication(history, application, currentEnvironment);
+    const nav = getMenuWithApplication(navigate, application, currentEnvironment);
 
     const routes = [
         {

--- a/Source/SelfService/Web/screens/microservicesScreen.tsx
+++ b/Source/SelfService/Web/screens/microservicesScreen.tsx
@@ -2,7 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 import React, { useEffect, useState } from 'react';
-import { Route, useHistory, Switch, generatePath } from 'react-router-dom';
+import { Route, useHistory, Routes, generatePath } from 'react-router-dom';
 
 import { ShortInfoWithEnvironment, HttpResponseMicroservices, getMicroservices } from '../api/api';
 import { HttpResponseApplication, getApplications, getApplication, HttpResponseApplications } from '../api/application';
@@ -151,7 +151,7 @@ export const MicroservicesScreen = withRouteApplicationState(({ routeApplication
     return (
         <LayoutWithSidebar navigation={nav}>
             <TopNavBar routes={routes} applications={applications} applicationId={currentApplicationId} environment={currentEnvironment} />
-            <Switch>
+            <Routes>
                 <Route exact path="/microservices/application/:applicationId/:environment/overview">
                     <Microservice application={application} environment={currentEnvironment} />
                 </Route>
@@ -165,7 +165,7 @@ export const MicroservicesScreen = withRouteApplicationState(({ routeApplication
                 </Route>
 
                 <RouteNotFound redirectUrl={redirectUrl} />
-            </Switch>
+            </Routes>
         </LayoutWithSidebar>
     );
 });

--- a/Source/SelfService/Web/store.ts
+++ b/Source/SelfService/Web/store.ts
@@ -1,7 +1,12 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+const basePath = '/selfservice';
+
 export function uriWithBasePathPrefix(uri: string): string {
-    const basePath = '/selfservice';
     return `${basePath}${uri}`;
+}
+
+export function uriWithoutBasePathPrefix(uri: string): string {
+    return uri.replace(basePath, '');
 }

--- a/Source/SelfService/Web/store.ts
+++ b/Source/SelfService/Web/store.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-export function uriWithAppPrefix(uri: string): string {
-    const prefix = '/selfservice';
-    return `${prefix}${uri}`;
+export function uriWithBasePathPrefix(uri: string): string {
+    const basePath = '/selfservice';
+    return `${basePath}${uri}`;
 }

--- a/Source/SelfService/Web/webpack.config.ts
+++ b/Source/SelfService/Web/webpack.config.ts
@@ -107,7 +107,11 @@ function webpack(env: Args, argv: Args) {
                     ws: true,
                 }
             },
-            before: (app, server, compiler) => { }
+            before: (app, server, compiler) => {
+                app.get(['/', '/.auth/*'], function (req, res) {
+                    res.redirect(basePath);
+                });
+            }
         },
         plugins: [
             new CleanWebpackPlugin({

--- a/Source/Shared/Web/package.json
+++ b/Source/Shared/Web/package.json
@@ -19,10 +19,9 @@
         "@types/react": "18.0.17",
         "@types/react-dom": "18.0.1",
         "@types/react-router-dom": "5.3.3",
-        "history": "5.3.0",
         "react": "18.2.0",
         "react-dom": "18.2.0",
-        "react-router-dom": "5.2.0"
+        "react-router-dom": "6.6.2"
     },
     "devDependencies": {
         "@types/babel__core": "7.1.19"

--- a/yarn.lock
+++ b/yarn.lock
@@ -15575,10 +15575,10 @@ serialize-javascript@^6.0.0:
   dependencies:
     randombytes "^2.1.0"
 
-serialize-query-params@^1.3.5:
-  version "1.3.6"
-  resolved "https://registry.yarnpkg.com/serialize-query-params/-/serialize-query-params-1.3.6.tgz#5dd5225db85ce747fe6fbc4897628504faafec6d"
-  integrity sha512-VlH7sfWNyPVZClPkRacopn6sn5uQMXBsjPVz1+pBHX895VpcYVznfJtZ49e6jymcrz+l/vowkepCZn/7xEAEdw==
+serialize-query-params@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/serialize-query-params/-/serialize-query-params-2.0.2.tgz#598a3fb9e13f4ea1c1992fbd20231aa16b31db81"
+  integrity sha512-1chMo1dST4pFA9RDXAtF0Rbjaut4is7bzFbI1Z26IuMub68pNCILku85aYmeFhvnY//BXUPUhoRMjYcsT93J/Q==
 
 serve-favicon@^2.5.0:
   version "2.5.0"
@@ -17193,12 +17193,12 @@ url@^0.11.0:
     punycode "1.3.2"
     querystring "0.2.0"
 
-use-query-params@1.2.3:
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/use-query-params/-/use-query-params-1.2.3.tgz#306c31a0cbc714e8a3b4bd7e91a6a9aaccaa5e22"
-  integrity sha512-cdG0tgbzK+FzsV6DAt2CN8Saa3WpRnze7uC4Rdh7l15epSFq7egmcB/zuREvPNwO5Yk80nUpDZpiyHsoq50d8w==
+use-query-params@2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/use-query-params/-/use-query-params-2.1.2.tgz#0bd100a0839e5195106cfb291b43d2159618ca9d"
+  integrity sha512-evg64srKaILvKyRQ1zpXvekTC7rktAT7OAekU7x6naHrOMqLHtq0MHR/PtKIQAP4d7HrkYNVOS8exHhiWy7m3A==
   dependencies:
-    serialize-query-params "^1.3.5"
+    serialize-query-params "^2.0.2"
 
 use-react-router-breadcrumbs@2.0.2:
   version "2.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1127,7 +1127,7 @@
   dependencies:
     regenerator-runtime "^0.13.2"
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.10.2", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.1", "@babel/runtime@^7.12.5", "@babel/runtime@^7.16.3", "@babel/runtime@^7.17.2", "@babel/runtime@^7.17.8", "@babel/runtime@^7.18.3", "@babel/runtime@^7.18.6", "@babel/runtime@^7.18.9", "@babel/runtime@^7.19.0", "@babel/runtime@^7.3.1", "@babel/runtime@^7.5.0", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.3", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7":
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.10.2", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.5", "@babel/runtime@^7.16.3", "@babel/runtime@^7.17.2", "@babel/runtime@^7.17.8", "@babel/runtime@^7.18.3", "@babel/runtime@^7.18.6", "@babel/runtime@^7.18.9", "@babel/runtime@^7.19.0", "@babel/runtime@^7.3.1", "@babel/runtime@^7.5.0", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.3", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7":
   version "7.19.4"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.19.4.tgz#a42f814502ee467d55b38dd1c256f53a7b885c78"
   integrity sha512-EXpLCrk55f+cYqmHsSR+yD/0gAIMxxA9QK9lnQWzhMCvt+YmoBN7Zx94s++Kv0+unHk39vxNO8t+CMA2WSS3wA==
@@ -2493,6 +2493,11 @@
     "@juggle/resize-observer" "^3.3.1"
     "@react-hook/latest" "^1.0.2"
     "@react-hook/passive-layout-effect" "^1.2.0"
+
+"@remix-run/router@1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@remix-run/router/-/router-1.2.1.tgz#812edd4104a15a493dda1ccac0b352270d7a188c"
+  integrity sha512-XiY0IsyHR+DXYS5vBxpoBe/8veTeoRpMHP+vDosLZxL5bnpetzI0igkxkLZS235ldLzyfkxF+2divEwWHP3vMQ==
 
 "@rollup/plugin-babel@^5.2.0":
   version "5.3.1"
@@ -9801,25 +9806,6 @@ he@1.2.0, he@^1.2.0:
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
 
-history@5.3.0:
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/history/-/history-5.3.0.tgz#1548abaa245ba47992f063a0783db91ef201c73b"
-  integrity sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==
-  dependencies:
-    "@babel/runtime" "^7.7.6"
-
-history@^4.9.0:
-  version "4.10.1"
-  resolved "https://registry.yarnpkg.com/history/-/history-4.10.1.tgz#33371a65e3a83b267434e2b3f3b1b4c58aad4cf3"
-  integrity sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==
-  dependencies:
-    "@babel/runtime" "^7.1.2"
-    loose-envify "^1.2.0"
-    resolve-pathname "^3.0.0"
-    tiny-invariant "^1.0.2"
-    tiny-warning "^1.0.0"
-    value-equal "^1.0.1"
-
 hmac-drbg@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/hmac-drbg/-/hmac-drbg-1.0.1.tgz#d2745701025a6c775a6c545793ed502fc0c649a1"
@@ -9829,7 +9815,7 @@ hmac-drbg@^1.0.1:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
-hoist-non-react-statics@^3.1.0, hoist-non-react-statics@^3.3.1, hoist-non-react-statics@^3.3.2:
+hoist-non-react-statics@^3.3.1, hoist-non-react-statics@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
   integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
@@ -11811,7 +11797,7 @@ longest-streak@^3.0.0:
   resolved "https://registry.yarnpkg.com/longest-streak/-/longest-streak-3.0.1.tgz#c97315b7afa0e7d9525db9a5a2953651432bdc5d"
   integrity sha512-cHlYSUpL2s7Fb3394mYxwTYj8niTaNHUCLr0qdiCXQfSjfuA7CKofpX2uSwEfFDQ0EB7JcnMnm+GjbqqoinYYg==
 
-loose-envify@^1.1.0, loose-envify@^1.2.0, loose-envify@^1.3.1, loose-envify@^1.4.0:
+loose-envify@^1.1.0, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
@@ -12546,14 +12532,6 @@ min-indent@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/min-indent/-/min-indent-1.0.1.tgz#a63f681673b30571fbe8bc25686ae746eefa9869"
   integrity sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==
-
-mini-create-react-context@^0.4.0:
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/mini-create-react-context/-/mini-create-react-context-0.4.1.tgz#072171561bfdc922da08a60c2197a497cc2d1d5e"
-  integrity sha512-YWCYEmd5CQeHGSAKrYvXgmzzkrvssZcuuQDDeqkT+PziKGMgE+0MCCtcKbROzocGBG1meBLl2FotlRwf4gAzbQ==
-  dependencies:
-    "@babel/runtime" "^7.12.1"
-    tiny-warning "^1.0.3"
 
 mini-css-extract-plugin@2.6.1, mini-css-extract-plugin@^2.4.5:
   version "2.6.1"
@@ -14697,7 +14675,7 @@ react-is@17.0.2, react-is@^17.0.0, react-is@^17.0.1:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
 
-react-is@^16.13.1, react-is@^16.6.0, react-is@^16.7.0:
+react-is@^16.13.1, react-is@^16.7.0:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
@@ -14737,34 +14715,20 @@ react-refresh@^0.11.0:
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.11.0.tgz#77198b944733f0f1f1a90e791de4541f9f074046"
   integrity sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==
 
-react-router-dom@5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-5.2.0.tgz#9e65a4d0c45e13289e66c7b17c7e175d0ea15662"
-  integrity sha512-gxAmfylo2QUjcwxI63RhQ5G85Qqt4voZpUXSEqCwykV0baaOTQDR1f0PmY8AELqIyVc0NEZUj0Gov5lNGcXgsA==
+react-router-dom@6.6.2:
+  version "6.6.2"
+  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-6.6.2.tgz#bbf1f9b45855b218d22fc2d294b79408a084740a"
+  integrity sha512-6SCDXxRQqW5af8ImOqKza7icmQ47/EMbz572uFjzvcArg3lZ+04PxSPp8qGs+p2Y+q+b+S/AjXv8m8dyLndIIA==
   dependencies:
-    "@babel/runtime" "^7.1.2"
-    history "^4.9.0"
-    loose-envify "^1.3.1"
-    prop-types "^15.6.2"
-    react-router "5.2.0"
-    tiny-invariant "^1.0.2"
-    tiny-warning "^1.0.0"
+    "@remix-run/router" "1.2.1"
+    react-router "6.6.2"
 
-react-router@5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/react-router/-/react-router-5.2.0.tgz#424e75641ca8747fbf76e5ecca69781aa37ea293"
-  integrity sha512-smz1DUuFHRKdcJC0jobGo8cVbhO3x50tCL4icacOlcwDOEQPq4TMqwx3sY1TP+DvtTgz4nm3thuo7A+BK2U0Dw==
+react-router@6.6.2:
+  version "6.6.2"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-6.6.2.tgz#556f7b56cff7fe32c5c02429fef3fcb2ecd08111"
+  integrity sha512-uJPG55Pek3orClbURDvfljhqFvMgJRo59Pktywkk8hUUkTY2aRfza8Yhl/vZQXs+TNQyr6tu+uqz/fLxPICOGQ==
   dependencies:
-    "@babel/runtime" "^7.1.2"
-    history "^4.9.0"
-    hoist-non-react-statics "^3.1.0"
-    loose-envify "^1.3.1"
-    mini-create-react-context "^0.4.0"
-    path-to-regexp "^1.7.0"
-    prop-types "^15.6.2"
-    react-is "^16.6.0"
-    tiny-invariant "^1.0.2"
-    tiny-warning "^1.0.0"
+    "@remix-run/router" "1.2.1"
 
 react-scripts@5.0.1:
   version "5.0.1"
@@ -15242,11 +15206,6 @@ resolve-from@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-5.0.0.tgz#c35225843df8f776df21c57557bc087e9dfdfc69"
   integrity sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==
-
-resolve-pathname@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/resolve-pathname/-/resolve-pathname-3.0.0.tgz#99d02224d3cf263689becbb393bc560313025dcd"
-  integrity sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng==
 
 resolve-url-loader@^4.0.0:
   version "4.0.0"
@@ -16654,12 +16613,7 @@ timers-browserify@^2.0.4:
   dependencies:
     setimmediate "^1.0.4"
 
-tiny-invariant@^1.0.2:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.3.1.tgz#8560808c916ef02ecfd55e66090df23a4b7aa642"
-  integrity sha512-AD5ih2NlSssTCwsMznbvwMZpJ1cbhkGd2uueNxzv2jDlEeZdU04JQfRnggJQ8DrcVBGjAsCKwFBbDlVNtEMlzw==
-
-tiny-warning@^1.0.0, tiny-warning@^1.0.2, tiny-warning@^1.0.3:
+tiny-warning@^1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/tiny-warning/-/tiny-warning-1.0.3.tgz#94a30db453df4c643d0fd566060d60a875d84754"
   integrity sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==
@@ -17368,11 +17322,6 @@ validate-npm-package-license@^3.0.1:
   dependencies:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
-
-value-equal@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/value-equal/-/value-equal-1.0.1.tgz#1e0b794c734c5c0cade179c437d356d931a34d6c"
-  integrity sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw==
 
 vary@~1.1.2:
   version "1.1.2"


### PR DESCRIPTION
## Summary

This PR upgrades the react router to the latest version, and does cleans up a few things along the way. There are a few motivations for the upgrade at this time.
 - Prepare for introducing several `modules` with their own navigation
 - Ensure that Studio doesn't lag behind on versions, making upgrading even harder in the future
 - Clean up some of the routes / Nested routes along the way

The guide at https://reactrouter.com/en/6.7.0/upgrading/v5 was the main reference for helping along the way.

What is **not done** in this PR:
 - Fixing click-jacking of navigation url's (no more onClick) for simple navigation
 - removing `selfservice` as base-url
 - Change ApplicationChanger behaviour to updated pattern. The reason for this is the store does not reset microservices across applications, and thus merges them across application environments. This needs to be fixed as a separate PR.

### Added

- For local dev, added handling in webpack devserver for known urls not using /selfservice basename
- Added a `ButtonLink` component in Studio that extends the design system button with react-router`Link`-component

### Changed

- Upgraded react router to v6.6.2
- Now leaning on relative url's. from within a Nested route, simplifying navigation and the need to build up full urls for router-navigation
- `Button` has a new optional `overrides` property to allow overriding from external usage. Used by `ButtonLink`


### Fixed

- microserviceTable now re-renders when microservices change, and sets the isLoading flag before and after.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203789530758097