### PR TITLE
Validation Rules for new connector page

### DIFF
--- a/Source/DesignSystem/atoms/Forms/Input.tsx
+++ b/Source/DesignSystem/atoms/Forms/Input.tsx
@@ -37,6 +37,12 @@ export type InputProps = {
     dashedBorder?: boolean;
 
     /**
+     * The type of the input.
+     * @default 'text'
+     */
+    type?: string;
+
+    /**
      * The sx prop lets you add custom styles to the component, overriding the styles defined by Material-UI.
      */
     sx?: SxProps;
@@ -47,7 +53,7 @@ export type InputProps = {
  * @param props - The {@link InputProps} for the input.
  * @returns A {@link Input} component.
  */
-export const Input = forwardRef<HTMLInputElement, InputProps>(({ autoFocus, startAdornment, placeholder, dashedBorder, sx, ...fieldProps }, ref) => {
+export const Input = forwardRef<HTMLInputElement, InputProps>(({ autoFocus, startAdornment, placeholder, dashedBorder, type, sx, ...fieldProps }, ref) => {
     const { field, hasError, errorMessage } = useController(fieldProps);
 
     return (
@@ -82,7 +88,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(({ autoFocus, star
                 required={isRequired(fieldProps.required)}
                 placeholder={placeholder}
                 aria-describedby={`${fieldProps.id}-helper-text`}
-                type='text'
+                type={type ?? 'text'}
                 size='small'
                 sx={{ typography: 'body2' }}
                 startAdornment={startAdornment ?

--- a/Source/DesignSystem/atoms/Forms/PasswordInput.stories.tsx
+++ b/Source/DesignSystem/atoms/Forms/PasswordInput.stories.tsx
@@ -1,0 +1,40 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import React from 'react';
+
+import { componentStories, Form, Tooltip, PasswordInput } from '@dolittle/design-system';
+
+type StoriesValuesProps = {
+    defaultInput: string;
+};
+
+const { metadata, createStory } = componentStories(PasswordInput, {
+    actions: { onChange: 'changed' },
+    decorator: (Story) => (
+        <Form<StoriesValuesProps>
+            initialValues={{
+                defaultInput: '',
+            }}>
+            {Story()}
+        </Form>
+    ),
+});
+
+metadata.parameters = {
+    docs: {
+        description: {
+            component: `
+The \`PasswordInput\` component is a wrapper around the \`Input\` component with a \`type='password'\` prop. It also masks the input, and allows the user to peek at the input, if they want
+            ` },
+    },
+};
+
+metadata.args = {
+    id: 'password',
+    label: 'Password',
+};
+
+export default metadata;
+
+export const Default = createStory();

--- a/Source/DesignSystem/atoms/Forms/PasswordInput.tsx
+++ b/Source/DesignSystem/atoms/Forms/PasswordInput.tsx
@@ -29,7 +29,7 @@ export const PasswordInput = forwardRef<HTMLInputElement, PasswordInputProps>(({
             type={showPassword ? 'text' : 'password'}
             startAdornment={
                 <IconButton
-                    icon={showPassword ? 'VisibilityOff' : 'Visibility'}
+                    icon={showPassword ? 'Visibility' : 'VisibilityOff'}
                     tooltipText={showPassword ? 'Hide password' : 'Show password'}
                     onClick={() => setShowPassword(!showPassword)}
                 />

--- a/Source/DesignSystem/atoms/Forms/PasswordInput.tsx
+++ b/Source/DesignSystem/atoms/Forms/PasswordInput.tsx
@@ -1,0 +1,42 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import React, { forwardRef } from 'react';
+
+import { IconButton } from '@dolittle/design-system';
+
+import type { Form } from './Form';
+import { Input, InputProps } from './Input';
+
+/**
+ * The props for a {@link PasswordInput} component.
+ */
+export type PasswordInputProps = InputProps & {
+};
+
+
+/**
+ * Creates a password input field to be used in a {@link Form}.
+ * By default, the input will be masked with an option to show the password.
+ * @param props - The {@link PasswordInputProps} for the input.
+ * @returns A {@link PasswordInput} component.
+ */
+export const PasswordInput = forwardRef<HTMLInputElement, PasswordInputProps>(({ ...inputProps }: PasswordInputProps, ref) => {
+    const [showPassword, setShowPassword] = React.useState(false);
+
+    return (
+        <Input
+            type={showPassword ? 'text' : 'password'}
+            startAdornment={
+                <IconButton
+                    icon={showPassword ? 'VisibilityOff' : 'Visibility'}
+                    tooltipText={showPassword ? 'Hide password' : 'Show password'}
+                    onClick={() => setShowPassword(!showPassword)}
+                />
+            }
+            {...inputProps}
+        />
+    );
+});
+
+PasswordInput.displayName = 'PasswordInput';

--- a/Source/DesignSystem/atoms/Forms/index.ts
+++ b/Source/DesignSystem/atoms/Forms/index.ts
@@ -4,5 +4,6 @@
 export { Checkbox } from './Checkbox';
 export { Form, FormProps, FormRef } from './Form';
 export { Input, InputProps } from './Input';
+export { PasswordInput, PasswordInputProps } from './PasswordInput';
 export { Select, SelectProps, SelectPropsOptions } from './Select';
 export { Switch } from './Switch';

--- a/Source/DesignSystem/theming/Icons/Icons.tsx
+++ b/Source/DesignSystem/theming/Icons/Icons.tsx
@@ -48,6 +48,8 @@ import {
     SupervisedUserCircleRounded,
     TextSnippetRounded,
     UploadRounded,
+    Visibility,
+    VisibilityOff,
     WarningRounded,
 } from '@mui/icons-material';
 
@@ -104,6 +106,8 @@ export const SvgIcons = {
     SupervisedUserCircleRounded: <SupervisedUserCircleRounded />,
     TextSnippetRounded: <TextSnippetRounded />,
     UploadRounded: <UploadRounded />,
+    Visibility: <Visibility />,
+    VisibilityOff: <VisibilityOff />,
     WarningRounded: <WarningRounded />,
 };
 

--- a/Source/SelfService/Web/integrations/connection/new/components/ActionButtons.tsx
+++ b/Source/SelfService/Web/integrations/connection/new/components/ActionButtons.tsx
@@ -4,24 +4,33 @@
 import React from 'react';
 
 import { Box } from '@mui/material';
+import { useHref } from 'react-router-dom';
 import { useFormState } from 'react-hook-form';
-
 import { Button } from '@dolittle/design-system';
+import { ConnectionModel } from '../../../../apis/integrations/generated';
 
-export const ActionButtons = () => {
+export type ActionButtonsProps = {
+    connection: ConnectionModel;
+
+};
+
+export const ActionButtons = ({ connection }: ActionButtonsProps) => {
     const { isValid, isDirty, isSubmitting } = useFormState();
+    const messageHref = useHref('../messages');
+
+    const isConnected = connection?.status.name === 'Connected';
 
     return <Box sx={{ my: 5 }}>
         <Button
             label='Save connection'
-            disabled={!isValid || !isDirty || isSubmitting}
+            disabled={!isValid || !isDirty || isSubmitting }
             type='submit'
             sx={{ mr: 3 }} />
 
         <Button
             label='Start Mapping Data'
             variant='filled'
-            disabled
-            href='#' />
+            disabled={isConnected}
+            href={messageHref} />
     </Box>;
 };

--- a/Source/SelfService/Web/integrations/connection/new/components/ActionButtons.tsx
+++ b/Source/SelfService/Web/integrations/connection/new/components/ActionButtons.tsx
@@ -4,22 +4,24 @@
 import React from 'react';
 
 import { Box } from '@mui/material';
+import { useFormState } from 'react-hook-form';
 
 import { Button } from '@dolittle/design-system';
 
-export const ActionButtons = () =>
-    <Box sx={{ my: 5 }}>
+export const ActionButtons = () => {
+    const { isValid, isDirty, isSubmitting } = useFormState();
+
+    return <Box sx={{ my: 5 }}>
         <Button
             label='Save connection'
-            //disabled
+            disabled={!isValid || !isDirty || isSubmitting}
             type='submit'
-            sx={{ mr: 3 }}
-        />
+            sx={{ mr: 3 }} />
 
         <Button
             label='Start Mapping Data'
             variant='filled'
             disabled
-            href='#'
-        />
+            href='#' />
     </Box>;
+};

--- a/Source/SelfService/Web/integrations/connection/new/components/ActionButtons.tsx
+++ b/Source/SelfService/Web/integrations/connection/new/components/ActionButtons.tsx
@@ -30,7 +30,7 @@ export const ActionButtons = ({ connection }: ActionButtonsProps) => {
         <Button
             label='Start Mapping Data'
             variant='filled'
-            disabled={isConnected}
+            disabled={!isConnected}
             href={messageHref} />
     </Box>;
 };

--- a/Source/SelfService/Web/integrations/connection/new/components/M3ConfigurationForm.tsx
+++ b/Source/SelfService/Web/integrations/connection/new/components/M3ConfigurationForm.tsx
@@ -80,9 +80,10 @@ export const M3ConfigurationForm = ({ connectionId, connection, hasSelectedDeplo
                 {
                     onSuccess: () => {
                         handleSuccessfulSave('Saved Name');
+                        currentForm.resetField('connectorName', { defaultValue: data.connectorName });
                         onNameSaved?.();
                     },
-                        onError: (error) => handleErrorWhenSaving('Error saving Name', error),
+                    onError: (error) => handleErrorWhenSaving('Error saving Name', error),
                 },
             );
         }
@@ -97,6 +98,7 @@ export const M3ConfigurationForm = ({ connectionId, connection, hasSelectedDeplo
                     {
                         onSuccess: () => {
                             handleSuccessfulSave('Saved Hosting Type');
+                            currentForm.resetField('selectHosting', { defaultValue: data.selectHosting });
                             onSelectHostingSaved?.();
                         },
                         onError: (error) => handleErrorWhenSaving('Error saving Hosting Type', error),
@@ -113,10 +115,11 @@ export const M3ConfigurationForm = ({ connectionId, connection, hasSelectedDeplo
                     {
                         onSuccess: () => {
                             handleSuccessfulSave('Saved Hosting Type');
+                            currentForm.resetField('selectHosting', { defaultValue: data.selectHosting });
                             onSelectHostingSaved?.();
                         },
                         onError: (error) => handleErrorWhenSaving('Error saving Hosting Type', error),
-                },
+                    },
                 );
             }
         }
@@ -137,6 +140,8 @@ export const M3ConfigurationForm = ({ connectionId, connection, hasSelectedDeplo
                 {
                     onSuccess: () => {
                         handleSuccessfulSave('Saved MDP Configuration');
+                        currentForm.resetField('metadataPublisherUrl', { defaultValue: data.metadataPublisherUrl });
+                        currentForm.resetField('metadataPublisherPassword', { defaultValue: data.metadataPublisherPassword });
                         onMdpConfigurationSaved?.();
                     },
                     onError: (error) => handleErrorWhenSaving('Error saving MDP Configuration', error),
@@ -153,6 +158,7 @@ export const M3ConfigurationForm = ({ connectionId, connection, hasSelectedDeplo
                 {
                     onSuccess: () => {
                         handleSuccessfulSave('Saved ION Configuration');
+                        currentForm.resetField('ionConfiguration', { defaultValue: data.ionConfiguration, keepDirty: false });
                         onIonConfigurationSaved?.();
                     },
                     onError: (error) => handleErrorWhenSaving('Error saving ION Configuration', error),

--- a/Source/SelfService/Web/integrations/connection/new/components/M3ConfigurationForm.tsx
+++ b/Source/SelfService/Web/integrations/connection/new/components/M3ConfigurationForm.tsx
@@ -15,6 +15,15 @@ import { useConnectionsIdNamePost } from '../../../../apis/integrations/connecti
 import { useConnectionsIdDeployCloudPost, useConnectionsIdDeployOnPremisesPost } from '../../../../apis/integrations/deploymentApi.hooks';
 import { useConnectionsIdConfigurationMdpPost, useConnectionsIdConfigurationIonPost } from '../../../../apis/integrations/connectionConfigurationApi.hooks';
 
+
+const useForceSubscribeToIonConfigurationStateChanges = (currentForm: FormRef<M3ConnectionParameters> | undefined) => {
+    useEffect(() => {
+        if (currentForm) {
+            const { isDirty } = currentForm.getFieldState('ionConfiguration', currentForm.formState);
+        }
+    }, [currentForm]);
+};
+
 export type M3ConnectionParameters = {
     connectorName: string;
     selectHosting: string;
@@ -57,11 +66,7 @@ export const M3ConfigurationForm = ({ connectionId, connection, hasSelectedDeplo
     const ionConfiguration = connection._configuration?.ion;
 
 
-    useEffect(() => {
-        if (currentForm) {
-            const { isDirty } = currentForm?.getFieldState('ionConfiguration', currentForm.formState);
-        }
-    }, [currentForm]);
+    useForceSubscribeToIonConfigurationStateChanges(currentForm);
 
     const handleM3ConnectionSave: SubmitHandler<M3ConnectionParameters> = useCallback((data) => {
         if (!connectionId || !currentForm) {
@@ -211,3 +216,4 @@ export const M3ConfigurationForm = ({ connectionId, connection, hasSelectedDeplo
         </Form>
     );
 };
+

--- a/Source/SelfService/Web/integrations/connection/new/components/M3ConfigurationForm.tsx
+++ b/Source/SelfService/Web/integrations/connection/new/components/M3ConfigurationForm.tsx
@@ -163,6 +163,7 @@ export const M3ConfigurationForm = ({ connectionId, connection, hasSelectedDeplo
                 {
                     onSuccess: () => {
                         handleSuccessfulSave('Saved ION Configuration');
+                        //TODO: This doesn't reset the field of the current form!
                         currentForm.resetField('ionConfiguration', { defaultValue: data.ionConfiguration, keepDirty: false });
                         onIonConfigurationSaved?.();
                     },

--- a/Source/SelfService/Web/integrations/connection/new/components/MainM3ConnectionInfo.tsx
+++ b/Source/SelfService/Web/integrations/connection/new/components/MainM3ConnectionInfo.tsx
@@ -58,7 +58,7 @@ export const MainM3ConnectionInfo = ({ connectionIdLinks, hasSelectedDeploymentT
             <MaxWidthTextBlock>{newConnectionDescription}</MaxWidthTextBlock>
 
             <Tooltip tooltipTitle='Connector Name' tooltipText={<ConnectorNameTooltipText />} sx={{ top: 16 }}>
-                <Input id='connectorName' label='Connector Name' required='Please enter the connector name'/>
+                <Input id='connectorName' label='Connector Name' placeholder='M3 Connector Test' required='Please enter the connector name'/>
             </Tooltip>
 
             <Tooltip tooltipTitle='Hosting' tooltipText={hostingTooltipText} displayOnHover={hasSelectedDeploymentType} sx={{ top: 38 }}>

--- a/Source/SelfService/Web/integrations/connection/new/components/MainM3ConnectionInfo.tsx
+++ b/Source/SelfService/Web/integrations/connection/new/components/MainM3ConnectionInfo.tsx
@@ -65,7 +65,8 @@ export const MainM3ConnectionInfo = ({ connectionIdLinks, hasSelectedDeploymentT
                 <Select
                     id='selectHosting'
                     label='Hosting'
-                    options={selectValues} disabled={hasSelectedDeploymentType}
+                    options={selectValues}
+                    disabled={hasSelectedDeploymentType}
                     required='Please select the hosting type'
                 />
             </Tooltip>

--- a/Source/SelfService/Web/integrations/connection/new/components/MainM3ConnectionInfo.tsx
+++ b/Source/SelfService/Web/integrations/connection/new/components/MainM3ConnectionInfo.tsx
@@ -58,14 +58,15 @@ export const MainM3ConnectionInfo = ({ connectionIdLinks, hasSelectedDeploymentT
             <MaxWidthTextBlock>{newConnectionDescription}</MaxWidthTextBlock>
 
             <Tooltip tooltipTitle='Connector Name' tooltipText={<ConnectorNameTooltipText />} sx={{ top: 16 }}>
-                <Input id='connectorName' label='Connector Name *' />
+                <Input id='connectorName' label='Connector Name' required='Please enter the connector name'/>
             </Tooltip>
 
             <Tooltip tooltipTitle='Hosting' tooltipText={hostingTooltipText} displayOnHover={hasSelectedDeploymentType} sx={{ top: 38 }}>
                 <Select
                     id='selectHosting'
-                    label='Hosting *'
+                    label='Hosting'
                     options={selectValues} disabled={hasSelectedDeploymentType}
+                    required='Please select the hosting type'
                 />
             </Tooltip>
         </Stack>

--- a/Source/SelfService/Web/integrations/connection/new/components/MetadataPublisherCredentials.tsx
+++ b/Source/SelfService/Web/integrations/connection/new/components/MetadataPublisherCredentials.tsx
@@ -4,11 +4,17 @@
 import React from 'react';
 
 import { Stack } from '@mui/material';
+import { useFormContext } from 'react-hook-form';
 
 import { Input, MaxWidthTextBlock } from '@dolittle/design-system';
 
-export const MetadataPublisherCredentials = () =>
-    <>
+export const MetadataPublisherCredentials = () => {
+    const { watch } = useFormContext();
+    const [ metadataPublisherUrl, metadataPublisherPassword ] = watch(['metadataPublisherUrl', 'metadataPublisherPassword']);
+
+    const required = !!metadataPublisherUrl || !!metadataPublisherPassword;
+
+    return <>
         <MaxWidthTextBlock>
             This will allow us to access your service and provide the data, including custom data fields, needed to configure your application logic.
         </MaxWidthTextBlock>
@@ -16,10 +22,17 @@ export const MetadataPublisherCredentials = () =>
         <Stack spacing={3.5} sx={{ mt: 3 }}>
             <Input
                 id='metadataPublisherUrl'
-                label='Your Metadata Publisher URL *'
+                label='Your Metadata Publisher URL'
                 placeholder='Your metadata publisher URL goes here...'
                 sx={{ width: 1, maxWidth: 500 }}
+                required={{ value: required, message: 'Please enter your metadata publisher URL' }}
             />
-            <Input id='metadataPublisherPassword' label='Password *' placeholder='Your password' />
+            <Input
+                id='metadataPublisherPassword'
+                label='Password'
+                placeholder='Your password'
+                required={{ value: required, message: 'Please enter the metadata publisher password' }}
+            />
         </Stack>
     </>;
+};

--- a/Source/SelfService/Web/integrations/connection/new/components/MetadataPublisherCredentials.tsx
+++ b/Source/SelfService/Web/integrations/connection/new/components/MetadataPublisherCredentials.tsx
@@ -6,7 +6,7 @@ import React from 'react';
 import { Stack } from '@mui/material';
 import { useFormContext } from 'react-hook-form';
 
-import { Input, MaxWidthTextBlock } from '@dolittle/design-system';
+import { Input, PasswordInput, MaxWidthTextBlock } from '@dolittle/design-system';
 
 export const MetadataPublisherCredentials = () => {
     const { watch } = useFormContext();
@@ -27,7 +27,7 @@ export const MetadataPublisherCredentials = () => {
                 sx={{ width: 1, maxWidth: 500 }}
                 required={{ value: required, message: 'Please enter your metadata publisher URL' }}
             />
-            <Input
+            <PasswordInput
                 id='metadataPublisherPassword'
                 label='Password'
                 placeholder='Your password'

--- a/Source/SelfService/Web/integrations/connection/new/index.tsx
+++ b/Source/SelfService/Web/integrations/connection/new/index.tsx
@@ -48,7 +48,7 @@ export const NewConnectionView = () => {
 
                     <AccordionList  {...accordionListProps} />
 
-                    <ActionButtons />
+                    <ActionButtons connection={connection} />
                 </M3ConfigurationForm>
             </Box>
         </Page>

--- a/Source/SelfService/Web/integrations/connection/new/index.tsx
+++ b/Source/SelfService/Web/integrations/connection/new/index.tsx
@@ -2,7 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 import React, { useRef } from 'react';
-import { Box, Typography } from '@mui/material';
+import { Box, Typography, Collapse } from '@mui/material';
 import { AccordionList, AccordionListProps, FileUploadFormRef } from '@dolittle/design-system';
 
 import { useConnectionsIdGet } from '../../../apis/integrations/connectionsApi.hooks';
@@ -29,6 +29,7 @@ export const NewConnectionView = () => {
     const hasSelectedDeploymentType = deploymentType?.toLowerCase() !== 'unknown';
 
     const accordionListProps: AccordionListProps = useBuildConfigurationAccordionList(connection, fileUploadRef);
+    const canConfigureConnection = connection?.status?.name !== 'Registered';
 
 
     if (query.isLoading) return <>Loading</>;
@@ -46,7 +47,10 @@ export const NewConnectionView = () => {
                 >
                     <MainM3ConnectionInfo hasSelectedDeploymentType={hasSelectedDeploymentType} connectionIdLinks={links} />
 
-                    <AccordionList  {...accordionListProps} />
+                    <Collapse in={canConfigureConnection}>
+                        <AccordionList  {...accordionListProps} />
+                    </Collapse>
+
 
                     <ActionButtons connection={connection} />
                 </M3ConfigurationForm>

--- a/Source/SelfService/Web/integrations/connection/new/useBuildConfigurationAccordionList.tsx
+++ b/Source/SelfService/Web/integrations/connection/new/useBuildConfigurationAccordionList.tsx
@@ -16,7 +16,6 @@ export function useBuildConfigurationAccordionList(connection: ConnectionModel |
         const connectorBundleStatus = hostBundleStatusFromServicesStatus(connection?.mdpStatus, connection?.ionStatus);
         const metadataPublisherCredentialsStatus = configurationStatusFromServiceCredentialsStatus(connection?.mdpStatus);
         const iONServiceAccountCredentialsStatus = configurationStatusFromServiceCredentialsStatus(connection?.ionStatus);
-        const disabled = connection?.status?.name === 'Registered';
 
         return {
             singleExpandMode: true,
@@ -27,7 +26,6 @@ export function useBuildConfigurationAccordionList(connection: ConnectionModel |
                     children: <ConnectorBundleConfiguration />,
                     progressStatus: connectorBundleStatus[0],
                     progressLabel: connectorBundleStatus[1],
-                    disabled,
                     sx: { mt: 8 },
                 },
                 {
@@ -36,7 +34,6 @@ export function useBuildConfigurationAccordionList(connection: ConnectionModel |
                     children: <MetadataPublisherCredentials />,
                     progressStatus: metadataPublisherCredentialsStatus[0],
                     progressLabel: metadataPublisherCredentialsStatus[1],
-                    disabled,
                     sx: { mt: 8 },
                 },
                 {
@@ -45,7 +42,6 @@ export function useBuildConfigurationAccordionList(connection: ConnectionModel |
                     children: <IonServiceAccountCredentials ref={fileUploadRef} />,
                     progressStatus: iONServiceAccountCredentialsStatus[0],
                     progressLabel: iONServiceAccountCredentialsStatus[1],
-                    disabled,
                     sx: { mt: 8 },
                 },
             ],


### PR DESCRIPTION
## Summary

Improvements to the new connector page that supports better validation and flow of the form

## Added 
 - PasswordInput: Add PasswordInput component with show/hide password functionality
 - New Connector:  Validation and enabling save button when configuring new connector
   - Enable save button when there are changes and valid
   - Reset fields after successfully saving
   - Make connector name and deployment type required
   - Required metadata password/url to be required if one of them is set
- Enable "Start Message Mapping" button when conneciton is Connected

## Changed
- New Connector: Expand configuration sections when user has selected deployment typw
- Input: Extend Input to accept "type" as a string prop that defaults to text


