### PR TITLE
Support latest v6 runtime (6.2.4)

### DIFF
--- a/Source/SelfService/Web/api/api.ts
+++ b/Source/SelfService/Web/api/api.ts
@@ -131,8 +131,8 @@ export function getRuntimes(): LatestRuntimeInfo[] {
     return [
         getLatestRuntimeInfo(),
         {
-            image: 'dolittle/runtime:6.1.0',
-            changelog: 'https://github.com/dolittle/Runtime/releases/tag/v6.1.0',
+            image: 'dolittle/runtime:6.2.4',
+            changelog: 'https://github.com/dolittle/Runtime/releases/tag/v6.2.4',
         }
     ];
 };


### PR DESCRIPTION
## Summary

Use v6.2.4 as the latest v6 of the runtime.