### PR TITLE
Add 'undefined' as possible value for MS PodStatuses

### DIFF
--- a/Source/SelfService/Web/applications/microservice/microserviceDetails/healthStatus/healthStatusTableColumns.tsx
+++ b/Source/SelfService/Web/applications/microservice/microserviceDetails/healthStatus/healthStatusTableColumns.tsx
@@ -14,12 +14,12 @@ import { HealthStatusTableRow } from './healthStatusTable';
 import { healthStatus } from '../../components/microserviceStatus';
 
 const StatusCell = (params: GridRenderCellParams<any, HealthStatusTableRow>) => {
-    const status = params.row.state.toLowerCase();
+    const status = params.row?.state?.toLowerCase();
 
     return (
         <StatusIndicator
-            status={healthStatus(status)?.status}
-            label={healthStatus(status)?.label}
+            status={healthStatus(status).status}
+            label={healthStatus(status).label}
         />
     );
 };

--- a/Source/SelfService/Web/applications/microservice/microserviceDetails/microserviceDetails.tsx
+++ b/Source/SelfService/Web/applications/microservice/microserviceDetails/microserviceDetails.tsx
@@ -136,8 +136,8 @@ export const MicroserviceView = ({ application, microserviceId, environment, pod
                 <Typography variant='h1' sx={{ mr: 3 }}>{currentMicroservice.name}</Typography>
                 <StatusIndicator
                     variantFilled
-                    status={getContainerHealthStatus(containerStatuses())?.status}
-                    label={getContainerHealthStatus(containerStatuses())?.label}
+                    status={getContainerHealthStatus(containerStatuses()).status}
+                    label={getContainerHealthStatus(containerStatuses()).label}
                 />
             </Box>
 

--- a/Source/SelfService/Web/applications/microservice/microservices/microservicesTable.tsx
+++ b/Source/SelfService/Web/applications/microservice/microservices/microservicesTable.tsx
@@ -32,12 +32,12 @@ const PublicUrlCell = (params: GridRenderCellParams) => {
 };
 
 const StatusCell = (params: GridRenderCellParams) => {
-    const status = params.value.toLowerCase();
+    const status = params.value?.toLowerCase();
 
     return (
         <StatusIndicator
-            status={healthStatus(status)?.status}
-            label={healthStatus(status)?.label}
+            status={healthStatus(status).status}
+            label={healthStatus(status).label}
         />
     );
 };
@@ -79,7 +79,7 @@ export const MicroserviceTable = ({ application, environment, microservices }: M
 
             return {
                 ...microservice,
-                phase: status[0]?.phase
+                phase: status[0]?.phase,
             } as MicroserviceObject;
         })).then(data => {
             setMicroserviceRows(data);


### PR DESCRIPTION
### Fixed

- Empty podStatus gave error to entire MS DataTable. Added 'undefined' as possible PodStatus that returns 'unknown' as status.

![MicrosoftTeams-image](https://user-images.githubusercontent.com/19160439/236857129-1e4baf3d-bbc1-4253-9618-722535784ee7.png)


