### PR TITLE
Fix BackupsListItems environment display

### DIFF
--- a/Source/SelfService/Web/applications/backup/backupsListItems.tsx
+++ b/Source/SelfService/Web/applications/backup/backupsListItems.tsx
@@ -11,13 +11,6 @@ import { Button, SimpleCard } from '@dolittle/design-system';
 import { HttpResponseApplication } from '../../apis/solutions/application';
 import { getLatestBackupLinkByApplication } from '../../apis/solutions/backups';
 
-const getFullEnvironmentName = (str: string) => {
-    if (str === 'Prod') return 'Production';
-    if (str === 'Dev') return 'Development';
-
-    return 'N/A';
-};
-
 export type BackupsListItemsProps = {
     application: HttpResponseApplication;
     environment: string;
@@ -45,7 +38,7 @@ export const BackupsListItems = ({ application, environment, name }: BackupsList
     return (
         <SimpleCard
             title={application.name}
-            subtitle={`${getFullEnvironmentName(environment)} Environment`}
+            subtitle={`${environment} Environment`}
             description={name}
             actionButtons={
                 <>


### PR DESCRIPTION
## Summary

BackupsListItems displayed only limited hardcoded environment values. If the value was not listed, 'N/A' was displayed.

<img width="935" alt="Screenshot 2023-06-16 at 12 46 41" src="https://github.com/dolittle/Studio/assets/19160439/4ca56d57-d79f-4117-8e2b-1b54d5ec3620">

### Fixed

- Removed fixed environment values from BackupsListItems.

