### PR TITLE
change runtime version 8 to 8.8.2

### DIFF
--- a/Source/SelfService/Web/api/api.ts
+++ b/Source/SelfService/Web/api/api.ts
@@ -122,8 +122,8 @@ export function getServerUrlPrefix(): string {
 
 export function getLatestRuntimeInfo(): LatestRuntimeInfo {
     return {
-        image: 'dolittle/runtime:8.6.0',
-        changelog: 'https://github.com/dolittle/Runtime/releases/tag/v8.6.0',
+        image: 'dolittle/runtime:8.8.2',
+        changelog: 'https://github.com/dolittle/Runtime/releases/tag/v8.8.2',
     };
 };
 


### PR DESCRIPTION
this puts new services on the at-this-time latest runtime version

## Summary

change the "8" version of the runtime to 8.8.2, which is currently the latest

not 100% sure that nothing else needs to change - so a review would be nice :)