### PR TITLE
edit save message

### DIFF
--- a/Source/DesignSystem/atoms/AlertDialog/AlertDialog.tsx
+++ b/Source/DesignSystem/atoms/AlertDialog/AlertDialog.tsx
@@ -97,6 +97,12 @@ export type AlertDialogProps = {
      * The callback that is called when the dialog is confirmed.
      */
     onConfirm: () => void;
+
+    /**
+     * The callback that is called when the dialog is closed.
+     * @default onCancel
+     */
+    onClose?: () => void;
 };
 
 /**
@@ -104,10 +110,10 @@ export type AlertDialogProps = {
  * @param {AlertDialogProps} props - The {@link AlertDialogProps} that contains the properties for the alert dialog.
  * @returns A {@link AlertDialog} component.
  */
-export const AlertDialog = ({ id, title, description, children, confirmBtnColor, cancelBtnText, confirmBtnText, isOpen, onCancel, onConfirm }: AlertDialogProps) =>
+export const AlertDialog = ({ id, title, description, children, confirmBtnColor, cancelBtnText, confirmBtnText, isOpen, onCancel, onConfirm, onClose }: AlertDialogProps) =>
     <Dialog
         open={isOpen ?? false}
-        onClose={onCancel}
+        onClose={onClose ?? onCancel}
         aria-labelledby={`${id}-dialog-title`}
         aria-describedby={`${id}-dialog-description`}
         PaperComponent={(props: PaperProps) =>
@@ -118,7 +124,7 @@ export const AlertDialog = ({ id, title, description, children, confirmBtnColor,
     >
         <DialogTitle id={`${id}-dialog-title`} sx={styles.title}>
             {title}
-            <IconButton tooltipText='Close dialog' edge='end' onClick={onCancel} />
+            <IconButton tooltipText='Close dialog' edge='end' onClick={onClose ?? onCancel} />
         </DialogTitle>
 
         <DialogContent sx={{ typography: 'body2' }}>

--- a/Source/SelfService/Web/apis/integrations/CacheKeys.ts
+++ b/Source/SelfService/Web/apis/integrations/CacheKeys.ts
@@ -8,6 +8,9 @@ export enum CACHE_KEYS {
 
     //ConnectionApi
     Connection_GET = 'connection_get',
+
+    //MessageMappingApi
+    ConnectionMessageMappings_GET = 'connection_messages_get',
     ConnectionMessageMapping_GET = 'connection_message_get',
 
     //MappableTablesApi

--- a/Source/SelfService/Web/apis/integrations/messageMappingApi.hooks.ts
+++ b/Source/SelfService/Web/apis/integrations/messageMappingApi.hooks.ts
@@ -8,7 +8,8 @@ import { CACHE_KEYS } from './CacheKeys';
 import {
     MessageMappingApi,
     ConnectionsIdMessageMappingsGetRequest,
-    ConnectionsIdMessageMappingsTablesTableMessagesMessagePostRequest
+    ConnectionsIdMessageMappingsTablesTableMessagesMessagePostRequest,
+    ConnectionsIdMessageMappingsTablesTableMessagesMessageGetRequest
 } from './generated';
 
 let apiInstance: MessageMappingApi | undefined;
@@ -23,9 +24,19 @@ const getOrCreateApi = () => {
 export const useConnectionsIdMessageMappingsGet = (params: ConnectionsIdMessageMappingsGetRequest) => {
     const api = getOrCreateApi();
     return useQuery({
-        queryKey: [CACHE_KEYS.ConnectionMessageMapping_GET, params.id],
+        queryKey: [CACHE_KEYS.ConnectionMessageMappings_GET, params.id],
         queryFn: api.connectionsIdMessageMappingsGet.bind(api, params),
         staleTime: 60000,
+    });
+};
+
+export const useConnectionsIdMessageMappingsTablesTableMessagesMessageGet = (params: ConnectionsIdMessageMappingsTablesTableMessagesMessageGetRequest) => {
+    const api = getOrCreateApi();
+    return useQuery({
+        queryKey: [CACHE_KEYS.ConnectionMessageMapping_GET, params.id, params.table, params.message],
+        queryFn: api.connectionsIdMessageMappingsTablesTableMessagesMessageGet.bind(api, params),
+        staleTime: 60000,
+        enabled: !!params.id && !!params.table && !!params.message,
     });
 };
 

--- a/Source/SelfService/Web/integrations/connection/connectionDetails/messages/changeMessage/components/SubmitButtonSection.tsx
+++ b/Source/SelfService/Web/integrations/connection/connectionDetails/messages/changeMessage/components/SubmitButtonSection.tsx
@@ -26,7 +26,7 @@ export const SubmitButtonSection = (props: SubmitButtonSectionProps) => {
                 variant='fullwidth'
                 type='submit'
                 sx={{ mt: 2.125 }}
-                disabled={!isValid || !isDirty || props.isSubmitting || props.disabled  }
+                disabled={!isValid || props.isSubmitting || props.disabled  }
             />
         </ContentSection>
     );

--- a/Source/SelfService/Web/integrations/connection/connectionDetails/messages/changeMessage/components/SubmitButtonSection.tsx
+++ b/Source/SelfService/Web/integrations/connection/connectionDetails/messages/changeMessage/components/SubmitButtonSection.tsx
@@ -16,7 +16,7 @@ export type SubmitButtonSectionProps = ViewModeProps & {
 
 export const SubmitButtonSection = (props: SubmitButtonSectionProps) => {
 
-    const { isValid,  } = useFormState();
+    const { isValid, isDirty } = useFormState();
     const buttonText = props.mode === 'new' ? 'Add Message and close' : 'Save Message and close';
 
     return (
@@ -26,7 +26,7 @@ export const SubmitButtonSection = (props: SubmitButtonSectionProps) => {
                 variant='fullwidth'
                 type='submit'
                 sx={{ mt: 2.125 }}
-                disabled={!isValid || props.isSubmitting || props.disabled  }
+                disabled={!isValid || !isDirty || props.isSubmitting || props.disabled  }
             />
         </ContentSection>
     );

--- a/Source/SelfService/Web/integrations/connection/connectionDetails/messages/changeMessage/components/TableSearchSection.tsx
+++ b/Source/SelfService/Web/integrations/connection/connectionDetails/messages/changeMessage/components/TableSearchSection.tsx
@@ -24,7 +24,7 @@ const SearchFieldAdornment =
     </InputAdornment>;
 
 export type TableSearchSectionProps = ViewModeProps & {
-    onTableSelected: (table: TableListingEntry) => void;
+    onTableSelected: (tableName: string) => void;
     searchInput: string;
     setSearchInput: (searchInput: string) => void;
 };
@@ -53,7 +53,7 @@ export const TableSearchSection = ({ onTableSelected, searchInput, setSearchInpu
                     <TableSearchResults
                         tableListings={searchResults}
                         isLoading={query.isLoading}
-                        onTableSelected={table => { onTableSelected(table); }}
+                        onTableSelected={table => { onTableSelected(table.name!); }}
                     />
                 </>
             }

--- a/Source/SelfService/Web/integrations/connection/connectionDetails/messages/changeMessage/components/TableSection.tsx
+++ b/Source/SelfService/Web/integrations/connection/connectionDetails/messages/changeMessage/components/TableSection.tsx
@@ -108,14 +108,14 @@ export const TableSection = (props: TableSectionProps) => {
                 <ContentSection
                     title={`${props.selectedTableName} Table`}
                     beforeHeaderSlot={
-                        <Button
+                        props.mode === 'new' && (<Button
                             label='Back to Search Results'
                             startWithIcon={<Icon icon='ArrowBack' />}
                             variant='text'
                             color='subtle'
                             sx={{ ml: 1, mt: 2 }}
                             onClick={props.onBackToSearchResultsClicked}
-                        />
+                        />)
                     }
                 >
                     {!mappableTableResult?.value ? <AlertBox /> : (

--- a/Source/SelfService/Web/integrations/connection/connectionDetails/messages/changeMessage/components/TableSection.tsx
+++ b/Source/SelfService/Web/integrations/connection/connectionDetails/messages/changeMessage/components/TableSection.tsx
@@ -9,7 +9,7 @@ import { Grid, LinearProgress } from '@mui/material';
 import { GridSelectionModel } from '@mui/x-data-grid-pro';
 import { AlertBox, Button, Icon, MaxWidthTextBlock, Switch } from '@dolittle/design-system/';
 
-import { FieldMapping, MappedField, TableListingEntry } from '../../../../../../apis/integrations/generated';
+import { FieldMapping, MappedField } from '../../../../../../apis/integrations/generated';
 import { useConnectionsIdMessageMappingsTablesTableGet } from '../../../../../../apis/integrations/mappableTablesApi.hooks';
 
 import { useConnectionId } from '../../../../../routes.hooks';
@@ -44,7 +44,7 @@ export const TableSection = (props: TableSectionProps) => {
                 }]) || []),
         [props.initialSelectedFields]);
     const [mappedFields, setMappedFields] = useState<Map<string, FieldMapping>>(initialMapped);
-    const { setValue } = useFormContext();
+    const { setValue: setFormValue, getValues: getFormValues,  } = useFormContext();
 
     if (!connectionId || !props.selectedTableName) return <AlertBox />;
 
@@ -78,7 +78,7 @@ export const TableSection = (props: TableSectionProps) => {
             fieldName: column.fieldName,
             fieldDescription: '',
         }));
-        setValue('fields', fields);
+        setFormValue('fields', fields);
     }, [selectedTableColumns]);
 
     const onFieldMapped = (m3Field: string, mappedFieldName: any) => {

--- a/Source/SelfService/Web/integrations/connection/connectionDetails/messages/changeMessage/components/TableSection.tsx
+++ b/Source/SelfService/Web/integrations/connection/connectionDetails/messages/changeMessage/components/TableSection.tsx
@@ -20,7 +20,7 @@ import { DataGridTableListingEntry, MessageMappingTable } from './MessageMapping
 
 
 export type TableSectionProps = ViewModeProps & {
-    selectedTable: TableListingEntry;
+    selectedTableName: string;
     onBackToSearchResultsClicked: () => void;
 };
 
@@ -31,11 +31,11 @@ export const TableSection = (props: TableSectionProps) => {
     const [mappedFields, setMappedFields] = useState<Map<string, FieldMapping>>(new Map());
     const { setValue } = useFormContext();
 
-    if (!connectionId || !props.selectedTable.name) return <AlertBox />;
+    if (!connectionId || !props.selectedTableName) return <AlertBox />;
 
     const { data: mappableTableResult, isLoading, isInitialLoading } = useConnectionsIdMessageMappingsTablesTableGet({
         id: connectionId,
-        table: props.selectedTable.name,
+        table: props.selectedTableName,
     });
 
     const allMappableTableColumns = mappableTableResult?.value?.columns || [];
@@ -82,7 +82,7 @@ export const TableSection = (props: TableSectionProps) => {
         <>
             {isInitialLoading ? <LinearProgress /> : (
                 <ContentSection
-                    title={`${props.selectedTable.name} Table`}
+                    title={`${props.selectedTableName} Table`}
                     beforeHeaderSlot={
                         <Button
                             label='Back to Search Results'

--- a/Source/SelfService/Web/integrations/connection/connectionDetails/messages/changeMessage/components/TableSection.tsx
+++ b/Source/SelfService/Web/integrations/connection/connectionDetails/messages/changeMessage/components/TableSection.tsx
@@ -27,10 +27,23 @@ export type TableSectionProps = ViewModeProps & {
 
 export const TableSection = (props: TableSectionProps) => {
     const connectionId = useConnectionId();
-    const [selectedRowIds, setSelectedRowIds] = useState<GridSelectionModel>([]);
+    const initialSelected = useMemo(
+        () => props.initialSelectedFields.map(field => field.mappedColumn?.m3ColumnName!) || [],
+        [props.initialSelectedFields]
+    );
+    const [selectedRowIds, setSelectedRowIds] = useState<GridSelectionModel>(initialSelected);
     const [hideUnselectedRows, setHideUnselectedRows] = useState(props.mode === 'edit');
 
-    const [mappedFields, setMappedFields] = useState<Map<string, FieldMapping>>(new Map());
+    const initialMapped: Map<string, FieldMapping> = useMemo(() => new Map(
+        props.initialSelectedFields.map(
+            field => [
+                field.mappedColumn?.m3ColumnName!, {
+                    columnName: field.mappedColumn?.m3ColumnName!,
+                    fieldName: field.mappedName,
+                    fieldDescription: field.mappedDescription,
+                }]) || []),
+        [props.initialSelectedFields]);
+    const [mappedFields, setMappedFields] = useState<Map<string, FieldMapping>>(initialMapped);
     const { setValue } = useFormContext();
 
     if (!connectionId || !props.selectedTableName) return <AlertBox />;
@@ -58,28 +71,6 @@ export const TableSection = (props: TableSectionProps) => {
         () => gridMappableTableColumns.filter(column => selectedIds.includes(column.m3ColumnName!)),
         [allMappableTableColumns, selectedIds]
     );
-
-    const initialMapped: Map<string, FieldMapping> = useMemo(() => new Map(
-        props.initialSelectedFields.map(
-            field => [
-                field.mappedColumn?.m3ColumnName!, {
-                    columnName: field.mappedColumn?.m3ColumnName!,
-                    fieldName: field.mappedName,
-                    fieldDescription: field.mappedDescription,
-                }]) || []),
-        [props.initialSelectedFields]);
-
-    useEffect(() => {
-        setMappedFields(initialMapped);
-    }, [initialMapped]);
-
-    const initialSelected = useMemo(
-        () => props.initialSelectedFields.map(field => field.mappedColumn?.m3ColumnName!) || [],
-        [props.initialSelectedFields]
-    );
-    useEffect(() => {
-        setSelectedRowIds(initialSelected);
-    }, [initialSelected]);
 
     useEffect(() => {
         const fields: FieldMapping[] = selectedTableColumns.map(column => ({

--- a/Source/SelfService/Web/integrations/connection/connectionDetails/messages/changeMessage/index.tsx
+++ b/Source/SelfService/Web/integrations/connection/connectionDetails/messages/changeMessage/index.tsx
@@ -38,12 +38,15 @@ export const ChangeMessageView = () => {
     const messageQuery = useConnectionsIdMessageMappingsTablesTableMessagesMessageGet({ id: connectionId!, table: table!, message: messageId! });
 
     const [searchInput, setSearchInput] = useState<string>('');
-    const [selectedTable, setSelectedTable] = useState<TableListingEntry>();
+    const [selectedTableName, setSelectedTableName] = useState<string>();
     const [showDiscardChangesDialog, setShowDiscardChangesDialog] = useState(false);
 
     const mode: ViewMode = location.pathname.endsWith('new') ? 'new' : 'edit';
-    const showTable = !!selectedTable;
+    const showTable = !!selectedTableName;
     const title = mode === 'new' ? 'Create New Message Type' : `Edit Message Type - ${messageId}`;
+    if(mode === 'edit' && table && !selectedTableName) {
+        setSelectedTableName(table);
+    }
 
     const toolbarButtons = {
         label: 'Discard changes',
@@ -72,7 +75,7 @@ export const ChangeMessageView = () => {
         saveMessageMappingMutation.mutate({
             id: connectionId!,
             message: values.name!,
-            table: selectedTable?.name!,
+            table: selectedTableName!,
             setMessageMappingRequestArguments: {
                 name: values.name!,
                 description: values.description!,
@@ -90,7 +93,7 @@ export const ChangeMessageView = () => {
         });
     };
 
-    const removeSelectedTable = () => setSelectedTable(undefined);
+    const removeSelectedTable = () => setSelectedTableName(undefined);
 
     return (
         <>
@@ -129,7 +132,7 @@ export const ChangeMessageView = () => {
                                     ? <>
                                         <TableSection
                                             mode={mode}
-                                            selectedTable={selectedTable}
+                                            selectedTableName={selectedTableName}
                                             onBackToSearchResultsClicked={() => removeSelectedTable()}
                                         />
                                         <SubmitButtonSection
@@ -140,7 +143,7 @@ export const ChangeMessageView = () => {
 
                                     : <TableSearchSection
                                         mode={mode}
-                                        onTableSelected={setSelectedTable}
+                                        onTableSelected={setSelectedTableName}
                                         searchInput={searchInput}
                                         setSearchInput={setSearchInput}
                                     />

--- a/Source/SelfService/Web/integrations/connection/connectionDetails/messages/changeMessage/index.tsx
+++ b/Source/SelfService/Web/integrations/connection/connectionDetails/messages/changeMessage/index.tsx
@@ -72,8 +72,7 @@ export const ChangeMessageView = () => {
     const cancelMessageMapping = () => {
         setShowDiscardChangesDialog(false);
 
-        if (mode === 'new') navigate('/integrations/connections');
-        else navigate(`/integrations/connections/${messageId}`);
+        navigate('..');
     };
 
     const handleNewMessageSave = (values: SetMessageMappingRequestArguments) => {
@@ -115,6 +114,7 @@ export const ChangeMessageView = () => {
                                         description={`By clicking ‘discard changes' none of the changes you have made to this screen will be stored.`}
                                         isOpen={showDiscardChangesDialog}
                                         onCancel={() => cancelMessageMapping()}
+                                        onClose={() => setShowDiscardChangesDialog(false)}
                                         onConfirm={() => setShowDiscardChangesDialog(false)}
                                         cancelBtnText='Discard changes'
                                         confirmBtnText='Continue working'

--- a/Source/SelfService/Web/integrations/connection/connectionDetails/messages/changeMessage/index.tsx
+++ b/Source/SelfService/Web/integrations/connection/connectionDetails/messages/changeMessage/index.tsx
@@ -34,19 +34,24 @@ export const ChangeMessageView = () => {
     const navigate = useNavigate();
     const { table, messageId } = useParams();
     const connectionId = useConnectionId();
-    const saveMessageMappingMutation = useConnectionsIdMessageMappingsTablesTableMessagesMessagePost();
-    const messageQuery = useConnectionsIdMessageMappingsTablesTableMessagesMessageGet({ id: connectionId!, table: table!, message: messageId! });
-
     const [searchInput, setSearchInput] = useState<string>('');
-    const [selectedTableName, setSelectedTableName] = useState<string>();
+    const [selectedTableName, setSelectedTableName] = useState<string>('');
     const [showDiscardChangesDialog, setShowDiscardChangesDialog] = useState(false);
 
+    const saveMessageMappingMutation = useConnectionsIdMessageMappingsTablesTableMessagesMessagePost();
+
+    const messageQuery = useConnectionsIdMessageMappingsTablesTableMessagesMessageGet({ id: connectionId!, table: table!, message: messageId! });
+
     const mode: ViewMode = location.pathname.endsWith('new') ? 'new' : 'edit';
-    const showTable = !!selectedTableName;
+    const showTable = !!selectedTableName || mode === 'edit';
     const title = mode === 'new' ? 'Create New Message Type' : `Edit Message Type - ${messageId}`;
-    if(mode === 'edit' && table && !selectedTableName) {
+
+    const messageType = messageQuery.data?.value;
+
+    if (mode === 'edit' && table && !selectedTableName) {
         setSelectedTableName(table);
     }
+
 
     const toolbarButtons = {
         label: 'Discard changes',
@@ -93,7 +98,7 @@ export const ChangeMessageView = () => {
         });
     };
 
-    const removeSelectedTable = () => setSelectedTableName(undefined);
+    const removeSelectedTable = () => setSelectedTableName('');
 
     return (
         <>
@@ -133,6 +138,7 @@ export const ChangeMessageView = () => {
                                         <TableSection
                                             mode={mode}
                                             selectedTableName={selectedTableName}
+                                            initialSelectedFields={messageType?.fieldMappings ?? []}
                                             onBackToSearchResultsClicked={() => removeSelectedTable()}
                                         />
                                         <SubmitButtonSection

--- a/Source/SelfService/Web/integrations/connection/connectionDetails/messages/changeMessage/index.tsx
+++ b/Source/SelfService/Web/integrations/connection/connectionDetails/messages/changeMessage/index.tsx
@@ -107,54 +107,62 @@ export const ChangeMessageView = () => {
                     ? <AlertBox />
                     : (
                         <>
-                            <AlertDialog
-                                id='discard-changes-dialog'
-                                title='Are you sure that you want to discard these changes?'
-                                description={`By clicking ‘discard changes' none of the changes you have made to this screen will be stored.`}
-                                isOpen={showDiscardChangesDialog}
-                                onCancel={() => cancelMessageMapping()}
-                                onConfirm={() => setShowDiscardChangesDialog(false)}
-                                cancelBtnText='Discard changes'
-                                confirmBtnText='Continue working'
-                            />
-
-                            <ContentHeader
-                                title={title}
-                                buttons={[toolbarButtons]}
-                                sx={{ minHeight: 64 }}
-                            />
-
-                            <Form<SetMessageMappingRequestArguments>
-                                initialValues={{
-                                    name: '',
-                                    description: '',
-                                    fields: [],
-                                }}
-                                onSubmit={handleNewMessageSave}
-                            >
-                                <MessageDetailsSection mode={mode} />
-                                {showTable
-                                    ? <>
-                                        <TableSection
-                                            mode={mode}
-                                            selectedTableName={selectedTableName}
-                                            initialSelectedFields={messageType?.fieldMappings ?? []}
-                                            onBackToSearchResultsClicked={() => removeSelectedTable()}
-                                        />
-                                        <SubmitButtonSection
-                                            mode={mode}
-                                            isSubmitting={saveMessageMappingMutation.isLoading}
-                                        />
-                                    </>
-
-                                    : <TableSearchSection
-                                        mode={mode}
-                                        onTableSelected={setSelectedTableName}
-                                        searchInput={searchInput}
-                                        setSearchInput={setSearchInput}
+                            {mode === 'new' || messageQuery.isSuccess && (
+                                <>
+                                    <AlertDialog
+                                        id='discard-changes-dialog'
+                                        title='Are you sure that you want to discard these changes?'
+                                        description={`By clicking ‘discard changes' none of the changes you have made to this screen will be stored.`}
+                                        isOpen={showDiscardChangesDialog}
+                                        onCancel={() => cancelMessageMapping()}
+                                        onConfirm={() => setShowDiscardChangesDialog(false)}
+                                        cancelBtnText='Discard changes'
+                                        confirmBtnText='Continue working'
                                     />
-                                }
-                            </Form>
+
+                                    <ContentHeader
+                                        title={title}
+                                        buttons={[toolbarButtons]}
+                                        sx={{ minHeight: 64 }}
+                                    />
+
+                                    <Form<SetMessageMappingRequestArguments>
+                                        initialValues={{
+                                            name: messageType?.name ?? '',
+                                            description: messageType?.description ?? '',
+                                            fields: messageType?.fieldMappings?.map(field => ({
+                                                columnName: field.mappedColumn?.m3ColumnName!,
+                                                fieldName: field.mappedName,
+                                                fieldDescription: field.mappedDescription,
+                                            })) || [],
+                                        }}
+                                        onSubmit={handleNewMessageSave}
+                                    >
+                                        <MessageDetailsSection mode={mode} />
+                                        {showTable
+                                            ? <>
+                                                <TableSection
+                                                    mode={mode}
+                                                    selectedTableName={selectedTableName}
+                                                    initialSelectedFields={messageType?.fieldMappings ?? []}
+                                                    onBackToSearchResultsClicked={() => removeSelectedTable()}
+                                                />
+                                                <SubmitButtonSection
+                                                    mode={mode}
+                                                    isSubmitting={saveMessageMappingMutation.isLoading}
+                                                />
+                                            </>
+
+                                            : <TableSearchSection
+                                                mode={mode}
+                                                onTableSelected={setSelectedTableName}
+                                                searchInput={searchInput}
+                                                setSearchInput={setSearchInput}
+                                            />
+                                        }
+                                    </Form>
+                                </>
+                            )}
                         </>
                     )
                 }

--- a/Source/SelfService/Web/integrations/connection/routes.tsx
+++ b/Source/SelfService/Web/integrations/connection/routes.tsx
@@ -36,7 +36,7 @@ export const routes: RouteObject[] = [
                         element: <ChangeMessageView />,
                     },
                     {
-                        path: 'edit/:messageId',
+                        path: 'edit/:table/:messageId',
                         element: <ChangeMessageView />,
                     },
                 ]


### PR DESCRIPTION
- Add query for getting a message
- Use query to fetch message type on edit page
- Change selectedTable to be selectedTableName.
- Use the existing field mapping to set the initial state in table
- Not show "back to search" for edit mode
- Only render content if new or query returns data
- Rename wording of hide/show selected switch
- Remove the "isDirty" check for now - need to get this to work with table values
- Add support to override the onClose action on AlertDialog
