### PR TITLE
save message mapping

### DIFF
--- a/Source/SelfService/Web/apis/integrations/messageMappingApi.hooks.ts
+++ b/Source/SelfService/Web/apis/integrations/messageMappingApi.hooks.ts
@@ -1,11 +1,15 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useMutation } from '@tanstack/react-query';
 
 import { API_CONFIGURATION } from './api';
 import { CACHE_KEYS } from './CacheKeys';
-import { MessageMappingApi, ConnectionsIdMessageMappingsGetRequest } from './generated';
+import {
+    MessageMappingApi,
+    ConnectionsIdMessageMappingsGetRequest,
+    ConnectionsIdMessageMappingsTablesTableMessagesMessagePostRequest
+} from './generated';
 
 let apiInstance: MessageMappingApi | undefined;
 
@@ -22,5 +26,13 @@ export const useConnectionsIdMessageMappingsGet = (params: ConnectionsIdMessageM
         queryKey: [CACHE_KEYS.ConnectionMessageMapping_GET, params.id],
         queryFn: api.connectionsIdMessageMappingsGet.bind(api, params),
         staleTime: 60000,
+    });
+};
+
+export const useConnectionsIdMessageMappingsTablesTableMessagesMessagePost = () => {
+    const api = getOrCreateApi();
+    return useMutation({
+        mutationFn: (params: ConnectionsIdMessageMappingsTablesTableMessagesMessagePostRequest) =>
+            api.connectionsIdMessageMappingsTablesTableMessagesMessagePost(params),
     });
 };

--- a/Source/SelfService/Web/integrations/connection/connectionDetails/messages/changeMessage/components/MessageDetailsSection.tsx
+++ b/Source/SelfService/Web/integrations/connection/connectionDetails/messages/changeMessage/components/MessageDetailsSection.tsx
@@ -17,12 +17,12 @@ export const MessageDetailsSection = (props: MessageDetailsSectionProps) =>
         <Grid container gap={4}>
             <Stack spacing={3}>
                 <Typography variant='subtitle2'>Provide a name for your message type</Typography>
-                <Input id='messageTypeName' label='Message Type Name' required />
+                <Input id='name' label='Message Type Name' required />
             </Stack>
 
             <Stack spacing={3}>
                 <Typography variant='subtitle2'>Add a description for this message type</Typography>
-                <Input id='messageTypeDescription' label='Message Type Description' />
+                <Input id='description' label='Message Type Description' />
             </Stack>
         </Grid>
     </ContentSection>;

--- a/Source/SelfService/Web/integrations/connection/connectionDetails/messages/changeMessage/components/MessageMappingTable.tsx
+++ b/Source/SelfService/Web/integrations/connection/connectionDetails/messages/changeMessage/components/MessageMappingTable.tsx
@@ -4,7 +4,7 @@
 import React from 'react';
 
 import { Paper } from '@mui/material';
-import { DataGridPro, GridColDef, GridSelectionModel, GridRowId } from '@mui/x-data-grid-pro';
+import { DataGridPro, GridColDef, GridSelectionModel, GridRowId, useGridApiRef } from '@mui/x-data-grid-pro';
 
 import { MappableTableColumn } from '../../../../../../apis/integrations/generated';
 
