### PR TITLE
Fix broken new message type form by setting initial state after data has loaded

### DIFF
--- a/Source/DesignSystem/atoms/Forms/Form.tsx
+++ b/Source/DesignSystem/atoms/Forms/Form.tsx
@@ -1,10 +1,13 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-import React, { useMemo, ReactNode } from 'react';
-import { useForm, FieldValues, FormProvider, SubmitHandler, SubmitErrorHandler } from 'react-hook-form';
+
+import React, { useMemo, ReactNode, forwardRef, useImperativeHandle, ForwardedRef } from 'react';
+import { useForm, FieldValues, FormProvider, SubmitHandler, SubmitErrorHandler, UseFormReturn } from 'react-hook-form';
 
 import { Box, SxProps } from '@mui/material';
+
+export type FormRef<T extends FieldValues> = UseFormReturn<T, any>;
 
 /**
  * The props for a {@link Form} component.
@@ -34,6 +37,13 @@ export type FormProps<T extends FieldValues> = {
      * The sx prop lets you add custom styles to the component, overriding the styles defined by Material-UI.
      */
     sx?: SxProps;
+
+    /**
+     * Optional ref that contains the {@link UseFormReturn<T>} object returned from {@link useForm}.
+     * Practical for accessing the form's state from the parent component, and doing things like resetting the form.
+     * More info on approach here: https://react-typescript-cheatsheet.netlify.app/docs/basic/getting-started/forward_and_create_ref/#option-1---wrapper-component
+     */
+    fRef?: ForwardedRef<FormRef<T>>;
 };
 
 /**
@@ -41,12 +51,14 @@ export type FormProps<T extends FieldValues> = {
  * @param {FormProps} props The {@link FormProps} for the form.
  * @returns A {@link Form} component.
  */
