### PR TITLE
remove applicationId from path to integrations

### DIFF
--- a/Source/SelfService/Web/App.tsx
+++ b/Source/SelfService/Web/App.tsx
@@ -97,7 +97,7 @@ export const App = () => {
                                             <DieAndRestart />
                                         </LayoutWithSidebar>
                                     } />
-                                    <Route path="/:applicationId/integrations/*" element={<IntegrationsIndex />} />
+                                    <Route path="/integrations/*" element={<IntegrationsIndex />} />
                                     <Route path='*' element={<RouteNotFound redirectUrl='/applications' auto={true} />} />
                                 </Routes>
                             </SnackbarProvider>


### PR DESCRIPTION
Don't need to have this prefix in right now, and it's a little annoying.
When we model "workspaces" in, it may need to come back