@@ -52,16 +52,20 @@ export const MessageMappingTable = ({
     onFieldMapped
 }: MessageMappingTableProps) => {
 
+    const gridApiRef = useGridApiRef();
+
     const processRowUpdate = (newRow: DataGridTableListingEntry, oldRow: DataGridTableListingEntry): DataGridTableListingEntry | Promise<DataGridTableListingEntry> => {
         // if field is not selected, mark as selected using the useApiRef
         console.log('processRowUpdate', newRow, oldRow);
         onFieldMapped(newRow.id, newRow.fieldName);
+        gridApiRef.current.selectRow(newRow.id, true);
         return newRow;
     };
 
     return (
         <Paper elevation={0} sx={{ width: 1, boxShadow: 'none' }}>
             <DataGridPro
+                apiRef={gridApiRef}
                 rows={dataGridListing}
                 columns={columns}
                 getRowHeight={() => 'auto'}

--- a/Source/SelfService/Web/integrations/connection/connectionDetails/messages/changeMessage/components/MessageMappingTable.tsx
+++ b/Source/SelfService/Web/integrations/connection/connectionDetails/messages/changeMessage/components/MessageMappingTable.tsx
@@ -54,9 +54,10 @@ export const MessageMappingTable = ({
 
     const gridApiRef = useGridApiRef();
 
-    const processRowUpdate = (newRow: DataGridTableListingEntry, oldRow: DataGridTableListingEntry): DataGridTableListingEntry | Promise<DataGridTableListingEntry> => {
-        // if field is not selected, mark as selected using the useApiRef
-        console.log('processRowUpdate', newRow, oldRow);
+    const processRowUpdate = (
+        newRow: DataGridTableListingEntry,
+        oldRow: DataGridTableListingEntry
+    ): DataGridTableListingEntry | Promise<DataGridTableListingEntry> => {
         onFieldMapped(newRow.id, newRow.fieldName);
         gridApiRef.current.selectRow(newRow.id, true);
         return newRow;

--- a/Source/SelfService/Web/integrations/connection/connectionDetails/messages/changeMessage/components/MessageMappingTable.tsx
+++ b/Source/SelfService/Web/integrations/connection/connectionDetails/messages/changeMessage/components/MessageMappingTable.tsx
@@ -8,8 +8,9 @@ import { DataGridPro, GridColDef, GridSelectionModel, GridRowId } from '@mui/x-d
 
 import { MappableTableColumn } from '../../../../../../apis/integrations/generated';
 
-type DataGridTableListingEntry = MappableTableColumn & {
+export type DataGridTableListingEntry = MappableTableColumn & {
     id: string;
+    fieldName: string;
 };
 
 const columns: GridColDef<DataGridTableListingEntry>[] = [
@@ -25,7 +26,7 @@ const columns: GridColDef<DataGridTableListingEntry>[] = [
         minWidth: 270,
     },
     {
-        field: '',
+        field: 'fieldName',
         headerName: 'Remapped Name',
         editable: true,
         minWidth: 270,
@@ -33,29 +34,30 @@ const columns: GridColDef<DataGridTableListingEntry>[] = [
 ];
 
 export type MessageMappingTableProps = {
-    mappableTableColumns: MappableTableColumn[];
+    dataGridListing: DataGridTableListingEntry[];
     selectedIds: GridSelectionModel;
     onSelectedIdsChanged: (newSelectedIds: GridSelectionModel) => void;
     disabledRows?: GridRowId[];
     isLoading: boolean;
     hideUnselectedRows?: boolean;
+    onFieldMapped: (m3Field: string, mappedFieldName) => void;
 };
 
 export const MessageMappingTable = ({
-    mappableTableColumns,
+    dataGridListing,
     selectedIds,
     onSelectedIdsChanged,
     disabledRows,
     isLoading,
+    onFieldMapped
 }: MessageMappingTableProps) => {
 
-    const dataGridListing: DataGridTableListingEntry[] = mappableTableColumns
-        .map(mappableTableColumn => {
-            return {
-                id: mappableTableColumn.m3ColumnName!,
-                ...mappableTableColumn,
-            };
-        });
+    const processRowUpdate = (newRow: DataGridTableListingEntry, oldRow: DataGridTableListingEntry): DataGridTableListingEntry | Promise<DataGridTableListingEntry> => {
+        // if field is not selected, mark as selected using the useApiRef
+        console.log('processRowUpdate', newRow, oldRow);
+        onFieldMapped(newRow.id, newRow.fieldName);
+        return newRow;
+    };
 
     return (
         <Paper elevation={0} sx={{ width: 1, boxShadow: 'none' }}>
@@ -73,6 +75,9 @@ export const MessageMappingTable = ({
                 pagination
                 pageSize={10}
                 rowsPerPageOptions={[10]}
+                processRowUpdate={processRowUpdate}
+                onProcessRowUpdateError={error => console.log(error)}
+                experimentalFeatures={{ newEditingApi: true }}
                 disableColumnMenu
                 disableColumnReorder
                 disableColumnResize

--- a/Source/SelfService/Web/integrations/connection/connectionDetails/messages/changeMessage/components/SubmitButtonSection.tsx
+++ b/Source/SelfService/Web/integrations/connection/connectionDetails/messages/changeMessage/components/SubmitButtonSection.tsx
@@ -3,6 +3,7 @@
 
 import React from 'react';
 
+import { useFormState } from 'react-hook-form';
 import { Button } from '@dolittle/design-system';
 
 import { ViewModeProps } from '../ViewMode';
@@ -14,6 +15,8 @@ export type SubmitButtonSectionProps = ViewModeProps & {
 };
 
 export const SubmitButtonSection = (props: SubmitButtonSectionProps) => {
+
+    const { isValid,  } = useFormState();
     const buttonText = props.mode === 'new' ? 'Add Message and close' : 'Save Message and close';
 
     return (
@@ -23,7 +26,7 @@ export const SubmitButtonSection = (props: SubmitButtonSectionProps) => {
                 variant='fullwidth'
                 type='submit'
                 sx={{ mt: 2.125 }}
-                disabled={!props.disabled}
+                disabled={!isValid}
             />
         </ContentSection>
     );

--- a/Source/SelfService/Web/integrations/connection/connectionDetails/messages/changeMessage/components/SubmitButtonSection.tsx
+++ b/Source/SelfService/Web/integrations/connection/connectionDetails/messages/changeMessage/components/SubmitButtonSection.tsx
@@ -26,7 +26,7 @@ export const SubmitButtonSection = (props: SubmitButtonSectionProps) => {
                 variant='fullwidth'
                 type='submit'
                 sx={{ mt: 2.125 }}
-                disabled={!isValid}
+                disabled={!isValid || props.isSubmitting || props.disabled  }
             />
         </ContentSection>
     );

--- a/Source/SelfService/Web/integrations/connection/connectionDetails/messages/changeMessage/components/TableSection.tsx
+++ b/Source/SelfService/Web/integrations/connection/connectionDetails/messages/changeMessage/components/TableSection.tsx
@@ -8,14 +8,14 @@ import { Grid, LinearProgress } from '@mui/material';
 import { AlertBox, Button, Icon, MaxWidthTextBlock, Switch } from '@dolittle/design-system/';
 import { GridSelectionModel } from '@mui/x-data-grid-pro';
 
-import { TableListingEntry } from '../../../../../../apis/integrations/generated';
+import { FieldMapping, TableListingEntry } from '../../../../../../apis/integrations/generated';
 import { useConnectionsIdMessageMappingsTablesTableGet } from '../../../../../../apis/integrations/mappableTablesApi.hooks';
 
 import { useConnectionId } from '../../../../../routes.hooks';
 
 import { ViewModeProps } from '../ViewMode';
 import { ContentSection } from './ContentSection';
-import { MessageMappingTable } from './MessageMappingTable';
+import { DataGridTableListingEntry, MessageMappingTable } from './MessageMappingTable';
 import { SubmitButtonSection } from './SubmitButtonSection';
 
 export type TableSectionProps = ViewModeProps & {
@@ -27,6 +27,7 @@ export const TableSection = (props: TableSectionProps) => {
     const connectionId = useConnectionId();
     const [selectedRowIds, setSelectedRowIds] = useState<GridSelectionModel>([]);
     const [hideUnselectedRows, setHideUnselectedRows] = useState(false);
+    const [mappedFields, setMappedFields] = useState<Map<string, FieldMapping>>(new Map());
 
     if (!connectionId || !props.selectedTable.name) return <AlertBox />;
 
@@ -39,10 +40,37 @@ export const TableSection = (props: TableSectionProps) => {
     const requiredTableColumns = mappableTableResult?.value?.required || [];
     const preselectedInitialIds = requiredTableColumns.map(required => required.m3ColumnName!);
     const selectedIds = (selectedRowIds.length > 0) ? selectedRowIds : preselectedInitialIds as GridSelectionModel;
+
+    const gridMappableTableColumns: DataGridTableListingEntry[] = useMemo(
+        () => allMappableTableColumns.map(column => {
+            const id = column.m3ColumnName!;
+            const fieldName = mappedFields.get(column.m3ColumnName!)?.fieldName || '';
+            console.log('mapping field', id);
+            console.log('mapping fieldName', fieldName);
+            console.log('Available mappings', Array.from(mappedFields.values()));
+            return {
+                id,
+                fieldName,
+                ...column,
+            };
+        }),
+        [allMappableTableColumns, mappedFields]);
     const selectedTableColumns = useMemo(
-        () => allMappableTableColumns.filter(column => selectedIds.includes(column.m3ColumnName!)),
+        () => gridMappableTableColumns.filter(column => selectedIds.includes(column.m3ColumnName!)),
         [allMappableTableColumns, selectedIds]
     );
+
+    const onFieldMapped = (m3Field: string, mappedFieldName: any) => {
+        setMappedFields((prevMappedFields) => {
+            const newMappedFields = new Map(prevMappedFields);
+            if (mappedFieldName) {
+                newMappedFields.set(m3Field, { columnName: m3Field, fieldName: mappedFieldName });
+            } else {
+                newMappedFields.delete(m3Field);
+            }
+            return newMappedFields;
+        });
+    };
 
     return (
         <>
@@ -70,11 +98,12 @@ export const TableSection = (props: TableSectionProps) => {
                                 <Switch id='hideUnselectedRows' label='Hide Unselected Rows' onChange={() => setHideUnselectedRows(!hideUnselectedRows)} />
                             </Grid>
                             <MessageMappingTable
-                                mappableTableColumns={hideUnselectedRows ? selectedTableColumns : allMappableTableColumns}
+                                dataGridListing={hideUnselectedRows ? selectedTableColumns : gridMappableTableColumns}
                                 isLoading={isLoading}
                                 selectedIds={selectedIds}
                                 disabledRows={preselectedInitialIds}
                                 onSelectedIdsChanged={setSelectedRowIds}
+                                onFieldMapped={onFieldMapped}
                             />
                             <SubmitButtonSection mode={props.mode} isSubmitting={false} />
                         </>

--- a/Source/SelfService/Web/integrations/connection/connectionDetails/messages/changeMessage/components/TableSection.tsx
+++ b/Source/SelfService/Web/integrations/connection/connectionDetails/messages/changeMessage/components/TableSection.tsx
@@ -38,23 +38,17 @@ export const TableSection = (props: TableSectionProps) => {
 
     const allMappableTableColumns = mappableTableResult?.value?.columns || [];
     const requiredTableColumns = mappableTableResult?.value?.required || [];
-    const preselectedInitialIds = requiredTableColumns.map(required => required.m3ColumnName!);
-    const selectedIds = (selectedRowIds.length > 0) ? selectedRowIds : preselectedInitialIds as GridSelectionModel;
+    const requiredTableColumnIds = requiredTableColumns.map(required => required.m3ColumnName!);
+    const selectedIds = (selectedRowIds.length > 0) ? selectedRowIds : requiredTableColumnIds as GridSelectionModel;
 
     const gridMappableTableColumns: DataGridTableListingEntry[] = useMemo(
-        () => allMappableTableColumns.map(column => {
-            const id = column.m3ColumnName!;
-            const fieldName = mappedFields.get(column.m3ColumnName!)?.fieldName || '';
-            console.log('mapping field', id);
-            console.log('mapping fieldName', fieldName);
-            console.log('Available mappings', Array.from(mappedFields.values()));
-            return {
-                id,
-                fieldName,
-                ...column,
-            };
-        }),
+        () => allMappableTableColumns.map(column => ({
+            id: column.m3ColumnName!,
+            fieldName: mappedFields.get(column.m3ColumnName!)?.fieldName || '',
+            ...column,
+        })),
         [allMappableTableColumns, mappedFields]);
+
     const selectedTableColumns = useMemo(
         () => gridMappableTableColumns.filter(column => selectedIds.includes(column.m3ColumnName!)),
         [allMappableTableColumns, selectedIds]
@@ -101,7 +95,7 @@ export const TableSection = (props: TableSectionProps) => {
                                 dataGridListing={hideUnselectedRows ? selectedTableColumns : gridMappableTableColumns}
                                 isLoading={isLoading}
                                 selectedIds={selectedIds}
-                                disabledRows={preselectedInitialIds}
+                                disabledRows={requiredTableColumnIds}
                                 onSelectedIdsChanged={setSelectedRowIds}
                                 onFieldMapped={onFieldMapped}
                             />

--- a/Source/SelfService/Web/integrations/connection/connectionDetails/messages/changeMessage/components/TableSection.tsx
+++ b/Source/SelfService/Web/integrations/connection/connectionDetails/messages/changeMessage/components/TableSection.tsx
@@ -3,10 +3,11 @@
 
 import React, { useState, useMemo } from 'react';
 
-import { Grid, LinearProgress } from '@mui/material';
+import { useFormContext } from 'react-hook-form';
 
-import { AlertBox, Button, Icon, MaxWidthTextBlock, Switch } from '@dolittle/design-system/';
+import { Grid, LinearProgress } from '@mui/material';
 import { GridSelectionModel } from '@mui/x-data-grid-pro';
+import { AlertBox, Button, Icon, MaxWidthTextBlock, Switch } from '@dolittle/design-system/';
 
 import { FieldMapping, TableListingEntry } from '../../../../../../apis/integrations/generated';
 import { useConnectionsIdMessageMappingsTablesTableGet } from '../../../../../../apis/integrations/mappableTablesApi.hooks';
@@ -16,7 +17,7 @@ import { useConnectionId } from '../../../../../routes.hooks';
 import { ViewModeProps } from '../ViewMode';
 import { ContentSection } from './ContentSection';
 import { DataGridTableListingEntry, MessageMappingTable } from './MessageMappingTable';
-import { SubmitButtonSection } from './SubmitButtonSection';
+
 
 export type TableSectionProps = ViewModeProps & {
     selectedTable: TableListingEntry;
@@ -28,6 +29,7 @@ export const TableSection = (props: TableSectionProps) => {
     const [selectedRowIds, setSelectedRowIds] = useState<GridSelectionModel>([]);
     const [hideUnselectedRows, setHideUnselectedRows] = useState(false);
     const [mappedFields, setMappedFields] = useState<Map<string, FieldMapping>>(new Map());
+    const { setValue } = useFormContext();
 
     if (!connectionId || !props.selectedTable.name) return <AlertBox />;
 
@@ -47,7 +49,8 @@ export const TableSection = (props: TableSectionProps) => {
             fieldName: mappedFields.get(column.m3ColumnName!)?.fieldName || '',
             ...column,
         })),
-        [allMappableTableColumns, mappedFields]);
+        [allMappableTableColumns, mappedFields]
+    );
 
     const selectedTableColumns = useMemo(
         () => gridMappableTableColumns.filter(column => selectedIds.includes(column.m3ColumnName!)),
@@ -65,6 +68,15 @@ export const TableSection = (props: TableSectionProps) => {
             return newMappedFields;
         });
     };
+
+    React.useEffect(() => {
+        const fields: FieldMapping[] = selectedTableColumns.map(column => ({
+            columnName: column.m3ColumnName!,
+            fieldName: column.fieldName,
+            fieldDescription: '',
+        }));
+        setValue('fields', fields);
+    }, [selectedTableColumns]);
 
     return (
         <>
@@ -99,7 +111,6 @@ export const TableSection = (props: TableSectionProps) => {
                                 onSelectedIdsChanged={setSelectedRowIds}
                                 onFieldMapped={onFieldMapped}
                             />
-                            <SubmitButtonSection mode={props.mode} isSubmitting={false} />
                         </>
                     )}
                 </ContentSection>

--- a/Source/SelfService/Web/integrations/connection/connectionDetails/messages/changeMessage/index.tsx
+++ b/Source/SelfService/Web/integrations/connection/connectionDetails/messages/changeMessage/index.tsx
@@ -4,10 +4,11 @@
 import React, { useState } from 'react';
 
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
-
 import { AlertDialog, Form, Icon } from '@dolittle/design-system';
 
 import { SetMessageMappingRequestArguments, TableListingEntry } from '../../../../../apis/integrations/generated';
+import { useConnectionsIdMessageMappingsTablesTableMessagesMessagePost } from '../../../../../apis/integrations/messageMappingApi.hooks';
+import { useConnectionId } from '../../../../routes.hooks';
 
 import { ViewMode } from './ViewMode';
 import { ContentContainer } from './components/ContentContainer';
@@ -28,6 +29,8 @@ export const ChangeMessageView = () => {
     const location = useLocation();
     const navigate = useNavigate();
     const { messageId } = useParams();
+    const connectionId = useConnectionId();
+    const saveMessageMappingMutation = useConnectionsIdMessageMappingsTablesTableMessagesMessagePost();
 
     const [searchInput, setSearchInput] = useState<string>('');
     const [selectedTable, setSelectedTable] = useState<TableListingEntry>();
@@ -61,7 +64,23 @@ export const ChangeMessageView = () => {
     };
 
     const handleNewMessageSave = (values: SetMessageMappingRequestArguments) => {
-        console.log('saving', values);
+        saveMessageMappingMutation.mutate({
+            id: connectionId!,
+            message: values.name!,
+            table: selectedTable?.name!,
+            setMessageMappingRequestArguments: {
+                name: values.name!,
+                description: values.description!,
+                fields: values.fields!,
+            }
+        }, {
+            onSuccess(data, variables, context) {
+                console.log('success', data);
+            },
+            onError(error, variables, context) {
+                console.log('error', error);
+            }
+        });
     };
 
     const removeSelectedTable = () => setSelectedTable(undefined);
@@ -101,7 +120,7 @@ export const ChangeMessageView = () => {
                             />
                             <SubmitButtonSection
                                 mode={mode}
-                                isSubmitting={false}
+                                isSubmitting={saveMessageMappingMutation.isLoading}
                             />
                         </>
 

--- a/Source/SelfService/Web/integrations/connection/connectionDetails/messages/changeMessage/index.tsx
+++ b/Source/SelfService/Web/integrations/connection/connectionDetails/messages/changeMessage/index.tsx
@@ -4,6 +4,7 @@
 import React, { useState } from 'react';
 
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
+import { enqueueSnackbar } from 'notistack';
 import { AlertDialog, Form, Icon } from '@dolittle/design-system';
 
 import { SetMessageMappingRequestArguments, TableListingEntry } from '../../../../../apis/integrations/generated';
@@ -75,10 +76,12 @@ export const ChangeMessageView = () => {
             }
         }, {
             onSuccess(data, variables, context) {
-                console.log('success', data);
+                navigate(`messages`);
+                enqueueSnackbar('Message successfully created', { variant: 'success' });
             },
             onError(error, variables, context) {
                 console.log('error', error);
+                enqueueSnackbar('Something went wrong when trying to save the message', { variant: 'error' });
             }
         });
     };

--- a/Source/SelfService/Web/integrations/connection/connectionDetails/messages/changeMessage/index.tsx
+++ b/Source/SelfService/Web/integrations/connection/connectionDetails/messages/changeMessage/index.tsx
@@ -7,7 +7,7 @@ import { useLocation, useNavigate, useParams } from 'react-router-dom';
 
 import { AlertDialog, Form, Icon } from '@dolittle/design-system';
 
-import { TableListingEntry } from '../../../../../apis/integrations/generated';
+import { SetMessageMappingRequestArguments, TableListingEntry } from '../../../../../apis/integrations/generated';
 
 import { ViewMode } from './ViewMode';
 import { ContentContainer } from './components/ContentContainer';
@@ -15,6 +15,7 @@ import { ContentHeader } from './components/ContentHeader';
 import { TableSearchSection } from './components/TableSearchSection';
 import { MessageDetailsSection } from './components/MessageDetailsSection';
 import { TableSection } from './components/TableSection';
+import { SubmitButtonSection } from './components/SubmitButtonSection';
 
 export type NewMessageMappingParameters = {
     name: string;
@@ -59,8 +60,8 @@ export const ChangeMessageView = () => {
         else navigate(`/integrations/connections/${messageId}`);
     };
 
-    const handleNewMessageSave = (values: NewMessageMappingParameters) => {
-
+    const handleNewMessageSave = (values: SetMessageMappingRequestArguments) => {
+        console.log('saving', values);
     };
 
     const removeSelectedTable = () => setSelectedTable(undefined);
@@ -82,22 +83,28 @@ export const ChangeMessageView = () => {
 
                 <ContentHeader title={title} buttons={[toolbarButtons]} sx={{ minHeight: 64 }} />
 
-                <Form<NewMessageMappingParameters>
+                <Form<SetMessageMappingRequestArguments>
                     initialValues={{
                         name: '',
                         description: '',
-                        messageTypeName: '',
-                        messageTypeDescription: '',
+                        fields: [],
                     }}
                     onSubmit={handleNewMessageSave}
                 >
                     <MessageDetailsSection mode={mode} />
                     {showTable
-                        ? <TableSection
-                            mode={mode}
-                            selectedTable={selectedTable}
-                            onBackToSearchResultsClicked={() => removeSelectedTable()}
-                        />
+                        ? <>
+                            <TableSection
+                                mode={mode}
+                                selectedTable={selectedTable}
+                                onBackToSearchResultsClicked={() => removeSelectedTable()}
+                            />
+                            <SubmitButtonSection
+                                mode={mode}
+                                isSubmitting={false}
+                            />
+                        </>
+
                         : <TableSearchSection
                             mode={mode}
                             onTableSelected={setSelectedTable}


### PR DESCRIPTION
- Successfully map the fiieldName changes from table into state
- clean up the code and remove some logging
- Use form context to set the selected fields in form
- Use form context's isValid to disable save button
- Mark row as selected when value has been mapped
- Wire up the mutation to save a new message type
- Add success and error handling with navigation and snackbars
