### PR TITLE
Fix unique naming when mass-selecting table

### DIFF
--- a/Source/SelfService/Web/integrations/connection/connectionDetails/messages/changeMessage/components/TableSection.tsx
+++ b/Source/SelfService/Web/integrations/connection/connectionDetails/messages/changeMessage/components/TableSection.tsx
@@ -28,6 +28,11 @@ export type TableSectionProps = ViewModeProps & {
 
 export const TableSection = ({ selectedTableName, initialSelectedFields, onBackToSearchResultsClicked, mode }: TableSectionProps) => {
     const connectionId = useConnectionId();
+
+    if (!connectionId || !selectedTableName) {
+        return <AlertBox />;
+    }
+
     const initialSelected = useMemo(
         () => initialSelectedFields.map(field => field.mappedColumn?.m3ColumnName) || [],
         [initialSelectedFields]
@@ -47,9 +52,8 @@ export const TableSection = ({ selectedTableName, initialSelectedFields, onBackT
         [initialSelectedFields]);
 
     const [mappedFields, setMappedFields] = useState<Map<string, FieldMapping>>(initialMapped);
-    const { setValue: setFormValue, getValues: getFormValues } = useFormContext();
+    const { setValue: setFormValue } = useFormContext();
 
-    if (!connectionId || !selectedTableName) return <AlertBox />;
 
     const { data: mappableTableResult, isLoading, isInitialLoading } = useConnectionsIdMessageMappingsTablesTableGet({
         id: connectionId,
@@ -117,7 +121,7 @@ export const TableSection = ({ selectedTableName, initialSelectedFields, onBackT
         setFormValue('fields', fields);
     }, [selectedTableColumns]);
 
-    const onFieldMapped = (m3Field: string, mappedFieldName: any) => {
+    const updateMappedFields = (m3Field: string, mappedFieldName: any) => {
         setMappedFields(prevMappedFields => {
             const newMappedFields = new Map(prevMappedFields);
 
@@ -162,7 +166,7 @@ export const TableSection = ({ selectedTableName, initialSelectedFields, onBackT
                                 selectedIds={selectedIds}
                                 disabledRows={requiredTableColumnIds}
                                 onSelectedIdsChanged={setSelectedRowIds}
-                                onFieldMapped={onFieldMapped}
+                                onFieldMapped={updateMappedFields}
                             />
                         </>
                     )}

--- a/Source/SelfService/Web/integrations/connection/connectionDetails/messages/changeMessage/components/TableSection.tsx
+++ b/Source/SelfService/Web/integrations/connection/connectionDetails/messages/changeMessage/components/TableSection.tsx
@@ -8,7 +8,7 @@ import { useFormContext } from 'react-hook-form';
 import { Grid, LinearProgress, Box } from '@mui/material';
 import { GridSelectionModel } from '@mui/x-data-grid-pro';
 
-import { AlertBox, Button, MaxWidthTextBlock, Switch } from '@dolittle/design-system/';
+import { AlertBox, Button, Switch } from '@dolittle/design-system/';
 import { ContentSection } from '../../../../../../components/layout/Content/ContentSection';
 
 import { FieldMapping, MappedField } from '../../../../../../apis/integrations/generated';
@@ -75,9 +75,7 @@ export const TableSection = ({ selectedTableName, initialSelectedFields, onBackT
         [gridMappableTableColumns, selectedIds]
     );
 
-    const uniqueMappedNames = useMemo(() => [...new Set(selectedTableColumns.map(column => column.fieldName))], [selectedTableColumns]);
-    const generateMappedFieldNameFrom = (columnDescription: string) => {
-
+    const generateMappedFieldNameFrom = (columnDescription: string, uniqueMappedNames: string[]) => {
         let generated = toPascalCase(columnDescription);
         let isUnique = true;
         let suffixNumber = 0;
@@ -95,10 +93,14 @@ export const TableSection = ({ selectedTableName, initialSelectedFields, onBackT
         return generated;
     };
 
+
     useEffect(() => {
         selectedTableColumns
             .filter(column => !column.fieldName)
-            .forEach(column => column.fieldName = generateMappedFieldNameFrom(column.m3Description));
+            .forEach(column => {
+                const uniqueMappedNames = [...new Set(selectedTableColumns.map(column => column.fieldName))];
+                column.fieldName = generateMappedFieldNameFrom(column.m3Description, uniqueMappedNames);
+            });
 
         gridMappableTableColumns
             .filter(column => column.fieldName)

--- a/Source/SelfService/Web/integrations/connection/connectionDetails/messages/changeMessage/components/TableSection.tsx
+++ b/Source/SelfService/Web/integrations/connection/connectionDetails/messages/changeMessage/components/TableSection.tsx
@@ -95,11 +95,13 @@ export const TableSection = ({ selectedTableName, initialSelectedFields, onBackT
 
 
     useEffect(() => {
+        const uniqueMappedNames = new Set(selectedTableColumns.map(column => column.fieldName));
         selectedTableColumns
             .filter(column => !column.fieldName)
             .forEach(column => {
-                const uniqueMappedNames = [...new Set(selectedTableColumns.map(column => column.fieldName))];
-                column.fieldName = generateMappedFieldNameFrom(column.m3Description, uniqueMappedNames);
+                const fieldName = generateMappedFieldNameFrom(column.m3Description, [...uniqueMappedNames]);
+                uniqueMappedNames.add(fieldName);
+                column.fieldName = fieldName;
             });
 
         gridMappableTableColumns


### PR DESCRIPTION
- Generate unique fieldname when mass-selecting a table
- Optimize the unique creation slightly by not needing to create a new Set for each loop