-export const Form = <T extends FieldValues>({ initialValues, onSubmit, onSubmitInvalid, children, sx }: FormProps<T>) => {
+export const Form = <T extends FieldValues>({ initialValues, onSubmit, onSubmitInvalid, children, sx, fRef }: FormProps<T>) => {
     const methods = useForm<T>({
         mode: 'onTouched',
         defaultValues: initialValues as any,
     });
     const { handleSubmit } = methods;
+
+    useImperativeHandle(fRef, () => methods, [methods]);
 
     const handleFormSubmit = useMemo(() => handleSubmit(
         (data, event) => onSubmit?.(data, event),
@@ -61,3 +73,4 @@ export const Form = <T extends FieldValues>({ initialValues, onSubmit, onSubmitI
         </Box>
     );
 };
+

--- a/Source/DesignSystem/atoms/Forms/index.ts
+++ b/Source/DesignSystem/atoms/Forms/index.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 export { Checkbox } from './Checkbox';
-export { Form, FormProps } from './Form';
+export { Form, FormProps, FormRef } from './Form';
 export { Input, InputProps } from './Input';
 export { Select, SelectProps, SelectPropsOptions } from './Select';
 export { Switch } from './Switch';

--- a/Source/DesignSystem/index.ts
+++ b/Source/DesignSystem/index.ts
@@ -11,7 +11,7 @@ export { AccordionList, AccordionListProps } from './atoms/AccordionList';
 export { AlertDialog, AlertDialogProps } from './atoms/AlertDialog';
 export { AlertBox, AlertBoxProps, AlertBoxErrorMessage, AlertBoxInfoMessage } from './atoms/AlertBox';
 export { Button, ButtonProps } from './atoms/Button';
-export { Checkbox, Form, Input, Select, SelectProps, SelectPropsOptions, Switch } from './atoms/Forms';
+export * from './atoms/Forms';
 export { DataTableToolbar, DataTableToolbarProps } from './atoms/DataTablePro/DataTableToolbar';
 //export { DropdownMenu } from './atoms/DropdownMenu';
 export { Icon } from './atoms/Icon';

--- a/Source/SelfService/Web/integrations/connection/connectionDetails/messages/changeMessage/components/MessageMappingForm.tsx
+++ b/Source/SelfService/Web/integrations/connection/connectionDetails/messages/changeMessage/components/MessageMappingForm.tsx
@@ -1,10 +1,10 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { enqueueSnackbar } from 'notistack';
 import { useNavigate } from 'react-router-dom';
-import { Form } from '@dolittle/design-system';
+import { Form, FormRef } from '@dolittle/design-system';
 
 
 import { ConnectionsIdMessageMappingsTablesTableMessagesMessagePostRequest, MessageMappingModel, SetMessageMappingRequestArguments } from '../../../../../../apis/integrations/generated';
@@ -33,27 +33,22 @@ export const MessageMappingForm = ({
     saveMessageMappingMutation
 }: MessageMappingFormProps) => {
     const navigate = useNavigate();
-
-    const [initialValues, setInitialValues] = useState<NewMessageMappingParameters>({
-        name: '',
-        description: '',
-        fields: [],
-    });
+    const formRef = useRef<FormRef<NewMessageMappingParameters>>(null);
 
     useEffect(() => {
         if (!messageType) {
             return;
         }
-        setInitialValues(
-            {
-                name: messageType?.name ?? '',
-                description: messageType?.description ?? '',
-                fields: messageType?.fieldMappings?.map(field => ({
-                    columnName: field.mappedColumn?.m3ColumnName!,
-                    fieldName: field.mappedName,
-                    fieldDescription: field.mappedDescription,
-                })) || [],
-            });
+
+        formRef.current?.reset({
+            name: messageType?.name ?? '',
+            description: messageType?.description ?? '',
+            fields: messageType?.fieldMappings?.map(field => ({
+                columnName: field.mappedColumn?.m3ColumnName!,
+                fieldName: field.mappedName,
+                fieldDescription: field.mappedDescription,
+            })) || [],
+        });
     }, [messageType]);
 
 
@@ -80,8 +75,17 @@ export const MessageMappingForm = ({
 
     return (
         <Form<NewMessageMappingParameters>
-            initialValues={initialValues}
+            initialValues={{
+                name: messageType?.name ?? '',
+                description: messageType?.description ?? '',
+                fields: messageType?.fieldMappings?.map(field => ({
+                    columnName: field.mappedColumn?.m3ColumnName!,
+                    fieldName: field.mappedName,
+                    fieldDescription: field.mappedDescription,
+                })) || [],
+            }}
             onSubmit={handleNewMessageSave}
+            fRef={formRef}
         >
             {children}
         </Form>

--- a/Source/SelfService/Web/integrations/connection/connectionDetails/messages/changeMessage/components/MessageMappingForm.tsx
+++ b/Source/SelfService/Web/integrations/connection/connectionDetails/messages/changeMessage/components/MessageMappingForm.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { enqueueSnackbar } from 'notistack';
 import { useNavigate } from 'react-router-dom';
 import { Form } from '@dolittle/design-system';
@@ -34,6 +34,29 @@ export const MessageMappingForm = ({
 }: MessageMappingFormProps) => {
     const navigate = useNavigate();
 
+    const [initialValues, setInitialValues] = useState<NewMessageMappingParameters>({
+        name: '',
+        description: '',
+        fields: [],
+    });
+
+    useEffect(() => {
+        if (!messageType) {
+            return;
+        }
+        setInitialValues(
+            {
+                name: messageType?.name ?? '',
+                description: messageType?.description ?? '',
+                fields: messageType?.fieldMappings?.map(field => ({
+                    columnName: field.mappedColumn?.m3ColumnName!,
+                    fieldName: field.mappedName,
+                    fieldDescription: field.mappedDescription,
+                })) || [],
+            });
+    }, [messageType]);
+
+
     const handleNewMessageSave = (values: NewMessageMappingParameters) => {
         saveMessageMappingMutation.mutate({
             id: connectionId!,
@@ -56,24 +79,12 @@ export const MessageMappingForm = ({
     };
 
     return (
-        <>
-            {!messageType
-                ? <>{children}</>
-                : <Form<NewMessageMappingParameters>
-                    initialValues={{
-                        name: messageType?.name ?? '',
-                        description: messageType?.description ?? '',
-                        fields: messageType?.fieldMappings?.map(field => ({
-                            columnName: field.mappedColumn?.m3ColumnName!,
-                            fieldName: field.mappedName,
-                            fieldDescription: field.mappedDescription,
-                        })) || [],
-                    }}
-                    onSubmit={handleNewMessageSave}
-                >
-                    {children}
-                </Form>
-            }
-        </>
+        <Form<NewMessageMappingParameters>
+            initialValues={initialValues}
+            onSubmit={handleNewMessageSave}
+        >
+            {children}
+        </Form>
+
     );
 };

--- a/Source/SelfService/Web/integrations/connection/connectionDetails/messages/changeMessage/components/TableSection.tsx
+++ b/Source/SelfService/Web/integrations/connection/connectionDetails/messages/changeMessage/components/TableSection.tsx
@@ -96,13 +96,6 @@ export const TableSection = ({ selectedTableName, initialSelectedFields, onBackT
     };
 
     useEffect(() => {
-        const fields: FieldMapping[] = selectedTableColumns.map(column => ({
-            columnName: column.m3ColumnName!,
-            fieldName: column.fieldName,
-            fieldDescription: '',
-        }));
-        setFormValue('fields', fields);
-
         selectedTableColumns
             .filter(column => !column.fieldName)
             .forEach(column => column.fieldName = generateMappedFieldNameFrom(column.m3Description!));
@@ -111,6 +104,13 @@ export const TableSection = ({ selectedTableName, initialSelectedFields, onBackT
             .filter(column => column.fieldName)
             .filter(column => !selectedTableColumns.map(c => c.m3ColumnName!).includes(column.m3ColumnName!))
             .forEach(column => column.fieldName = '');
+
+        const fields: FieldMapping[] = selectedTableColumns.map(column => ({
+            columnName: column.m3ColumnName!,
+            fieldName: column.fieldName,
+            fieldDescription: '',
+        }));
+        setFormValue('fields', fields);
     }, [selectedTableColumns]);
 
     const onFieldMapped = (m3Field: string, mappedFieldName: any) => {


### PR DESCRIPTION
- Extend Form with a ref that returns the hook methods
- Use secondary option by passing in ref as props without forwardRef
- Set the form values after request has returned data
