### PR TITLE
Reset M3 configuration form state correctly

### DIFF
--- a/Source/SelfService/Web/integrations/connection/configuration/M3ConfigurationForm.tsx
+++ b/Source/SelfService/Web/integrations/connection/configuration/M3ConfigurationForm.tsx
@@ -40,10 +40,7 @@ export type M3ConfigurationFormProps = {
     connectionId: string;
     connection: ConnectionModel
     hasSelectedDeploymentType: boolean;
-    onNameSaved?: () => void;
-    onSelectHostingSaved?: () => void;
-    onMdpConfigurationSaved?: () => void;
-    onIonConfigurationSaved?: () => void;
+    onSaved?: () => void;
     children?: React.ReactNode;
 };
 
@@ -52,10 +49,7 @@ export const M3ConfigurationForm = React.forwardRef<M3ConfigurationFormRef, M3Co
         connectionId,
         connection,
         hasSelectedDeploymentType,
-        onNameSaved,
-        onSelectHostingSaved,
-        onMdpConfigurationSaved,
-        onIonConfigurationSaved,
+        onSaved,
         children
     }: M3ConfigurationFormProps,
     ref: React.Ref<M3ConfigurationFormRef>
@@ -80,8 +74,9 @@ export const M3ConfigurationForm = React.forwardRef<M3ConfigurationFormRef, M3Co
     useEffect(() => {
         if (currentForm?.formState.isSubmitSuccessful) {
             currentForm.reset(currentForm.getValues());
+            onSaved?.();
         }
-    }, [currentForm?.reset, currentForm?.formState.isSubmitSuccessful, currentForm?.formState.defaultValues]);
+    }, [currentForm?.reset, currentForm?.formState.isSubmitSuccessful, currentForm?.formState.defaultValues, onSaved]);
 
 
     const { enqueueSnackbar } = useSnackbar();
@@ -116,7 +111,6 @@ export const M3ConfigurationForm = React.forwardRef<M3ConfigurationFormRef, M3Co
                 {
                     onSuccess: () => {
                         handleSuccessfulSave('Saved Name');
-                        onNameSaved?.();
                     },
                     onError: (error) => handleErrorWhenSaving('Error saving Name', error),
                 },
@@ -133,7 +127,6 @@ export const M3ConfigurationForm = React.forwardRef<M3ConfigurationFormRef, M3Co
                     {
                         onSuccess: () => {
                             handleSuccessfulSave('Saved Hosting Type');
-                            onSelectHostingSaved?.();
                         },
                         onError: (error) => handleErrorWhenSaving('Error saving Hosting Type', error),
                     },
@@ -149,7 +142,6 @@ export const M3ConfigurationForm = React.forwardRef<M3ConfigurationFormRef, M3Co
                     {
                         onSuccess: () => {
                             handleSuccessfulSave('Saved Hosting Type');
-                            onSelectHostingSaved?.();
                         },
                         onError: (error) => handleErrorWhenSaving('Error saving Hosting Type', error),
                     },
@@ -173,7 +165,6 @@ export const M3ConfigurationForm = React.forwardRef<M3ConfigurationFormRef, M3Co
                 {
                     onSuccess: () => {
                         handleSuccessfulSave('Saved MDP Configuration');
-                        onMdpConfigurationSaved?.();
                     },
                     onError: (error) => handleErrorWhenSaving('Error saving MDP Configuration', error),
                 },
@@ -189,7 +180,6 @@ export const M3ConfigurationForm = React.forwardRef<M3ConfigurationFormRef, M3Co
                 {
                     onSuccess: () => {
                         handleSuccessfulSave('Saved ION Configuration');
-                        onIonConfigurationSaved?.();
                     },
                     onError: (error) => handleErrorWhenSaving('Error saving ION Configuration', error),
                 },

--- a/Source/SelfService/Web/integrations/connection/configuration/M3ConfigurationForm.tsx
+++ b/Source/SelfService/Web/integrations/connection/configuration/M3ConfigurationForm.tsx
@@ -51,6 +51,14 @@ export const M3ConfigurationForm = ({ connectionId, connection, hasSelectedDeplo
             setCurrentForm(ref);
         }
     }, []);
+
+    useEffect(() => {
+        if (currentForm?.formState.isSubmitSuccessful) {
+            currentForm.reset(currentForm.getValues());
+        }
+    }, [currentForm?.reset, currentForm?.formState.isSubmitSuccessful, currentForm?.formState.defaultValues]);
+
+
     const { enqueueSnackbar } = useSnackbar();
 
     const queryClient = useQueryClient();
