### PR TITLE
Storybook icon buttons

### DIFF
--- a/Source/DesignSystem/atoms/AlertBox/AlertBox.tsx
+++ b/Source/DesignSystem/atoms/AlertBox/AlertBox.tsx
@@ -5,7 +5,7 @@ import React, { ReactElement, useState, useEffect } from 'react';
 
 import { Alert, AlertTitle, Collapse, Link, SxProps, Typography } from '@mui/material';
 
-import { IconButton } from '@dolittle/design-system/atoms/IconButton/IconButton';
+import { IconButton } from '@dolittle/design-system';
 
 export const AlertBoxErrorMessage = () =>
     <>
@@ -89,10 +89,14 @@ export const AlertBox = ({ severity, title, message, isDismissible, isOpen = tru
                 variant='outlined'
                 severity={severity || 'error'}
                 role='alert'
-                action={isDismissible && <IconButton onClick={() => {
-                    setOpen(false);
-                    onDismissed?.();
-                }} />}
+                action={isDismissible &&
+                    <IconButton
+                        label='Dismiss alert'
+                        onClick={() => {
+                            setOpen(false);
+                            onDismissed?.();
+                        }}
+                    />}
                 sx={{
                     'display': 'inline-flex',
                     'borderColor': !severity || severity === 'error' ? 'error.dark' : null,

--- a/Source/DesignSystem/atoms/ConfirmDialog/ConfirmDialog.tsx
+++ b/Source/DesignSystem/atoms/ConfirmDialog/ConfirmDialog.tsx
@@ -28,7 +28,7 @@ export const ConfirmDialog = ({ isOpen, id, title, description, children, handle
     >
         <DialogTitle id={`${id}-title`} variant='h6' sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
             {title}
-            <IconButton onClick={handleCancel} />
+            <IconButton label='Close dialog' onClick={handleCancel} />
         </DialogTitle>
 
         <DialogContent>

--- a/Source/DesignSystem/atoms/ConfirmDialog/ConfirmDialog.tsx
+++ b/Source/DesignSystem/atoms/ConfirmDialog/ConfirmDialog.tsx
@@ -3,10 +3,9 @@
 
 import React from 'react';
 
-import { IconButton, Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle } from '@mui/material';
-import { CloseRounded } from '@mui/icons-material';
+import { Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle } from '@mui/material';
 
-import { Button } from '@dolittle/design-system';
+import { Button, IconButton } from '@dolittle/design-system';
 
 export type ConfirmDialogProps = {
     id: string;
@@ -27,18 +26,9 @@ export const ConfirmDialog = ({ isOpen, id, title, description, children, handle
         aria-labelledby={`${id}-title`}
         aria-describedby={`${id}-description`}
     >
-        <DialogTitle id={`${id}-title`} variant='h6'>
+        <DialogTitle id={`${id}-title`} variant='h6' sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
             {title}
-            <IconButton
-                onClick={handleCancel}
-                sx={{
-                    position: 'absolute',
-                    right: 8,
-                    top: 8,
-                    color: 'text.primary'
-                }}>
-                {<CloseRounded />}
-            </IconButton>
+            <IconButton onClick={handleCancel} />
         </DialogTitle>
 
         <DialogContent>

--- a/Source/DesignSystem/atoms/IconButton/IconButton.stories.tsx
+++ b/Source/DesignSystem/atoms/IconButton/IconButton.stories.tsx
@@ -59,9 +59,11 @@ Inherit.parameters = {
 };
 
 export const Secondary = createStory({
+    label: 'Secondary Icon Button',
     color: 'primary'
 });
 
 export const Disabled = createStory({
+    label: 'Disabled Icon Button',
     disabled: true
 });

--- a/Source/DesignSystem/atoms/IconButton/IconButton.stories.tsx
+++ b/Source/DesignSystem/atoms/IconButton/IconButton.stories.tsx
@@ -12,7 +12,7 @@ const { metadata, createStory } = componentStories(IconButton);
 metadata.argTypes = {
     label: {
         type: 'string',
-        defaultValue: 'Download',
+        defaultValue: 'Close',
         control: {
             type: 'text'
         }
@@ -34,6 +34,9 @@ metadata.argTypes = {
     href: {
         control: false
     },
+    download: {
+        control: false
+    },
     onClick: {
         control: false
     }
@@ -46,8 +49,7 @@ export const Inherit = createStory({
     icon: <DownloadRounded />
 });
 
-// TODO: Haven't figured out how to display react elements in the docs tab yet
-// so this is a workaround.
+// TODO: Haven't figured out how to display react SVG elements in the docs tab yet, so this is a workaround.
 Inherit.parameters = {
     docs: {
         source: {

--- a/Source/DesignSystem/atoms/IconButton/IconButton.stories.tsx
+++ b/Source/DesignSystem/atoms/IconButton/IconButton.stories.tsx
@@ -5,11 +5,39 @@ import React from 'react';
 
 import { DownloadRounded } from '@mui/icons-material';
 
-import { componentStories } from '@dolittle/design-system';
-
-import { IconButton } from './IconButton';
+import { componentStories, IconButton } from '@dolittle/design-system';
 
 const { metadata, createStory } = componentStories(IconButton);
+
+metadata.argTypes = {
+    label: {
+        type: 'string',
+        defaultValue: 'Download',
+        control: {
+            type: 'text'
+        }
+    },
+    icon: {
+        control: false,
+        table: {
+            type: {
+                summary: 'ReactElement<SvgIconProps>'
+            }
+        }
+    },
+    color: {
+        defaultValue: 'inherit'
+    },
+    size: {
+        defaultValue: 'small'
+    },
+    href: {
+        control: false
+    },
+    onClick: {
+        control: false
+    }
+};
 
 export default metadata;
 
@@ -17,6 +45,16 @@ export const Inherit = createStory({
     label: 'Download',
     icon: <DownloadRounded />
 });
+
+// TODO: Haven't figured out how to display react elements in the docs tab yet
+// so this is a workaround.
+Inherit.parameters = {
+    docs: {
+        source: {
+            code: `<IconButton label='Download' icon={<DownloadRounded />} />`
+        }
+    }
+};
 
 export const Secondary = createStory({
     color: 'primary'

--- a/Source/DesignSystem/atoms/IconButton/IconButton.stories.tsx
+++ b/Source/DesignSystem/atoms/IconButton/IconButton.stories.tsx
@@ -3,31 +3,25 @@
 
 import React from 'react';
 
-import { Box, Typography } from '@mui/material';
 import { DownloadRounded } from '@mui/icons-material';
+
+import { componentStories } from '@dolittle/design-system';
 
 import { IconButton } from './IconButton';
 
-export default {
-    title: 'IconButton',
-    component: IconButton
-};
+const { metadata, createStory } = componentStories(IconButton);
 
-export const IconButtons = () =>
-    <Box sx={{ display: 'flex', alignContent: 'center', textAlign: 'center' }}>
-        <Box sx={{ mr: 8 }}>
-            <Typography variant='body1' color='primary'>Default Icon</Typography>
-            <IconButton
-                size='medium'
-                sx={{ mt: 2 }}
-            />
-        </Box>
+export default metadata;
 
-        <Box>
-            <Typography variant='body1' color='primary'>Download Icon</Typography>
-            <IconButton
-                icon={<DownloadRounded />}
-                sx={{ mt: 2 }}
-            />
-        </Box>
-    </Box>;
+export const Inherit = createStory({
+    label: 'Download',
+    icon: <DownloadRounded />
+});
+
+export const Secondary = createStory({
+    color: 'primary'
+});
+
+export const Disabled = createStory({
+    disabled: true
+});

--- a/Source/DesignSystem/atoms/IconButton/IconButton.tsx
+++ b/Source/DesignSystem/atoms/IconButton/IconButton.tsx
@@ -11,6 +11,7 @@ export type IconButtonProps = {
      * The aria-label of the icon button.
      *
      * For accessibility, it is recommended to set this value to a meaningful string rather than an empty string.
+     * @default Close
      */
     label?: string;
 
@@ -23,7 +24,7 @@ export type IconButtonProps = {
     /**
      * Most icons will use the default inherit styling.
      *
-     * Secondary icons use 'primary' color.
+     * Secondary icon button use 'primary' color.
      *
      * They are used for the most important actions, such as Save, Submit, or Continue.
      * @default inherit
@@ -31,22 +32,31 @@ export type IconButtonProps = {
     color?: 'inherit' | 'primary';
 
     /**
-     * Set icon size.
+     * Set icon size to medium.
      * @default small
      */
     size?: 'small' | 'medium';
 
     /**
-     * Add link to internal navigation.
+     * Icon button can be disabled.
+     * @default false
+     */
+    disabled?: boolean;
+
+    /**
+     * Navigate to internal page.
+     *
+     * When this is set, the component will render as an anchor element.
      * @default undefined
      */
     href?: string;
 
     /**
-     * Icon can be disabled.
-     * @default false
+     * Download file.
+     * @default undefined
+     * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#attr-download for more information.
      */
-    disabled?: boolean;
+    download?: string;
 
     /**
      * Callback fired when the component is clicked.
@@ -62,14 +72,15 @@ export type IconButtonProps = {
  * @example
  * <IconButton label="Download" icon={<DownloadRounded />} />
  */
-export const IconButton = ({ label, icon, color, size = 'small', href, disabled, onClick }: IconButtonProps): ReactElement =>
+export const IconButton = ({ label, icon, color, size = 'small', disabled, href, download, onClick }: IconButtonProps): ReactElement =>
     <MuiIconButton
         aria-label={!icon ? 'Close' : label}
         color={color || 'inherit'}
         size={size}
-        // @ts-ignore
-        href={href}
         disabled={disabled}
+        component={href ? 'a' : 'button'}
+        href={href}
+        download={download}
         onClick={onClick}
     >
         {!icon ? <CloseRounded fontSize={size} /> : React.cloneElement(icon, { fontSize: size })}

--- a/Source/DesignSystem/atoms/IconButton/IconButton.tsx
+++ b/Source/DesignSystem/atoms/IconButton/IconButton.tsx
@@ -17,15 +17,15 @@ export type IconButtonProps = {
     /**
      * Choose icon from @mui/icons-material or leave empty to use default 'close' icon.
      * @default <CloseRounded />
-     * @type {ReactElement<SvgIconProps>}
      */
     icon?: ReactElement<SvgIconProps>;
 
     /**
      * Most icons will use the default inherit styling.
      *
-     * Secondary icons use 'primary' color. They are used for the most important actions,
-     * such as Save, Submit, or Continue.
+     * Secondary icons use 'primary' color.
+     *
+     * They are used for the most important actions, such as Save, Submit, or Continue.
      * @default inherit
      */
     color?: 'inherit' | 'primary';

--- a/Source/DesignSystem/atoms/IconButton/IconButton.tsx
+++ b/Source/DesignSystem/atoms/IconButton/IconButton.tsx
@@ -3,25 +3,74 @@
 
 import React, { MouseEventHandler, ReactElement } from 'react';
 
-import { SvgIconProps, SxProps, IconButton as MuiIconButton } from '@mui/material';
+import { IconButton as MuiIconButton, SvgIconProps } from '@mui/material';
 import { CloseRounded } from '@mui/icons-material';
 
-type IconButtonProps = {
+export type IconButtonProps = {
+    /**
+     * The aria-label of the icon button.
+     *
+     * For accessibility, it is recommended to set this value to a meaningful string rather than an empty string.
+     */
+    label?: string;
+
+    /**
+     * Choose icon from @mui/icons-material or leave empty to use default 'close' icon.
+     * @default <CloseRounded />
+     * @type {ReactElement<SvgIconProps>}
+     */
     icon?: ReactElement<SvgIconProps>;
+
+    /**
+     * Most icons will use the default inherit styling.
+     *
+     * Secondary icons use 'primary' color. They are used for the most important actions,
+     * such as Save, Submit, or Continue.
+     * @default inherit
+     */
+    color?: 'inherit' | 'primary';
+
+    /**
+     * Set icon size.
+     * @default small
+     */
+    size?: 'small' | 'medium';
+
+    /**
+     * Add link to internal navigation.
+     * @default undefined
+     */
+    href?: string;
+
+    /**
+     * Icon can be disabled.
+     * @default false
+     */
     disabled?: boolean;
-    color?: 'primary' | 'secondary' | 'error' | 'info' | 'success' | 'warning' | 'inherit';
-    size?: 'small' | 'medium' | 'large';
-    sx?: SxProps;
+
+    /**
+     * Callback fired when the component is clicked.
+     * @default undefined
+     */
     onClick?: MouseEventHandler<HTMLButtonElement>;
 };
 
-export const IconButton = ({ disabled, color, size, sx, onClick, icon }: IconButtonProps) =>
+/**
+ * A icon button component.
+ * @param {...IconButtonProps} props - The {@link IconButtonProps}.
+ * @returns {ReactElement} A new {@link IconButton} component.
+ * @example
+ * <IconButton label="Download" icon={<DownloadRounded />} />
+ */
+export const IconButton = ({ label, icon, color, size = 'small', href, disabled, onClick }: IconButtonProps): ReactElement =>
     <MuiIconButton
-        disabled={disabled}
+        aria-label={!icon ? 'Close' : label}
         color={color || 'inherit'}
-        size={size || 'small'}
-        sx={sx}
+        size={size}
+        // @ts-ignore
+        href={href}
+        disabled={disabled}
         onClick={onClick}
     >
-        {icon || <CloseRounded aria-label='close' fontSize={size || 'small'} />}
+        {!icon ? <CloseRounded fontSize={size} /> : React.cloneElement(icon, { fontSize: size })}
     </MuiIconButton>;

--- a/Source/DesignSystem/atoms/IconButton/IconButton.tsx
+++ b/Source/DesignSystem/atoms/IconButton/IconButton.tsx
@@ -8,12 +8,11 @@ import { CloseRounded } from '@mui/icons-material';
 
 export type IconButtonProps = {
     /**
-     * The aria-label of the icon button.
+     * Required. The aria-label of the icon button.
      *
      * For accessibility, it is recommended to set this value to a meaningful string rather than an empty string.
-     * @default Close
      */
-    label?: string;
+    label: string;
 
     /**
      * Choose icon from @mui/icons-material or leave empty to use default 'close' icon.
@@ -74,7 +73,7 @@ export type IconButtonProps = {
  */
 export const IconButton = ({ label, icon, color, size = 'small', disabled, href, download, onClick }: IconButtonProps): ReactElement =>
     <MuiIconButton
-        aria-label={!icon ? 'Close' : label}
+        aria-label={label}
         color={color || 'inherit'}
         size={size}
         disabled={disabled}

--- a/Source/DesignSystem/atoms/IconButton/index.ts
+++ b/Source/DesignSystem/atoms/IconButton/index.ts
@@ -1,4 +1,4 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-export { IconButton } from './IconButton';
+export { IconButton, IconButtonProps } from './IconButton';

--- a/Source/DesignSystem/atoms/Snackbar/Snackbar.stories.tsx
+++ b/Source/DesignSystem/atoms/Snackbar/Snackbar.stories.tsx
@@ -75,7 +75,7 @@ const Snackbar = () => {
                         enqueueSnackbar(`Snackbar with action buttons -  ${count} - Undone.`)
                     } />
 
-                    <IconButton onClick={() => {
+                    <IconButton label='Dismiss snackbar' onClick={() => {
                         enqueueSnackbar(`Snackbar with action buttons -  ${count} - Dismissed.`);
                         closeSnackbar(key);
                     }} />

--- a/Source/DesignSystem/index.ts
+++ b/Source/DesignSystem/index.ts
@@ -10,6 +10,7 @@ export { AlertBox, AlertBoxProps, AlertBoxErrorMessage, AlertBoxInfoMessage } fr
 export { Button } from './atoms/Button';
 export { ConfirmDialog } from './atoms/ConfirmDialog';
 export { Checkbox, Form, Input, Select, SwitchToggle } from './atoms/Forms';
+export { IconButton, IconButtonProps } from './atoms/IconButton';
 export { LoadingSpinner } from './atoms/LoadingSpinner';
 export { Summary } from './atoms/Metrics';
 export { Tabs } from './atoms/Tabs';

--- a/Source/SelfService/Web/microservice/helpers/downloadHelpers.tsx
+++ b/Source/SelfService/Web/microservice/helpers/downloadHelpers.tsx
@@ -7,9 +7,10 @@ import { useSnackbar } from 'notistack';
 
 import { getPodLogs } from '../../api/api';
 
-import { Link } from '@mui/material';
 import { DownloadRounded } from '@mui/icons-material';
 import { GridRenderCellParams } from '@mui/x-data-grid-pro';
+
+import { IconButton } from '@dolittle/design-system';
 
 export const DownloadLogs = (params: GridRenderCellParams) => {
     const [data, setData] = useState({ logs: '' });
@@ -17,23 +18,23 @@ export const DownloadLogs = (params: GridRenderCellParams) => {
     const { enqueueSnackbar } = useSnackbar();
 
     useEffect(() => {
-        getPodLogs(params.row.application, params.row.podName, params.row.containerName).then(setData);
-    }, [params.row.application, params.row.podName, params.row.containerName]);
+        getPodLogs(params?.row.application, params?.row.podName, params?.row.containerName).then(setData);
+    }, [params?.row.application, params?.row.podName, params?.row.containerName]);
 
     const logsBlob = new Blob([data.logs], { type: 'text/plain' });
-    const containerImage = params.row.image.replace(':', '/');
+    const containerImage = params?.row.image.replace(':', '/');
 
     const handleNotification = () => {
         enqueueSnackbar(`'${containerImage}' logs have been downloaded.`);
     };
 
     return (
-        <Link
+        <IconButton
             href={URL.createObjectURL(logsBlob)}
             download={`${containerImage}.log`}
             onClick={handleNotification}
-        >
-            <DownloadRounded fontSize='small' sx={{ color: 'text.primary' }} />
-        </Link>
+            label='Download logs'
+            icon={<DownloadRounded />}
+        />
     );
 };

--- a/Source/SelfService/Web/microservice/helpers/downloadHelpers.tsx
+++ b/Source/SelfService/Web/microservice/helpers/downloadHelpers.tsx
@@ -12,17 +12,21 @@ import { GridRenderCellParams } from '@mui/x-data-grid-pro';
 
 import { IconButton } from '@dolittle/design-system';
 
-export const DownloadLogs = (params: GridRenderCellParams) => {
+type DownloadHelperProps = {
+    row: GridRenderCellParams['row'];
+};
+
+export const DownloadLogs = ({ row: { application, podName, containerName, image } }: DownloadHelperProps) => {
     const [data, setData] = useState({ logs: '' });
 
     const { enqueueSnackbar } = useSnackbar();
 
     useEffect(() => {
-        getPodLogs(params?.row.application, params?.row.podName, params?.row.containerName).then(setData);
-    }, [params?.row.application, params?.row.podName, params?.row.containerName]);
+        getPodLogs(application, podName, containerName).then(setData);
+    }, [application, podName, containerName]);
 
     const logsBlob = new Blob([data.logs], { type: 'text/plain' });
-    const containerImage = params?.row.image.replace(':', '/');
+    const containerImage = image.replace(':', '/');
 
     const handleNotification = () => {
         enqueueSnackbar(`'${containerImage}' logs have been downloaded.`);


### PR DESCRIPTION
## Summary

Made Storybook Icon Buttons component reusable.
Added JsDocs to Icon Buttons so it would be easier to understand how to use Icons.

<img width="1051" alt="Screenshot 2023-01-30 at 10 18 07" src="https://user-images.githubusercontent.com/19160439/215424537-d18ef437-0210-4448-9c81-08ff0eee7d8d.png">

### Added

- Link functionality to Icon Button
- JsDocs to Icon Button 
- Controls to IconButton.stories

### Fixed

- Wording on IconButton.stories

### Changed

- Refactor downloadHelpers.tsx props

