### PR TITLE
Alert box fixes

### DIFF
--- a/Source/DesignSystem/atoms/AlertBox/AlertBox.stories.tsx
+++ b/Source/DesignSystem/atoms/AlertBox/AlertBox.stories.tsx
@@ -42,32 +42,32 @@ const InfoMessage = () =>
 
 export const Error = createStory({
     severity: 'error',
-    title: 'Something went wrong',
+    title: 'This is a error title',
     message: <ErrorMessage />
 });
 
 export const Warning = createStory({
     severity: 'warning',
-    title: 'This is a warning.',
+    title: 'This is a warning title',
     message: <ErrorMessage />
 });
 
 export const Info = createStory({
     severity: 'info',
-    title: 'This is an info message.',
+    title: 'This is a informational title',
     message: <InfoMessage />
 });
 
 export const Success = createStory({
     severity: 'success',
-    title: 'All good!',
+    title: 'This is a success title',
     message: 'You are all set up and ready to go!'
 });
 
-export const WithAction = createStory({
+export const WithCloseAction = createStory({
     severity: 'info',
-    title: 'This is an info message.',
-    message: 'For more information, please',
+    title: 'This is an alert box with a "close" action',
+    message: 'You can click the close button to dismiss the alert box.',
     isDismissable: true,
     onDismiss: () => alert('Close action was clicked.')
 });

--- a/Source/DesignSystem/atoms/AlertBox/AlertBox.stories.tsx
+++ b/Source/DesignSystem/atoms/AlertBox/AlertBox.stories.tsx
@@ -29,17 +29,13 @@ metadata.parameters = {
 metadata.argTypes = {
     message: {
         control: {
-            type: 'text'
+            type: 'text',
+            value: 'This is a message'
         },
         table: {
             type: {
                 summary: 'string | ReactElement'
             }
-        }
-    },
-    isDismissable: {
-        control: {
-            type: 'boolean'
         }
     },
     sx: {
@@ -52,6 +48,11 @@ metadata.argTypes = {
             }
         }
     }
+};
+
+metadata.args = {
+    isDismissible: false,
+    isOpen: true
 };
 
 export default metadata;
@@ -84,5 +85,5 @@ export const WithCloseAction = createStory({
     severity: 'info',
     title: 'This is an alert box with a "close" action',
     message: 'You can click the close button to dismiss the alert box.',
-    isDismissable: true
+    isDismissible: true
 });

--- a/Source/DesignSystem/atoms/AlertBox/AlertBox.stories.tsx
+++ b/Source/DesignSystem/atoms/AlertBox/AlertBox.stories.tsx
@@ -28,6 +28,39 @@ metadata.parameters = {
     }
 };
 
+metadata.argTypes = {
+    message: {
+        control: {
+            type: 'text'
+        },
+        table: {
+            type: {
+                summary: 'string | ReactElement'
+            }
+        }
+    },
+    isDismissable: {
+        control: {
+            type: 'boolean'
+        }
+    },
+    onDismiss: {
+        control: {
+            disable: true
+        }
+    },
+    sx: {
+        control: {
+            disable: true
+        },
+        table: {
+            type: {
+                summary: 'SxProps'
+            }
+        }
+    }
+};
+
 export default metadata;
 
 const ErrorMessage = () =>

--- a/Source/DesignSystem/atoms/AlertBox/AlertBox.stories.tsx
+++ b/Source/DesignSystem/atoms/AlertBox/AlertBox.stories.tsx
@@ -44,11 +44,6 @@ metadata.argTypes = {
             type: 'boolean'
         }
     },
