### PR TITLE
Add routing to backend

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ develop-frontend:
 develop-backend:
 	cd Source/SelfService/Backend && \
 	HEADER_SECRET="FAKE" \
-	PLATFORM_API="localhost:8081" \
+	PROXY='{"/": "localhost:8081", "/bridge/": "127.0.0.1:5000"}' \
 	DEVELOPMENT_CUSTOMER_ID="${DEVELOPMENT_CUSTOMER_ID}" \
 	DEVELOPMENT_USER_ID="${DEVELOPMENT_USER_ID}" \
 	go run main.go

--- a/Source/SelfService/Backend/go.mod
+++ b/Source/SelfService/Backend/go.mod
@@ -1,6 +1,6 @@
 module github.com/dolittle/studio
 
-go 1.16
+go 1.19
 
 require (
 	github.com/sirupsen/logrus v1.8.1

--- a/Source/SelfService/Backend/main.go
+++ b/Source/SelfService/Backend/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"encoding/json"
+	"fmt"
 	"log"
 	"net/http"
 	"net/http/httputil"
@@ -11,9 +13,34 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+type Route struct {
+	Pattern string
+	Host    string
+}
+
+type Routes []Route
+
+// parseRoutes takes raw json string and parses to a list of routes.
+func parseRoutes(raw string) (*Routes, error) {
+	var doc map[string]string
+	routes := &Routes{}
+	err := json.Unmarshal([]byte(raw), &doc)
+	if err != nil {
+		return routes, err
+	}
+	for pattern, host := range doc {
+		routes = append(*routes, Route{pattern, host})
+	}
+	fmt.Println(doc)
+	return routes, nil
+}
+
 type AppConfig struct {
-	PlatformApiHost       string
-	BridgeApiHost         string
+	PlatformApiHost string
+	BridgeApiHost   string
+	// Routing is json document with the keys being a http.ServeMux pattern
+	// and the vals being the host to reverse proxy to.
+	Routing               string
 	ListenOn              string
 	SharedSecret          string
 	DevelopmentEnabled    bool

--- a/Source/SelfService/Backend/main_test.go
+++ b/Source/SelfService/Backend/main_test.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+)
+
+var appConfig = AppConfig{
+	PlatformApiHost: "something",
+	BridgeApiHost:   "somethingelse",
+	ListenOn:        "localhost:1234",
+}
+
+func TestProxyWithoutBridge(t *testing.T) {
+	path := "/bridge/hello"
+	platformAPI := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != path {
+			t.Error("Path should be unaltered")
+		}
+	}))
+	defer platformAPI.Close()
+
+	url, _ := url.Parse(platformAPI.URL)
+	service := NewBackend(logrus.StandardLogger(), AppConfig{PlatformApiHost: url.Host})
+
+	ts := httptest.NewServer(service)
+	defer ts.Close()
+
+	res, err := http.Get(ts.URL + path)
+	if err != nil {
+		t.Errorf("Could not get %s", ts.URL)
+	}
+	if res.StatusCode != 200 {
+		t.Errorf("Expected Status OK, got %v", res.Status)
+	}
+}
+
+func TestProxyWithBridge(t *testing.T) {
+	bPath := "/bridge/hello"
+	pPath := "/foo/bar"
+	platformAPI := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != pPath {
+			t.Errorf("[platform-api] Forwarding error for: %s!", r.URL.Path)
+		}
+	}))
+	defer platformAPI.Close()
+
+	bridgeAPI := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != bPath {
+			t.Errorf("[bridge-api] Forwarding error for: %s!", r.URL.Path)
+		}
+	}))
+	defer bridgeAPI.Close()
+
+	pURL, _ := url.Parse(platformAPI.URL)
+	bURL, _ := url.Parse(bridgeAPI.URL)
+
+	service := NewBackend(logrus.StandardLogger(), AppConfig{
+		PlatformApiHost: pURL.Host,
+		BridgeApiHost:   bURL.Host,
+	})
+
+	ts := httptest.NewServer(service.mux)
+	defer ts.Close()
+
+	res, err := http.Get(ts.URL + pPath)
+	if err != nil {
+		t.Errorf("Could not get %s", ts.URL)
+	}
+	if res.StatusCode != 200 {
+		t.Errorf("Expected Status OK, got %v", res.Status)
+	}
+
+	res, err = http.Get(ts.URL + bPath)
+	if err != nil {
+		t.Errorf("Could not get %s", ts.URL)
+	}
+	if res.StatusCode != 200 {
+		t.Errorf("Expected Status OK, got %v", res.Status)
+	}
+}

--- a/Source/SelfService/Backend/main_test.go
+++ b/Source/SelfService/Backend/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -82,4 +83,8 @@ func TestProxyWithBridge(t *testing.T) {
 	if res.StatusCode != 200 {
 		t.Errorf("Expected Status OK, got %v", res.Status)
 	}
+}
+
+func TestParseRoutes(t *testing.T) {
+	fmt.Println(parseRoutes(`{"hello": "world"}`))
 }


### PR DESCRIPTION
## Summary
To enable requests to be routed to different backend services, this PR introduces proxy configuration via the `PROXY` environment variable. This is needed for e.g. routing bridge related requests to the bridge-api, and platform related request to the platform-api. Also some rudimentary tests are added.

### Added

Configurable routing via the optional `PROXY` environment variable. The value of this variable, if present, is assumed to be a valid json document where the keys are a [http.ServeMux](https://pkg.go.dev/net/http#ServeMux) pattern and the values are the corresponding host for the backend to setup a reverse proxy to. 

If no `PROXY` environment variable is given, or if it's value is empty, we'll fallback to the old behavior of using the `PLATFORM_API` environment variable.

The `PLATFORM_API` environment variable is kept as a legacy option, but will be ignored completely if the `PROXY` environment variable is set.

### Example

Routing bridge request to `localhost:2222`, and all other to `localhost:1111`:
```
PROXY='{"/": "localhost:1111", "/bridge/": "localhost:2222"}'
```

### Ref
[RFC-0001](https://github.com/dolittle/rfcs/blob/main/0001_use_rest_in_studio.md)
[Task](https://app.asana.com/0/0/1203966934671264/f)