@@ -91,7 +99,6 @@ export const M3ConfigurationForm = ({ connectionId, connection, hasSelectedDeplo
                 {
                     onSuccess: () => {
                         handleSuccessfulSave('Saved Name');
-                        currentForm.resetField('connectorName', { defaultValue: data.connectorName });
                         onNameSaved?.();
                     },
                     onError: (error) => handleErrorWhenSaving('Error saving Name', error),
@@ -109,7 +116,6 @@ export const M3ConfigurationForm = ({ connectionId, connection, hasSelectedDeplo
                     {
                         onSuccess: () => {
                             handleSuccessfulSave('Saved Hosting Type');
-                            currentForm.resetField('selectHosting', { defaultValue: data.selectHosting });
                             onSelectHostingSaved?.();
                         },
                         onError: (error) => handleErrorWhenSaving('Error saving Hosting Type', error),
@@ -126,7 +132,6 @@ export const M3ConfigurationForm = ({ connectionId, connection, hasSelectedDeplo
                     {
                         onSuccess: () => {
                             handleSuccessfulSave('Saved Hosting Type');
-                            currentForm.resetField('selectHosting', { defaultValue: data.selectHosting });
                             onSelectHostingSaved?.();
                         },
                         onError: (error) => handleErrorWhenSaving('Error saving Hosting Type', error),
@@ -151,8 +156,6 @@ export const M3ConfigurationForm = ({ connectionId, connection, hasSelectedDeplo
                 {
                     onSuccess: () => {
                         handleSuccessfulSave('Saved MDP Configuration');
-                        currentForm.resetField('metadataPublisherUrl', { defaultValue: data.metadataPublisherUrl });
-                        currentForm.resetField('metadataPublisherPassword', { defaultValue: data.metadataPublisherPassword });
                         onMdpConfigurationSaved?.();
                     },
                     onError: (error) => handleErrorWhenSaving('Error saving MDP Configuration', error),
@@ -169,8 +172,6 @@ export const M3ConfigurationForm = ({ connectionId, connection, hasSelectedDeplo
                 {
                     onSuccess: () => {
                         handleSuccessfulSave('Saved ION Configuration');
-                        //TODO: This doesn't reset the field of the current form!
-                        currentForm.resetField('ionConfiguration', { defaultValue: data.ionConfiguration, keepDirty: false });
                         onIonConfigurationSaved?.();
                     },
                     onError: (error) => handleErrorWhenSaving('Error saving ION Configuration', error),

--- a/Source/SelfService/Web/integrations/connection/connectionDetails/configuration/ActionToolbar.tsx
+++ b/Source/SelfService/Web/integrations/connection/connectionDetails/configuration/ActionToolbar.tsx
@@ -11,40 +11,26 @@ import { Button } from '@dolittle/design-system';
 
 export type ActionToolbarProps = {
     canEdit: boolean;
-    onEdit: () => void;
-    onDelete: () => void;
-    onCancel: () => void;
-    onSave: () => void;
+    onEditAction?: () => void;
+    onDeleteAction?: () => void;
+    onCancelAction?: () => void;
 };
 
-export const ActionToolbar = ({ onEdit, onDelete, onCancel, onSave, canEdit = false }: ActionToolbarProps) => {
+export const ActionToolbar = ({ onEditAction, onDeleteAction, onCancelAction, canEdit = false }: ActionToolbarProps) => {
     const { isValid, isDirty } = useFormState();
-    const [saved, setSaved] = useState(false);
-
-    // Delay triggering onSave until after the default click handler has propagated with the submit button
-    useEffect(() => {
-        if (saved) {
-            onSave();
-        }
-    }, [saved]);
 
     return (
         <Box sx={{ display: 'flex', mt: 4, gap: 2 }}>
             {canEdit
-                ? <Button label={'Cancel'} startWithIcon='CancelRounded' onClick={onCancel} />
-                : <Button label='Edit' startWithIcon='EditRounded' onClick={onEdit} />}
+                ? <Button label={'Cancel'} startWithIcon='CancelRounded' onClick={onCancelAction} type='reset' />
+                : <Button label='Edit' startWithIcon='EditRounded' onClick={onEditAction} />}
             <Button
                 label='Save'
                 startWithIcon='SaveRounded'
                 disabled={!canEdit || !isDirty || !isValid}
                 type='submit'
-                onClick={(event) => {
-                    setSaved(false);
-                    setSaved(true);
-                    return event;
-                }}
             />
-            <Button label='Delete Connection' startWithIcon='DeleteRounded' onClick={onDelete} />
+            <Button label='Delete Connection' startWithIcon='DeleteRounded' onClick={onDeleteAction} />
         </Box>
     );
 };

--- a/Source/SelfService/Web/integrations/connection/connectionDetails/configuration/index.tsx
+++ b/Source/SelfService/Web/integrations/connection/connectionDetails/configuration/index.tsx
@@ -18,7 +18,6 @@ import { ActionToolbar } from './ActionToolbar';
 
 export const ConfigurationView = () => {
     const [canEdit, setEditMode] = useState(false);
-    const [resetForm, setResetForm] = useState(false);
     const connectionId = useConnectionId();
     const query = useConnectionsIdGet(
         { id: connectionId || '' },
@@ -47,18 +46,18 @@ export const ConfigurationView = () => {
                 connectionId={connectionId}
                 connection={connection}
                 hasSelectedDeploymentType={hasSelectedDeploymentType}
-                onIonConfigurationSaved={() => fileUploadRef.current?.clearSelected()}
+                onSaved={() => {
+                    fileUploadRef.current?.clearSelected();
+                    setEditMode(false);
+                }}
                 ref={formRef}
             >
                 <ActionToolbar
                     canEdit={canEdit}
-                    onEdit={() => setEditMode(true)}
-                    onDelete={() => { }}
-                    onCancel={() => {
+                    onEditAction={() => setEditMode(true)}
+                    onDeleteAction={() => { }}
+                    onCancelAction={() => {
                         formRef.current?.reset(true);
-                        setEditMode(false);
-                    }}
-                    onSave={() => {
                         setEditMode(false);
                     }}
                 />

--- a/Source/SelfService/Web/integrations/connection/connectionDetails/configuration/index.tsx
+++ b/Source/SelfService/Web/integrations/connection/connectionDetails/configuration/index.tsx
@@ -10,7 +10,7 @@ import { AccordionList, AccordionListProps, Button, FileUploadFormRef } from '@d
 import { useConnectionsIdGet } from '../../../../apis/integrations/connectionsApi.hooks';
 import { useConnectionId } from '../../../routes.hooks';
 
-import { M3ConfigurationForm } from '../../configuration/M3ConfigurationForm';
+import { M3ConfigurationForm, M3ConfigurationFormRef } from '../../configuration/M3ConfigurationForm';
 import { MainM3ConnectionInfo } from '../../configuration/MainM3ConnectionInfo';
 import { useBuildConfigurationAccordionList } from '../../configuration/useBuildConfigurationAccordionList';
 import { ActionToolbar } from './ActionToolbar';
@@ -25,6 +25,7 @@ export const ConfigurationView = () => {
         { refetchInterval: (data) => data?.value?.status.name !== 'Connected' ? 5000 : false }
     );
 
+    const formRef = useRef<M3ConfigurationFormRef>(null);
     const fileUploadRef = useRef<FileUploadFormRef>(null);
     const connection = query.data?.value;
     const links = query.data?.links || [];
@@ -47,16 +48,14 @@ export const ConfigurationView = () => {
                 connection={connection}
                 hasSelectedDeploymentType={hasSelectedDeploymentType}
                 onIonConfigurationSaved={() => fileUploadRef.current?.clearSelected()}
+                ref={formRef}
             >
                 <ActionToolbar
                     canEdit={canEdit}
                     onEdit={() => setEditMode(true)}
                     onDelete={() => { }}
                     onCancel={() => {
-                        if (resetForm) {
-                            setResetForm(false);
-                        }
-                        setResetForm(true);
+                        formRef.current?.reset(true);
                         setEditMode(false);
                     }}
                     onSave={() => {

--- a/Source/SelfService/Web/integrations/connection/new/index.tsx
+++ b/Source/SelfService/Web/integrations/connection/new/index.tsx
@@ -43,7 +43,7 @@ export const NewConnectionView = () => {
                     connectionId={connectionId}
                     connection={connection}
                     hasSelectedDeploymentType={hasSelectedDeploymentType}
-                    onIonConfigurationSaved={() => fileUploadRef.current?.clearSelected()}
+                    onSaved={() => fileUploadRef.current?.clearSelected()}
                 >
                     <MainM3ConnectionInfo hasSelectedDeploymentType={hasSelectedDeploymentType} connectionIdLinks={links} canEdit />
 


### PR DESCRIPTION
- Reset form state after succesful submit
- Reset Form back to original values when pressing "Cancel"
- More straight forward saving of form and cleaned up ActionToolbar
