### PR TITLE
Improve message type name validation to not support non alpha numeric characters

### DIFF
--- a/Source/SelfService/Web/applications/microservice/deployMicroservice/containerImageFields.tsx
+++ b/Source/SelfService/Web/applications/microservice/deployMicroservice/containerImageFields.tsx
@@ -8,7 +8,7 @@ import { Box, SxProps, Typography } from '@mui/material';
 import { Input, Link, Tooltip } from '@dolittle/design-system';
 
 import { HeadArguments } from '../components/form/headArguments';
-import { alphaNumericCharsRegex } from '../../../utils/validation/patterns';
+import { alphaNumericLowerCasedCharsRegex } from '../../../utils/validation/patterns';
 
 const portDescription = `By default, your mircroservice will be hosted on port 80 within the secure Dolittle cluster,
 but this can be overridden if your image requires it.`;
@@ -48,7 +48,7 @@ export const ContainerImageFields = ({ sx }: ContainerImageFieldsProps) =>
                 label='Port'
                 required='Provide a port. Default is 80.'
                 pattern={{
-                    value: alphaNumericCharsRegex,
+                    value: alphaNumericLowerCasedCharsRegex,
                     message: 'Please enter a valid port number.'
                 }}
             />

--- a/Source/SelfService/Web/applications/microservice/microserviceDetails/configurationFilesSection/setupSection/containerImageFields.tsx
+++ b/Source/SelfService/Web/applications/microservice/microserviceDetails/configurationFilesSection/setupSection/containerImageFields.tsx
@@ -8,7 +8,7 @@ import { Box, SxProps, Typography } from '@mui/material';
 import { Input } from '@dolittle/design-system';
 
 import { HeadArguments } from '../../../components/form/headArguments';
-import { alphaNumericCharsRegex } from '../../../../../utils/validation/patterns';
+import { alphaNumericLowerCasedCharsRegex } from '../../../../../utils/validation/patterns';
 
 type ContainerImageFieldsProps = {
     disabled: boolean;
@@ -34,7 +34,7 @@ export const ContainerImageFields = ({ disabled, sx }: ContainerImageFieldsProps
             disabled={disabled}
             required
             pattern={{
-                value: alphaNumericCharsRegex,
+                value: alphaNumericLowerCasedCharsRegex,
                 message: 'Please enter a valid port number.'
             }}
             dashedBorder

--- a/Source/SelfService/Web/integrations/connection/connectionDetails/messages/changeMessage/components/MessageDetailsSection.tsx
+++ b/Source/SelfService/Web/integrations/connection/connectionDetails/messages/changeMessage/components/MessageDetailsSection.tsx
@@ -9,7 +9,7 @@ import { Input } from '@dolittle/design-system';
 
 import { ViewModeProps } from '../ViewMode';
 import { ContentSection } from '../../../../../../components/layout/Content/ContentSection';
-import { nonWhitespaceRegex } from '../../../../../../utils/validation/patterns';
+import { alphaNumericCharsRegex } from '../../../../../../utils/validation/patterns';
 
 
 export type MessageDetailsSectionProps = ViewModeProps & {};
@@ -19,7 +19,7 @@ export const MessageDetailsSection = (props: MessageDetailsSectionProps) =>
         <Grid container gap={4}>
             <Stack spacing={3}>
                 <Typography variant='subtitle2'>Provide a name for your message type</Typography>
-                <Input id='name' label='Message Type Name' required pattern={{value: nonWhitespaceRegex, message: 'Cannot contain spaces'}}/>
+                <Input id='name' label='Message Type Name' required pattern={{value: alphaNumericCharsRegex, message: 'Can only contain characters or numbers'}}/>
             </Stack>
 
             <Stack spacing={3}>

--- a/Source/SelfService/Web/integrations/connection/connectionDetails/messages/changeMessage/components/MessageMappingForm.tsx
+++ b/Source/SelfService/Web/integrations/connection/connectionDetails/messages/changeMessage/components/MessageMappingForm.tsx
@@ -34,6 +34,7 @@ export const MessageMappingForm = ({
 }: MessageMappingFormProps) => {
     const navigate = useNavigate();
     const formRef = useRef<FormRef<NewMessageMappingParameters>>(null);
+    const [hasBeenReset, setHasBeenReset] = useState(false);
 
     useEffect(() => {
         if (!messageType) {
@@ -49,7 +50,14 @@ export const MessageMappingForm = ({
                 fieldDescription: field.mappedDescription,
             })) || [],
         });
-    }, [messageType]);
+        setHasBeenReset(true);
+    }, [messageType, formRef.current?.reset]);
+
+    useEffect(() => {
+        if (hasBeenReset) {
+            formRef.current?.trigger();
+        }
+    }, [formRef.current?.trigger, hasBeenReset]);
 
 
     const handleNewMessageSave = (values: NewMessageMappingParameters) => {

--- a/Source/SelfService/Web/spaces/applications/create/inputField.tsx
+++ b/Source/SelfService/Web/spaces/applications/create/inputField.tsx
@@ -6,7 +6,7 @@ import React from 'react';
 import { Box } from '@mui/material';
 
 import { Input } from '@dolittle/design-system';
-import { alphaNumericCharsRegex, emailRegex } from '../../../utils/validation/patterns';
+import { alphaNumericLowerCasedCharsRegex, emailRegex } from '../../../utils/validation/patterns';
 
 const styles = {
     formFieldsWrapper: {
@@ -36,7 +36,7 @@ export const InputFields = ({ nameId, contactId, emailId }: InputFieldsProps) =>
             label='Application Name'
             required='Application name required.'
             pattern={{
-                value: alphaNumericCharsRegex,
+                value: alphaNumericLowerCasedCharsRegex,
                 message: 'Name can only contain lowercase alphanumeric characters.'
             }}
             sx={{ display: 'flex' }}

--- a/Source/SelfService/Web/utils/validation/patterns.ts
+++ b/Source/SelfService/Web/utils/validation/patterns.ts
@@ -7,9 +7,9 @@
 export const emailRegex = /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
 
 /**
- * Regular expression for matching alpha characters
+ * Regular expression for matching lower-cased alpha numeric characters
  */
-export const alphaNumericCharsRegex = /^([a-z0-9]+)$/;
+export const alphaNumericLowerCasedCharsRegex = /^([a-z0-9]+)$/;
 
 /**
  * Regular expression for matching non-whitespace characters

--- a/Source/SelfService/Web/utils/validation/patterns.ts
+++ b/Source/SelfService/Web/utils/validation/patterns.ts
@@ -12,6 +12,11 @@ export const emailRegex = /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(
 export const alphaNumericLowerCasedCharsRegex = /^([a-z0-9]+)$/;
 
 /**
+ * Regular expression for matching any cased alpha numeric characters
+ */
+export const alphaNumericCharsRegex = /^[a-zA-Z0-9]*$/;
+
+/**
  * Regular expression for matching non-whitespace characters
  */
 export const nonWhitespaceRegex = /^\S+$/;


### PR DESCRIPTION
- Update current alpha numeric regex pattern to include it's for lower case only
- Use any cased alpha numeric regex for input validation of message type name
- Trigger form validation after initial values have been set
