### PR TITLE
Fix broken links to images tags in container registry view for images containing '/'

### DIFF
--- a/Source/SelfService/Web/containerregistry/images.tsx
+++ b/Source/SelfService/Web/containerregistry/images.tsx
@@ -2,7 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 import React from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, generatePath } from 'react-router-dom';
 
 import {
     Table, TableContainer, TableHead,
@@ -43,7 +43,11 @@ export const View: React.FunctionComponent<Props> = (props) => {
                                     scope="row"
                                     onClick={(event) => {
                                         event.preventDefault();
-                                        const href = `/containerregistry/application/${applicationId}/${environment}/overview/tags/${row.name}`;
+                                        const href = generatePath(
+                                            '/containerregistry/application/:applicationId/:environment/overview/tags/:image',
+                                            { applicationId, environment, image: row.name }
+                                        );
+                                        // const href = `/containerregistry/application/${applicationId}/${environment}/overview/tags/${row.name}`;
                                         navigate(href);
                                     }}
                                     sx={{

--- a/Source/SelfService/Web/containerregistry/images.tsx
+++ b/Source/SelfService/Web/containerregistry/images.tsx
@@ -45,9 +45,8 @@ export const View: React.FunctionComponent<Props> = (props) => {
                                         event.preventDefault();
                                         const href = generatePath(
                                             '/containerregistry/application/:applicationId/:environment/overview/tags/:image',
-                                            { applicationId, environment, image: row.name }
+                                            { applicationId, environment, image: encodeURIComponent(row.name) }
                                         );
-                                        // const href = `/containerregistry/application/${applicationId}/${environment}/overview/tags/${row.name}`;
                                         navigate(href);
                                     }}
                                     sx={{


### PR DESCRIPTION
## Summary

As part of the upgrade to latest react router (#301) the image/tags route was changed and no longer supported using `/` as part of the URL. This fix encodes the :image parameter so that it should work


### Fixed

- Fix broken links to images tags in container registry view for images containing '/'
