### PR TITLE
Redirect to connector tab by connection status

### DIFF
--- a/Source/SelfService/Web/integrations/connection/connectionDetails/index.tsx
+++ b/Source/SelfService/Web/integrations/connection/connectionDetails/index.tsx
@@ -15,6 +15,7 @@ import { getConnectionStatus } from '../../../utils/helpers/connectionStatuses';
 
 import { Page } from '../../../components/layout/page';
 
+//TODO: Make this dynamic based on current url in the tab component
 const getCurrentTab = (location: Location) => {
     if (location.pathname.includes('configuration')) return 0;
     else if (location.pathname.includes('messages')) return 1;

--- a/Source/SelfService/Web/integrations/connection/connectionDetails/index.tsx
+++ b/Source/SelfService/Web/integrations/connection/connectionDetails/index.tsx
@@ -12,7 +12,6 @@ import { useRedirectToTabByStatus } from './useRedirectToTabByStatus';
 
 export const childRoutePaths = ['configuration', 'messages', 'expose'];
 
-//TODO: Make this dynamic based on current url in the tab component
 const getSelectedTab = (location: Location) => {
     const pathname = location.pathname;
     const foundIndex = childRoutePaths.findIndex((path) => pathname.endsWith(path));

--- a/Source/SelfService/Web/integrations/connection/connectionDetails/index.tsx
+++ b/Source/SelfService/Web/integrations/connection/connectionDetails/index.tsx
@@ -13,13 +13,11 @@ import { useRedirectToTabByStatus } from './useRedirectToTabByStatus';
 export const childRoutePaths = ['configuration', 'messages', 'expose'];
 
 //TODO: Make this dynamic based on current url in the tab component
-const getCurrentTab = (location: Location) => {
-    if (location.pathname.includes('configuration')) return 0;
-    else if (location.pathname.includes('messages')) return 1;
-    else if (location.pathname.includes('expose')) return 2;
-    else return 0;
+const getSelectedTab = (location: Location) => {
+    const pathname = location.pathname;
+    const foundIndex = childRoutePaths.findIndex((path) => pathname.endsWith(path));
+    return foundIndex >= 0 ? foundIndex : 0;
 };
-
 
 const tabs = [
     {
@@ -72,7 +70,7 @@ export const ConnectionDetails = () => {
                     healthStatusLabel={getConnectionStatus(status).label}
                     sx={{ mb: 4 }}
                 >
-                    <Tabs selectedTab={getCurrentTab(location)} tabs={tabs} />
+                    <Tabs selectedTab={getSelectedTab(location)} tabs={tabs} />
                     <Outlet />
                 </Page>
             }

--- a/Source/SelfService/Web/integrations/connection/connectionDetails/index.tsx
+++ b/Source/SelfService/Web/integrations/connection/connectionDetails/index.tsx
@@ -1,18 +1,12 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-import React from 'react';
-
-import { Outlet, Link, useLocation, Location } from 'react-router-dom';
-
+import React, { useMemo } from 'react';
+import { Link, Location, Outlet, Navigate, useLocation, useNavigate } from 'react-router-dom';
 import { useConnectionsIdGet } from '../../../apis/integrations/connectionsApi.hooks';
-
 import { useConnectionId } from '../../routes.hooks';
-
 import { Tabs } from '@dolittle/design-system';
-
 import { getConnectionStatus } from '../../../utils/helpers/connectionStatuses';
-
 import { Page } from '../../../components/layout/page';
 
 //TODO: Make this dynamic based on current url in the tab component
@@ -50,11 +44,24 @@ const tabs = [
     },
 ];
 
+const pendingStatuses = ['registered', 'pending'];
+const childRoutePaths = ['configuration', 'messages', 'expose'];
+
 export const ConnectionDetails = () => {
     const location = useLocation();
     const connectionId = useConnectionId();
     const query = useConnectionsIdGet({ id: connectionId || '' });
     const data = query.data?.value;
+
+    const redirectUrl = useMemo(() => {
+        if (!query.data?.value || childRoutePaths.some((path) => location.pathname.endsWith(path))) {
+            return null;
+        } else {
+            return pendingStatuses.includes(query.data.value.status?.name?.toLowerCase())
+                ? 'configuration'
+                : 'messages';
+        }
+    }, [query.data?.value, location.pathname]);
 
     if (query.isLoading) return <>Loading</>;
     if (!data || !connectionId) return null;
@@ -62,15 +69,21 @@ export const ConnectionDetails = () => {
     const pageTitle = data.name || 'Connection Details';
     const status = data.status?.name?.toLocaleLowerCase();
 
+
     return (
-        <Page
-            title={pageTitle}
-            healthStatus={getConnectionStatus(status).status}
-            healthStatusLabel={getConnectionStatus(status).label}
-            sx={{ mb: 4 }}
-        >
-            <Tabs selectedTab={getCurrentTab(location)} tabs={tabs} />
-            <Outlet />
-        </Page>
+        <>
+            {redirectUrl
+                ? <Navigate to={redirectUrl} replace={true} />
+                : <Page
+                    title={pageTitle}
+                    healthStatus={getConnectionStatus(status).status}
+                    healthStatusLabel={getConnectionStatus(status).label}
+                    sx={{ mb: 4 }}
+                >
+                    <Tabs selectedTab={getCurrentTab(location)} tabs={tabs} />
+                    <Outlet />
+                </Page>
+            }
+        </>
     );
 };

--- a/Source/SelfService/Web/integrations/connection/connectionDetails/useRedirectToTabByStatus.tsx
+++ b/Source/SelfService/Web/integrations/connection/connectionDetails/useRedirectToTabByStatus.tsx
@@ -1,0 +1,27 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import React, { useMemo } from 'react';
+import {type Location, useLocation } from 'react-router-dom';
+import { childRoutePaths} from '.';
+import { ConnectionStatus } from '../../../apis/integrations/generated';
+
+export const pendingStatuses = ['registered', 'pending', 'failing'];
+
+/**
+ * Hook that resolves the sub-tab to redirect to based on the status of the connection
+ * @param status status of a connection
+ * @returns short path name of the tab to redirect to. Does not include the full path
+ */
+export function useRedirectToTabByStatus(status?: ConnectionStatus) {
+    const location = useLocation();
+    return useMemo(() => {
+        if (!status?.name || childRoutePaths.some((path) => location.pathname.endsWith(path))) {
+            return null;
+        } else {
+            return pendingStatuses.includes(status.name.toLowerCase())
+                ? 'configuration'
+                : 'messages';
+        }
+    }, [status?.name, location.pathname]);
+}

--- a/Source/SelfService/Web/integrations/connection/index.tsx
+++ b/Source/SelfService/Web/integrations/connection/index.tsx
@@ -1,33 +1,20 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-import React, { useEffect } from 'react';
-
-import { useRoutes, useNavigate, useLocation } from 'react-router-dom';
-
+import React from 'react';
+import { useRoutes } from 'react-router-dom';
 import { routes } from './routes';
 import { useConnectionId } from '../routes.hooks';
-
 import { useConnectionsIdGet } from '../../apis/integrations/connectionsApi.hooks';
 import { DebugRouter } from '../../components/debugRouter';
 
-const pendingStatuses = ['registered', 'pending'];
 
 export const Connection = () => {
     const connectionId = useConnectionId();
     const routesElement = useRoutes(routes);
     const query = useConnectionsIdGet({ id: connectionId || '' });
-    // const useNavigateIfStatusIsPending
-    const location = useLocation();
-    const navigate = useNavigate();
 
-    // useEffect(() => {
-    //     if (query.data?.value && !location.pathname.includes('new')) {
-    //         if (pendingStatuses.includes(query.data.value.status?.name?.toLowerCase() || '')) {
-    //             navigate('new', { replace: true });
-    //         }
-    //     }
-    // }, [query.data, location.pathname]);
+
 
     if (query.isError) return <>Something went wrong. Could not load connection details for {connectionId}</>;
 

--- a/Source/SelfService/Web/integrations/connections/connectionsTable.tsx
+++ b/Source/SelfService/Web/integrations/connections/connectionsTable.tsx
@@ -81,7 +81,7 @@ export const ConnectionsTable = ({ connections, isLoading }: ConnectionsTablePro
     const handleRowClick = (connectionModel: ConnectionModel) => {
         if (connectionModel.connectionId) {
             //TODO: Redirect correctly based on status
-            const href = connectionModel.connectionId + '/messages';
+            const href = connectionModel.connectionId;
             navigate(href);
         }
     };

--- a/Source/SelfService/Web/integrations/connections/connectionsTable.tsx
+++ b/Source/SelfService/Web/integrations/connections/connectionsTable.tsx
@@ -80,6 +80,7 @@ export const ConnectionsTable = ({ connections, isLoading }: ConnectionsTablePro
 
     const handleRowClick = (connectionModel: ConnectionModel) => {
         if (connectionModel.connectionId) {
+            //TODO: Redirect correctly based on status
             const href = connectionModel.connectionId + '/messages';
             navigate(href);
         }

--- a/Source/SelfService/Web/integrations/connections/index.tsx
+++ b/Source/SelfService/Web/integrations/connections/index.tsx
@@ -2,12 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 import React from 'react';
-
 import { useSnackbar } from 'notistack';
-import { useNavigate, useParams } from 'react-router-dom';
-
+import { useNavigate } from 'react-router-dom';
 import { useConnectionsGet, useConnectionsIdPost } from '../../apis/integrations/connectionsApi.hooks';
-
 import { Page } from '../../components/layout/page';
 import { NoConnections } from './noConnections';
 import { ConnectionsTable } from './connectionsTable';
@@ -24,7 +21,6 @@ export const Connections = () => {
     const { enqueueSnackbar } = useSnackbar();
     const navigate = useNavigate();
 
-    //const { applicationId } = useParams();
     const { data, isLoading, isError } = useConnectionsGet();
     const mutation = useConnectionsIdPost();
 
@@ -42,13 +38,11 @@ export const Connections = () => {
             return;
         }
 
-        console.log('mutating', newConnectionId);
-
         mutation.mutate(
             { id: newConnectionId }, {
             onSuccess: () => {
                 //TODO: Move the generating of this url to a "well-known" place.
-                const href = `${newConnectionId}/messages`;
+                const href = `${newConnectionId}`;
                 enqueueSnackbar('Connection created.', { variant: 'success' });
                 navigate(href);
             },


### PR DESCRIPTION
- WIP: Todos
- Redirect to correct tab when loading connection screen
- Extract redirect to logic into hook
- Slight improvement to the active tab resolving logic - would be good to make this part of the tab component though, maybe a RouterTabs?
