### PR TITLE
Make y-axis dynamic of the microservices health metrics graphs 

### DIFF
--- a/Environment/mock/index.js
+++ b/Environment/mock/index.js
@@ -5,7 +5,7 @@ const express = require('express');
 
 const { logging, notImplemented } = require('./middlewares');
 
-const applications = require('./api/solutions/applications');
+const applications = require('./api/applications');
 const proxy = require('./proxy');
 const logs = require('./monitoring/logs');
 const metrics = require('./monitoring/metrics');

--- a/Source/SelfService/Web/applications/microservice/microserviceDetails/healthStatus/healthStatus.tsx
+++ b/Source/SelfService/Web/applications/microservice/microserviceDetails/healthStatus/healthStatus.tsx
@@ -104,11 +104,11 @@ export const HealthStatus = ({ applicationId, environment, microserviceId, msNam
 
             {cpu.loading
                 ? null
-                : <Graph title='CPU Usage' unit='CPUs' subtitle='Last 24 hours' range={[0, 2]} domain={timeRange} sx={{ mt: 3 }} data={cpuGraphData} />
+                : <Graph title='CPU Usage' unit='CPUs' subtitle='Last 24 hours' domain={timeRange} sx={{ mt: 3 }} data={cpuGraphData} />
             }
             {memory.loading
                 ? null
-                : <Graph title='Memory Usage' unit='MiB' subtitle='Last 24 hours' range={[0, 2048]} domain={timeRange} sx={{ mt: 3 }} data={memoryGraphData} />
+                : <Graph title='Memory Usage' unit='MiB' subtitle='Last 24 hours' domain={timeRange} sx={{ mt: 3 }} data={memoryGraphData} />
             }
         </>
     );


### PR DESCRIPTION
## Summary

Make health status metrics dynamic based on data, instead of hardcoding y-axis. This to cater to some pods having hight limits than the presets. We don't necessarily know what the pod resource limits are. These can be re-introduced at a later time when the API returns the exact resource limit information.

### Changed

- Dynamic y-axis on health metrics graphs, instead of fixed limits.