### PR TITLE
Fix broken redirect to messages sub paths (again)

### DIFF
--- a/Source/SelfService/Web/integrations/connection/connectionDetails/useRedirectToTabByStatus.tsx
+++ b/Source/SelfService/Web/integrations/connection/connectionDetails/useRedirectToTabByStatus.tsx
@@ -16,7 +16,7 @@ export const pendingStatuses = ['registered', 'pending', 'failing'];
 export function useRedirectToTabByStatus(status?: ConnectionStatus) {
     const location = useLocation();
     return useMemo(() => {
-        if (!status?.name || childRoutePaths.some((path) => location.pathname.endsWith(path))) {
+        if (!status?.name || childRoutePaths.some((path) => location.pathname.includes(path))) {
             return null;
         } else {
             return pendingStatuses.includes(status.name.toLowerCase())


### PR DESCRIPTION
Actually fix redirect logic to evaluate the subpath exists, not that it ends with the route