-    onDismiss: {
-        control: {
-            disable: true
-        }
-    },
     sx: {
         control: {
             disable: true
@@ -101,6 +96,5 @@ export const WithCloseAction = createStory({
     severity: 'info',
     title: 'This is an alert box with a "close" action',
     message: 'You can click the close button to dismiss the alert box.',
-    isDismissable: true,
-    onDismiss: () => alert('Close action was clicked.')
+    isDismissable: true
 });

--- a/Source/DesignSystem/atoms/AlertBox/AlertBox.stories.tsx
+++ b/Source/DesignSystem/atoms/AlertBox/AlertBox.stories.tsx
@@ -1,6 +1,10 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+import React from 'react';
+
+import { Link } from '@mui/material';
+
 import { componentStories } from '@dolittle/design-system';
 
 import { AlertBox } from './AlertBox';
@@ -24,53 +28,46 @@ metadata.parameters = {
     }
 };
 
-
 export default metadata;
+
+const ErrorMessage = () =>
+    <>
+        Please try again later. If problem persists, please contact <Link href='#'>Dolittle support</Link>.
+    </>;
+
+const InfoMessage = () =>
+    <>
+        For more information, please contact <Link href='#'>Dolittle support</Link>.
+    </>;
 
 export const Error = createStory({
     severity: 'error',
     title: 'Something went wrong',
-    message: 'Please try again later. If problem persists, please',
-    endWithLink: {
-        linkHref: 'mailto: support@dolittle.com',
-        linkText: 'contact support'
-    }
+    message: <ErrorMessage />
 });
 
 export const Warning = createStory({
     severity: 'warning',
     title: 'This is a warning.',
-    message: 'Please try again later. If problem persists, please',
-    endWithLink: {
-        linkHref: 'mailto: support@dolittle.com',
-        linkText: 'contact support'
-    }
+    message: <ErrorMessage />
 });
 
 export const Info = createStory({
     severity: 'info',
     title: 'This is an info message.',
-    message: 'For more information, please',
-    endWithLink: {
-        linkHref: 'https://www.dolittle.com/',
-        linkText: 'look our website'
-    }
+    message: <InfoMessage />
 });
 
 export const Success = createStory({
     severity: 'success',
     title: 'All good!',
-    message: 'You are all set up and ready to go!',
+    message: 'You are all set up and ready to go!'
 });
 
 export const WithAction = createStory({
     severity: 'info',
     title: 'This is an info message.',
     message: 'For more information, please',
-    endWithLink: {
-        linkHref: 'https://www.dolittle.com/',
-        linkText: 'look our website'
-    },
     isDismissable: true,
     onDismiss: () => alert('Close action was clicked.')
 });

--- a/Source/DesignSystem/atoms/AlertBox/AlertBox.stories.tsx
+++ b/Source/DesignSystem/atoms/AlertBox/AlertBox.stories.tsx
@@ -3,11 +3,9 @@
 
 import React from 'react';
 
-import { Link } from '@mui/material';
-
 import { componentStories } from '@dolittle/design-system';
 
-import { AlertBox } from './AlertBox';
+import { AlertBox, AlertBoxErrorMessage, AlertBoxInfoMessage } from './AlertBox';
 
 const { metadata, createStory } = componentStories(AlertBox);
 
@@ -58,32 +56,22 @@ metadata.argTypes = {
 
 export default metadata;
 
-const ErrorMessage = () =>
-    <>
-        Please try again later. If problem persists, please contact <Link href='#'>Dolittle support</Link>.
-    </>;
-
-const InfoMessage = () =>
-    <>
-        For more information, please contact <Link href='#'>Dolittle support</Link>.
-    </>;
-
 export const Error = createStory({
     severity: 'error',
     title: 'This is a error title',
-    message: <ErrorMessage />
+    message: <AlertBoxErrorMessage />
 });
 
 export const Warning = createStory({
     severity: 'warning',
     title: 'This is a warning title',
-    message: <ErrorMessage />
+    message: <AlertBoxErrorMessage />
 });
 
 export const Info = createStory({
     severity: 'info',
     title: 'This is a informational title',
-    message: <InfoMessage />
+    message: <AlertBoxInfoMessage />
 });
 
 export const Success = createStory({

--- a/Source/DesignSystem/atoms/AlertBox/AlertBox.stories.tsx
+++ b/Source/DesignSystem/atoms/AlertBox/AlertBox.stories.tsx
@@ -14,13 +14,13 @@ const { metadata, createStory } = componentStories(AlertBox);
 metadata.parameters = {
     docs: {
         description: {
-            component: `An alert displays a short, important message in a way that attracts the user’s attention without interrupting the user’s tasks. These should not be confused with snackbars, which are used to signal feedback around specific system tasks that a user has just completed or attempted to complete. Alerts are used to indicate system status and feedback as a whole.
+            component: `An alert displays a short, important message in a way that attracts the user's attention without interrupting the user's tasks. These should not be confused with snackbars, which are used to signal feedback around specific system tasks that a user has just completed or attempted to complete. Alerts are used to indicate system status and feedback as a whole.
             
 **Styling:** The default style for alerts is outlined with an icon to indicate what severity level the alert is. Alerts can contain a title that provides additional information about the severity level. An alert can have an action such as a close button.
 
 **Severity levels:** We have four severity levels: error alerts, warning alerts, info alerts, and success alerts. 
-- *Error alerts* let the user know something is wrong. Explain the problem and provide the user with a next step, an alternative solution or contact information to our help services. Keep the message simple and direct. Don’t use technical details or blame the user. 
-- *Warning alerts* anticipate a change that will impact the system and therefore user’s experience. Inform but don’t alarm. If an action is required from the user, clearly state what is needed and tell them what to expect after. Provide a cancel option if possible. 
+- *Error alerts* let the user know something is wrong. Explain the problem and provide the user with a next step, an alternative solution or contact information to our help services. Keep the message simple and direct. Don't use technical details or blame the user. 
+- *Warning alerts* anticipate a change that will impact the system and therefore user's experience. Inform but don't alarm. If an action is required from the user, clearly state what is needed and tell them what to expect after. Provide a cancel option if possible. 
 - *Success alerts* indicate the system is functioning as it should.  
 - *Info alerts* provide the user with additional helpful information that doesn't require action.
 `,

--- a/Source/DesignSystem/atoms/AlertBox/AlertBox.tsx
+++ b/Source/DesignSystem/atoms/AlertBox/AlertBox.tsx
@@ -15,28 +15,23 @@ export type AlertBoxProps = {
 
     /**
      * Required. The title of the alert.
-     * @type {string}
      */
     title: string;
 
     /**
      * Required. The message of the alert.
-     * @type {string}
-     * @type {ReactElement}
      */
     message: string | ReactElement;
 
     /**
      * Set if the alert is dismissable.
      * @default false
-     * @type {boolean}
      */
     isDismissable?: boolean;
     onDismiss?: () => void;
 
     /**
      * The sx prop lets you add custom styles to the component, overriding the styles defined by Material-UI.
-     * @type {SxProps}
      */
     sx?: SxProps;
 };

--- a/Source/DesignSystem/atoms/AlertBox/AlertBox.tsx
+++ b/Source/DesignSystem/atoms/AlertBox/AlertBox.tsx
@@ -1,9 +1,9 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-import React, { ReactElement } from 'react';
+import React, { ReactElement, useState } from 'react';
 
-import { Alert, AlertTitle, SxProps, Typography } from '@mui/material';
+import { Alert, AlertTitle, Collapse, SxProps, Typography } from '@mui/material';
 
 import { IconButton } from '@dolittle/design-system/atoms/IconButton/IconButton';
 
@@ -28,7 +28,6 @@ export type AlertBoxProps = {
      * @default false
      */
     isDismissable?: boolean;
-    onDismiss?: () => void;
 
     /**
      * The sx prop lets you add custom styles to the component, overriding the styles defined by Material-UI.
@@ -47,18 +46,25 @@ export type AlertBoxProps = {
  *    message='Something went wrong.'
  * />
  */
-export const AlertBox = ({ severity, isDismissable, onDismiss, sx, title, message }: AlertBoxProps): ReactElement =>
-    <Alert
-        variant='outlined'
-        severity={severity}
-        action={isDismissable && <IconButton onClick={onDismiss} />}
-        sx={{
-            'display': 'inline-flex',
-            'borderColor': severity === 'error' ? 'error.dark' : null,
-            '& .MuiAlert-action': { pt: 0 },
-            ...sx
-        }}
-    >
-        <AlertTitle>{title}</AlertTitle>
-        <Typography variant='body2'>{message}</Typography>
-    </Alert>;
+export const AlertBox = ({ severity, isDismissable, sx, title, message }: AlertBoxProps): ReactElement => {
+    const [open, setOpen] = useState(true);
+
+    return (
+        <Collapse in={open}>
+            <Alert
+                variant='outlined'
+                severity={severity}
+                action={isDismissable && <IconButton onClick={() => setOpen(false)} />}
+                sx={{
+                    'display': 'inline-flex',
+                    'borderColor': severity === 'error' ? 'error.dark' : null,
+                    '& .MuiAlert-action': { pt: 0 },
+                    ...sx
+                }}
+            >
+                <AlertTitle>{title}</AlertTitle>
+                <Typography variant='body2'>{message}</Typography>
+            </Alert>
+        </Collapse>
+    );
+};

--- a/Source/DesignSystem/atoms/AlertBox/AlertBox.tsx
+++ b/Source/DesignSystem/atoms/AlertBox/AlertBox.tsx
@@ -3,55 +3,31 @@
 
 import React from 'react';
 
-import { Alert, AlertTitle, Box, Link, SxProps, Typography } from '@mui/material';
+import { Alert, AlertTitle, SxProps, Typography } from '@mui/material';
 
 import { IconButton } from '@dolittle/design-system/atoms/IconButton/IconButton';
-
-type LinkContent = {
-    linkText: string;
-    linkHref: string;
-};
 
 export type AlertBoxProps = {
     severity: 'error' | 'warning' | 'info' | 'success';
     title: string;
-    message: string;
-    endWithLink?: LinkContent;
+    message: React.ReactElement | string;
     isDismissable?: boolean;
     onDismiss?: () => void;
     sx?: SxProps;
 };
 
-const spaceChar = '\u2002';
-const periodChar = '.';
-
-const MessageEndLink = ({ linkText, linkHref }: LinkContent) =>
-    <Typography variant='body2'>
-        {spaceChar}
-        <Link href={linkHref}>{linkText}</Link>
-        {periodChar}
-    </Typography>;
-
-export const AlertBox = ({ severity, isDismissable, onDismiss, sx, title, message, endWithLink }: AlertBoxProps) =>
+export const AlertBox = ({ severity, isDismissable, onDismiss, sx, title, message }: AlertBoxProps) =>
     <Alert
         variant='outlined'
         severity={severity}
         action={isDismissable && <IconButton onClick={onDismiss} />}
         sx={{
             'display': 'inline-flex',
-            'textAlign': 'left',
-            'position': 'relative',
             'borderColor': severity === 'error' ? 'error.dark' : null,
-            '& .MuiAlert-action': {
-                pt: 0
-            },
+            '& .MuiAlert-action': { pt: 0 },
             ...sx
         }}
     >
         <AlertTitle>{title}</AlertTitle>
-
-        <Box sx={{ display: 'inline-flex' }}>
-            <Typography variant='body2'>{message}</Typography>
-            {endWithLink && <MessageEndLink {...endWithLink} />}
-        </Box>
+        <Typography variant='body2'>{message}</Typography>
     </Alert>;

--- a/Source/DesignSystem/atoms/AlertBox/AlertBox.tsx
+++ b/Source/DesignSystem/atoms/AlertBox/AlertBox.tsx
@@ -19,9 +19,10 @@ export const AlertBoxInfoMessage = () =>
 
 export type AlertBoxProps = {
     /**
-     * Required. The severity of the alert.
+     * The severity of the alert.
+     * @default 'error'
      */
-    severity: 'error' | 'warning' | 'info' | 'success';
+    severity?: 'error' | 'warning' | 'info' | 'success';
 
     /**
      * Required. The title of the alert.
@@ -64,7 +65,7 @@ export const AlertBox = ({ severity, isDismissable, sx, title, message }: AlertB
         <Collapse in={open}>
             <Alert
                 variant='outlined'
-                severity={severity}
+                severity={severity || 'error'}
                 action={isDismissable && <IconButton onClick={() => setOpen(false)} />}
                 sx={{
                     'display': 'inline-flex',

--- a/Source/DesignSystem/atoms/AlertBox/AlertBox.tsx
+++ b/Source/DesignSystem/atoms/AlertBox/AlertBox.tsx
@@ -48,7 +48,7 @@ export type AlertBoxProps = {
 };
 
 /**
- * A AlertBox component.
+ * A alert box component.
  * @param {...AlertBoxProps} props - The {@link AlertBoxProps}.
  * @returns {ReactElement} A new {@link AlertBox} component.
  * @example
@@ -69,7 +69,7 @@ export const AlertBox = ({ severity, isDismissable, sx, title, message }: AlertB
                 action={isDismissable && <IconButton onClick={() => setOpen(false)} />}
                 sx={{
                     'display': 'inline-flex',
-                    'borderColor': severity === 'error' ? 'error.dark' : null,
+                    'borderColor': !severity || severity === 'error' ? 'error.dark' : null,
                     'textAlign': 'left',
                     '& .MuiAlert-action': { pt: 0 },
                     ...sx

--- a/Source/DesignSystem/atoms/AlertBox/AlertBox.tsx
+++ b/Source/DesignSystem/atoms/AlertBox/AlertBox.tsx
@@ -1,22 +1,58 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-import React from 'react';
+import React, { ReactElement } from 'react';
 
 import { Alert, AlertTitle, SxProps, Typography } from '@mui/material';
 
 import { IconButton } from '@dolittle/design-system/atoms/IconButton/IconButton';
 
 export type AlertBoxProps = {
+    /**
+     * Required. The severity of the alert.
+     */
     severity: 'error' | 'warning' | 'info' | 'success';
+
+    /**
+     * Required. The title of the alert.
+     * @type {string}
+     */
     title: string;
-    message: React.ReactElement | string;
+
+    /**
+     * Required. The message of the alert.
+     * @type {string}
+     * @type {ReactElement}
+     */
+    message: string | ReactElement;
+
+    /**
+     * Set if the alert is dismissable.
+     * @default false
+     * @type {boolean}
+     */
     isDismissable?: boolean;
     onDismiss?: () => void;
+
+    /**
+     * The sx prop lets you add custom styles to the component, overriding the styles defined by Material-UI.
+     * @type {SxProps}
+     */
     sx?: SxProps;
 };
 
-export const AlertBox = ({ severity, isDismissable, onDismiss, sx, title, message }: AlertBoxProps) =>
+/**
+ * A AlertBox component.
+ * @param {...AlertBoxProps} props - The {@link AlertBoxProps}.
+ * @returns {ReactElement} A new {@link AlertBox} component.
+ * @example
+ * <AlertBox
+ *    severity='error'
+ *    title='Error'
+ *    message='Something went wrong.'
+ * />
+ */
+export const AlertBox = ({ severity, isDismissable, onDismiss, sx, title, message }: AlertBoxProps): ReactElement =>
     <Alert
         variant='outlined'
         severity={severity}

--- a/Source/DesignSystem/atoms/AlertBox/AlertBox.tsx
+++ b/Source/DesignSystem/atoms/AlertBox/AlertBox.tsx
@@ -3,9 +3,19 @@
 
 import React, { ReactElement, useState } from 'react';
 
-import { Alert, AlertTitle, Collapse, SxProps, Typography } from '@mui/material';
+import { Alert, AlertTitle, Collapse, Link, SxProps, Typography } from '@mui/material';
 
 import { IconButton } from '@dolittle/design-system/atoms/IconButton/IconButton';
+
+export const AlertBoxErrorMessage = () =>
+    <>
+        Please try again later. If problem persists, please contact <Link href='#'>Dolittle support</Link>.
+    </>;
+
+export const AlertBoxInfoMessage = () =>
+    <>
+        For more information, please contact <Link href='#'>Dolittle support</Link>.
+    </>;
 
 export type AlertBoxProps = {
     /**
@@ -15,6 +25,7 @@ export type AlertBoxProps = {
 
     /**
      * Required. The title of the alert.
+     * Convension is to NOT use a period at the end of the title.
      */
     title: string;
 
@@ -58,6 +69,7 @@ export const AlertBox = ({ severity, isDismissable, sx, title, message }: AlertB
                 sx={{
                     'display': 'inline-flex',
                     'borderColor': severity === 'error' ? 'error.dark' : null,
+                    'textAlign': 'left',
                     '& .MuiAlert-action': { pt: 0 },
                     ...sx
                 }}

--- a/Source/DesignSystem/atoms/AlertBox/AlertBox.tsx
+++ b/Source/DesignSystem/atoms/AlertBox/AlertBox.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-import React, { ReactElement, useState } from 'react';
+import React, { ReactElement, useState, useEffect } from 'react';
 
 import { Alert, AlertTitle, Collapse, Link, SxProps, Typography } from '@mui/material';
 
@@ -20,26 +20,44 @@ export const AlertBoxInfoMessage = () =>
 export type AlertBoxProps = {
     /**
      * The severity of the alert.
-     * @default 'error'
+     * @default error
      */
     severity?: 'error' | 'warning' | 'info' | 'success';
 
     /**
      * Required. The title of the alert.
+     *
      * Convension is to NOT use a period at the end of the title.
      */
     title: string;
 
     /**
      * Required. The message of the alert.
+     *
+     * Link component can be used to add links to the message.
      */
     message: string | ReactElement;
 
     /**
-     * Set if the alert is dismissable.
+     * Set if the alert is dismissible.
+     *
+     * This will put the close, 'x', icon to the top right.
      * @default false
      */
-    isDismissable?: boolean;
+    isDismissible?: boolean;
+
+    /**
+     * Set alert box as closed with 'false' value and open alert conditionally inside the parent component.
+     * @default true
+     */
+    isOpen?: boolean;
+
+    /**
+     * If alert box is set to be closed conditionally (isOpen=false) inside the parent component,
+     * this callback function can be called if the alert should be dismissed.
+     * @default undefined
+     */
+    onDismissed?: () => void;
 
     /**
      * The sx prop lets you add custom styles to the component, overriding the styles defined by Material-UI.
@@ -58,15 +76,23 @@ export type AlertBoxProps = {
  *    message='Something went wrong.'
  * />
  */
-export const AlertBox = ({ severity, isDismissable, sx, title, message }: AlertBoxProps): ReactElement => {
-    const [open, setOpen] = useState(true);
+export const AlertBox = ({ severity, title, message, isDismissible, isOpen = true, onDismissed, sx }: AlertBoxProps): ReactElement => {
+    const [open, setOpen] = useState(isOpen);
+
+    useEffect(() => {
+        setOpen(isOpen);
+    }, [isOpen]);
 
     return (
         <Collapse in={open}>
             <Alert
                 variant='outlined'
                 severity={severity || 'error'}
-                action={isDismissable && <IconButton onClick={() => setOpen(false)} />}
+                role='alert'
+                action={isDismissible && <IconButton onClick={() => {
+                    setOpen(false);
+                    onDismissed?.();
+                }} />}
                 sx={{
                     'display': 'inline-flex',
                     'borderColor': !severity || severity === 'error' ? 'error.dark' : null,

--- a/Source/DesignSystem/atoms/AlertBox/index.ts
+++ b/Source/DesignSystem/atoms/AlertBox/index.ts
@@ -1,4 +1,4 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-export { AlertBox, AlertBoxProps } from './AlertBox';
+export { AlertBox, AlertBoxProps, AlertBoxErrorMessage, AlertBoxInfoMessage } from './AlertBox';

--- a/Source/DesignSystem/index.ts
+++ b/Source/DesignSystem/index.ts
@@ -6,7 +6,7 @@ export { themeDark } from './theming/theme';
 
 // Atoms
 export { Accordion } from './atoms/Accordion';
-export { AlertBox, AlertBoxErrorMessage, AlertBoxInfoMessage } from './atoms/AlertBox';
+export { AlertBox, AlertBoxProps, AlertBoxErrorMessage, AlertBoxInfoMessage } from './atoms/AlertBox';
 export { Button } from './atoms/Button';
 export { ConfirmDialog } from './atoms/ConfirmDialog';
 export { Checkbox, Form, Input, Select, SwitchToggle } from './atoms/Forms';

--- a/Source/DesignSystem/index.ts
+++ b/Source/DesignSystem/index.ts
@@ -6,7 +6,7 @@ export { themeDark } from './theming/theme';
 
 // Atoms
 export { Accordion } from './atoms/Accordion';
-export { AlertBox } from './atoms/AlertBox';
+export { AlertBox, AlertBoxErrorMessage, AlertBoxInfoMessage } from './atoms/AlertBox';
 export { Button } from './atoms/Button';
 export { ConfirmDialog } from './atoms/ConfirmDialog';
 export { Checkbox, Form, Input, Select, SwitchToggle } from './atoms/Forms';

--- a/Source/SelfService/Web/App.tsx
+++ b/Source/SelfService/Web/App.tsx
@@ -78,7 +78,7 @@ export const App = () => {
                                     success: Snackbar
                                 }}
                                 iconVariant={{
-                                    error: <ErrorRounded fontSize="small" sx={{ mr: 1 }} />,
+                                    error: <ErrorRounded fontSize='small' sx={{ mr: 1 }} />,
                                     warning: null,
                                     info: null,
                                     success: null,

--- a/Source/SelfService/Web/application/building.tsx
+++ b/Source/SelfService/Web/application/building.tsx
@@ -9,7 +9,7 @@ import { isApplicationOnline } from '../api/application';
 import { Box, List, ListItem, Typography } from '@mui/material';
 import { ArrowBack } from '@mui/icons-material';
 
-import { AlertBox, Button, LoadingSpinner } from '@dolittle/design-system';
+import { AlertBox, AlertBoxErrorMessage, Button, LoadingSpinner } from '@dolittle/design-system';
 
 export const Building = () => {
     const { applicationId } = useParams() as any;
@@ -33,7 +33,7 @@ export const Building = () => {
     if (!isLoading) {
         return (
             <Box sx={{ width: 1 }}>
-                <AlertBox title='Could not create application.' message='Please try again later. If problem persists, please contact support.' severity='error' />
+                <AlertBox title='Could not create application' message={<AlertBoxErrorMessage />} severity='error' />
                 <Button label='Go back to applications page' secondary startWithIcon={<ArrowBack />} href='/applications/' sx={{ mt: 4 }} />
             </Box>
         );

--- a/Source/SelfService/Web/application/create/create.tsx
+++ b/Source/SelfService/Web/application/create/create.tsx
@@ -7,7 +7,7 @@ import { useHistory } from 'react-router-dom';
 import { Typography } from '@mui/material';
 
 import { Guid } from '@dolittle/rudiments';
-import { AlertBox, Form, LoadingSpinner } from '@dolittle/design-system';
+import { AlertBox, AlertBoxErrorMessage, Form, LoadingSpinner } from '@dolittle/design-system';
 
 import { createApplication, HttpApplicationRequest } from '../../api/application';
 
@@ -98,12 +98,7 @@ export const Create = () => {
                 {errorOnCreatingApp &&
                     <AlertBox
                         title='Oops, something went wrong'
-                        message='Please try again later. If problem persists, please'
-                        severity='error'
-                        endWithLink={{
-                            linkText: 'contact support',
-                            linkHref: 'mailto: support@dolittle.com'
-                        }}
+                        message={<AlertBoxErrorMessage />}
                         sx={{ mt: 6 }}
                     />
                 }

--- a/Source/SelfService/Web/logging/logPanel.tsx
+++ b/Source/SelfService/Web/logging/logPanel.tsx
@@ -3,18 +3,10 @@
 
 import React, { useState, useCallback } from 'react';
 import { InView } from 'react-intersection-observer';
-import {
-    Box,
-    Divider,
-    FormControlLabel,
-    FormGroup,
-    Grid,
-    Paper,
-    Switch,
-    Typography,
-} from '@mui/material';
 
-import { AlertBox } from '@dolittle/design-system';
+import { Box, Divider, FormControlLabel, FormGroup, Grid, Paper, Switch, Typography, } from '@mui/material';
+
+import { AlertBox, AlertBoxErrorMessage } from '@dolittle/design-system';
 
 import { ObservableLogLines, ObservablePartialLogLines } from './loki/logLines';
 import { DataLabels } from './loki/types';
@@ -103,13 +95,8 @@ export const LogPanel = (props: LogPanelProps) => {
     if (props.logs.failed) {
         return (
             <AlertBox
-                severity="error"
                 title='Something went wrong'
-                message='Please try again later. If the problem persists, please'
-                endWithLink={{
-                    linkText: 'contact support',
-                    linkHref: 'mailto:support@dolittle.com'
-                }}
+                message={<AlertBoxErrorMessage />}
                 sx={{ mt: 2 }}
             />
         );

--- a/Source/SelfService/Web/microservice/microserviceView/configurationFilesSection/environmentVariablesSection/environmentVariableSection.tsx
+++ b/Source/SelfService/Web/microservice/microserviceView/configurationFilesSection/environmentVariablesSection/environmentVariableSection.tsx
@@ -162,7 +162,6 @@ export const EnvironmentVariablesSection = ({ applicationId, environment, micros
         return updatedRow;
     };
 
-    // Naming
     const handleEnvVariableAdd = () => {
         setDisableAddButton(true);
 
@@ -259,7 +258,7 @@ export const EnvironmentVariablesSection = ({ applicationId, environment, micros
                     />
                 </Box>
 
-                <RestartInfoBox name={microserviceName} isAlertBoxOpen={restartInfoBoxIsOpen} handleDismiss={() => setRestartInfoBoxIsOpen(false)} />
+                <RestartInfoBox microserviceName={microserviceName} isOpen={restartInfoBoxIsOpen} onDismissed={() => setRestartInfoBoxIsOpen(false)} />
 
                 {noEnvVariables ?
                     <EmptyDataTable

--- a/Source/SelfService/Web/microservice/microserviceView/configurationFilesSection/filesSection/filesSection.tsx
+++ b/Source/SelfService/Web/microservice/microserviceView/configurationFilesSection/filesSection/filesSection.tsx
@@ -197,7 +197,7 @@ export const FilesSection = ({ applicationId, environment, microserviceName, mic
 
                 <FileUploadForm ref={fileUploadRef} onSelected={handleFileSelect} allowMultipleFiles />
 
-                <RestartInfoBox name={microserviceName} isAlertBoxOpen={restartInfoBoxIsOpen} handleDismiss={() => setRestartInfoBoxIsOpen(false)} />
+                <RestartInfoBox microserviceName={microserviceName} isOpen={restartInfoBoxIsOpen} onDismissed={() => setRestartInfoBoxIsOpen(false)} />
 
                 {configFileTableRows.length > 0 ?
                     <ConfigFilesTable rows={configFileTableRows} selectionModel={selectedRowIds} handleSelectionModelChange={setSelectedRowIds} /> :

--- a/Source/SelfService/Web/microservice/microserviceView/configurationFilesSection/restartInfoBox.tsx
+++ b/Source/SelfService/Web/microservice/microserviceView/configurationFilesSection/restartInfoBox.tsx
@@ -3,27 +3,21 @@
 
 import React from 'react';
 
-import { Collapse } from '@mui/material';
+import { AlertBox, AlertBoxProps } from '@dolittle/design-system';
 
-import { AlertBox } from '@dolittle/design-system';
-
-type RestartInfoBoxProps = {
-    name: string;
-    isAlertBoxOpen: boolean;
-    handleDismiss: () => void;
+type RestartInfoBoxProps = Partial<AlertBoxProps> & {
+    microserviceName: string;
 };
 
-export const RestartInfoBox = ({ name, isAlertBoxOpen, handleDismiss }: RestartInfoBoxProps) =>
-    <Collapse in={isAlertBoxOpen}>
-        <AlertBox
-            severity='info'
-            title='Restart Microservice'
-            message={
-                `New uploads will be added as soon as microservice '${name}' restarts.
+export const RestartInfoBox = ({ microserviceName, ...alertBoxProps }: RestartInfoBoxProps) =>
+    <AlertBox
+        severity='info'
+        title='Restart Microservice'
+        message={
+            `New uploads will be added as soon as microservice '${name}' restarts.
                 It will restart automatically in a few minutes or you can manually restart it now.`
-            }
-            isDismissable
-            onDismiss={handleDismiss}
-            sx={{ width: 1, mb: 2 }}
-        />
-    </Collapse>;
+        }
+        isDismissible
+        sx={{ width: 1, mb: 2 }}
+        {...alertBoxProps}
+    />;

--- a/Source/SelfService/Web/microservice/microserviceView/healthStatus/healthStatus.tsx
+++ b/Source/SelfService/Web/microservice/microserviceView/healthStatus/healthStatus.tsx
@@ -5,7 +5,7 @@ import React, { useMemo, useState } from 'react';
 
 import { RestartAltRounded } from '@mui/icons-material';
 
-import { AlertBox, Button, Graph } from '@dolittle/design-system';
+import { AlertBox, AlertBoxErrorMessage, Button, Graph } from '@dolittle/design-system';
 
 import { ContainerStatusInfo, HttpResponsePodStatus } from '../../../api/api';
 
@@ -103,13 +103,8 @@ export const HealthStatus = ({ applicationId, environment, microserviceId, msNam
             {containerTables.length > 0
                 ? containerTables
                 : <AlertBox
-                    severity='error'
                     title='Cannot display microservice containers'
-                    message='Please try again later. If problem persists, please'
-                    endWithLink={{
-                        linkText: 'contact support',
-                        linkHref: 'mailto: support@dolittle.com'
-                    }}
+                    message={<AlertBoxErrorMessage />}
                 />
             }
 


### PR DESCRIPTION
## Summary

Make AlertBox component in Design System reusable and add JsDocs for documentation.
Display AlertBox in stories and added controls so it would be easier to understand how to use alerts in code.

<img width="985" alt="Screenshot 2023-01-27 at 01 06 05" src="https://user-images.githubusercontent.com/19160439/214970644-d61029d0-edd0-4fca-a76b-71cf6d59f397.png">

### Added

- JsDocs to AlertBox.tsx
- Controls to AlertBox.stories.tsx
- Controlled alert 'open' and 'close' state if needed

### Fixed

- Better wording in alertBox.stories.tsx
- How to use links inside alert message

