### PR TITLE
Wrap IonServiceCredentials instructions in copy box

### DIFF
--- a/Source/SelfService/Web/integrations/connection/configuration/ConnectorBundleConfiguration.tsx
+++ b/Source/SelfService/Web/integrations/connection/configuration/ConnectorBundleConfiguration.tsx
@@ -9,6 +9,17 @@ import { getBridgeServerUrlPrefix } from '../../../apis/integrations/api';
 
 import { TextCopyBox } from './TextCopyBox';
 
+const copyInstructions = [
+    `Please make sure your organization's firewall rules allow the M3 connector to connect to Kafka in order to communicate with our API. The Kafka cluster is reachable as:`,
+    `kafka-test-env-dolittle-test-env.aivencloud.com, and is using port 14691.`,
+    `All IPs for that address need to be available for outgoing traffic on port 14691.
+This includes the following IPs:`,
+    'For example, the following IP addresses are reachable:',
+    '134.122.86.202:14691 (outgoing)',
+    '165.22.83.2:14691 (outgoing)',
+    '134.122.94.197:14691 (outgoing)',
+];
+
 export type ConnectorBundleConfigurationProps = {
     connectionId: string;
 };
@@ -37,8 +48,29 @@ export const ConnectorBundleConfiguration = ({ connectionId }: ConnectorBundleCo
         <MaxWidthTextBlock>
             {`You will most likely need to configure your organization's firewall access to enable connectivity with the bundle. If you are not
                 responsible for firewall access, please share the information below with the responsible party:`}
+
+            <TextCopyBox instructions={copyInstructions}>
+                <Typography>
+                    Please make sure your organization’s firewall rules allow the M3 connector to connect to Kafka in order
+                    to communicate with our API. The Kafka cluster is reachable as:
+                </Typography>
+
+                <Typography>
+                    <b>kafka-test-env-dolittle-test-env.aivencloud.com</b>, and is using <b>port 14691</b>.
+                </Typography>
+
+                <Typography>
+                    All IPs for that address need to be available for outgoing traffic on port 14691. <br />
+                    This includes the following IPs:
+                </Typography>
+
+                <Typography>For example, the following IP addresses are reachable:</Typography>
+
+                <Typography>134.122.86.202:14691 (outgoing)</Typography>
+                <Typography>165.22.83.2:14691 (outgoing)</Typography>
+                <Typography>134.122.94.197:14691 (outgoing)</Typography>
+            </TextCopyBox>
         </MaxWidthTextBlock>
 
-        <TextCopyBox />
     </>;
 };

--- a/Source/SelfService/Web/integrations/connection/configuration/IonServiceAccountCredentials.tsx
+++ b/Source/SelfService/Web/integrations/connection/configuration/IonServiceAccountCredentials.tsx
@@ -3,12 +3,12 @@
 
 import React from 'react';
 
-import { Box } from '@mui/material';
 import { useFormContext } from 'react-hook-form';
 import { enqueueSnackbar } from 'notistack';
 
 import { FileUploadForm, FileUploadFormRef, MaxWidthTextBlock } from '@dolittle/design-system';
-import { IonConfigRequest, IonConfigRequestFromJSON } from '../../../apis/integrations/generated';
+import { IonConfigRequest } from '../../../apis/integrations/generated';
+import { TextCopyBox } from './TextCopyBox';
 
 
 /**
@@ -40,13 +40,6 @@ export const instructions = [
     `10. Last, click 'Download'. Upload the files below.`,
 ];
 
-
-const InstructionsListItems = () =>
-    <Box sx={{ pl: 3, pt: 3 }}>
-        {instructions.map((item, index) => (
-            <MaxWidthTextBlock key={index} sx={{ mb: 2 }}>{item}</MaxWidthTextBlock>
-        ))}
-    </Box>;
 
 export type IonServiceAccountCredentialsProps = {
     canEdit: boolean;
@@ -83,7 +76,10 @@ export const IonServiceAccountCredentials = React.forwardRef<FileUploadFormRef, 
             Follow the steps below then upload your credentials. If you already have an ION service account setup, skip to step 8 to access your credentials.
         </MaxWidthTextBlock>
 
-        <InstructionsListItems />
+        <MaxWidthTextBlock>
+            <TextCopyBox instructions={instructions} />
+        </MaxWidthTextBlock>
+
 
         {props.canEdit && (
             <MaxWidthTextBlock>

--- a/Source/SelfService/Web/integrations/connection/configuration/TextCopyBox.tsx
+++ b/Source/SelfService/Web/integrations/connection/configuration/TextCopyBox.tsx
@@ -1,70 +1,48 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-import React from 'react';
+import React, { useCallback } from 'react';
 
 import { useSnackbar } from 'notistack';
 
-import { Paper, Typography } from '@mui/material';
+import { Paper, Typography, SxProps } from '@mui/material';
 
 import { Button } from '@dolittle/design-system';
 
-const instruction1 = `Please make sure your organization's firewall rules allow the M3 connector to connect to Kafka in order to communicate with our API. The Kafka cluster is reachable as:`;
-const instruction2 = 'kafka-test-env-dolittle-test-env.aivencloud.com, and is using port 14691.';
-const instruction3 = `All IPs for that address need to be available for outgoing traffic on port 14691.
-This includes the following IPs:`;
-const instruction4 = 'For example, the following IP addresses are reachable:';
+export type TextCopyBoxProps = {
+    /**
+     * The list of instructions to display
+     * This will be rendered as a list with default text styling, and be made available for copying as a multi-line string
+     * For more control, use the children prop.
+     */
+    instructions: string[];
 
-const ipAddress1 = '134.122.86.202:14691 (outgoing)';
-const ipAddress2 = '165.22.83.2:14691 (outgoing)';
-const ipAddress3 = '134.122.94.197:14691 (outgoing)';
+    /**
+     * Pass in children if you want to have more control over the styling of the instructions
+     */
+    children?: React.ReactNode;
 
-const textToCopy = `
-${instruction1}
+    /**
+     * Style overrides applied to the root Paper component
+     */
+    sx?: SxProps;
+};
 
-${instruction2}
-
-${instruction3}
-
-${instruction4}
-
-${ipAddress1}
-
-${ipAddress2}
-
-${ipAddress3}
-`;
-
-export const TextCopyBox = () => {
+export const TextCopyBox = ({ instructions, children, sx }: TextCopyBoxProps) => {
     const { enqueueSnackbar } = useSnackbar();
 
-    const handleTextCopy = () => {
+    const handleTextCopy = useCallback(() => {
+        const textToCopy = instructions.join('\n\n');
         navigator.clipboard.writeText(textToCopy);
         enqueueSnackbar('Copied to clipboard');
-    };
+    }, [instructions]);
 
     return (
-        <Paper elevation={0} sx={{ 'mt': 3, 'p': 2, '& p': { mb: 3 } }}>
-            <Typography>
-                Please make sure your organization’s firewall rules allow the M3 connector to connect to Kafka in order
-                to communicate with our API. The Kafka cluster is reachable as:
-            </Typography>
-
-            <Typography>
-                <b>kafka-test-env-dolittle-test-env.aivencloud.com</b>, and is using <b>port 14691</b>.
-            </Typography>
-
-            <Typography>
-                All IPs for that address need to be available for outgoing traffic on port 14691. <br />
-                This includes the following IPs:
-            </Typography>
-
-            <Typography>For example, the following IP addresses are reachable:</Typography>
-
-            <Typography>134.122.86.202:14691 (outgoing)</Typography>
-            <Typography>165.22.83.2:14691 (outgoing)</Typography>
-            <Typography>134.122.94.197:14691 (outgoing)</Typography>
-
+        <Paper elevation={0} sx={{ 'mt': 3, 'p': 2, '& p': { mb: 3 }, ...sx }}>
+            {children
+                ? <>{children}</>
+                : <>{instructions.map((instruction, index) => <Typography key={index}>{instruction}</Typography>)}</>
+            }
             <Button
                 label='Copy content'
                 startWithIcon='CopyAllRounded'


### PR DESCRIPTION
- Make TextCopyBox a reusable component
- Wrap instructions for IonServiceCredentials in a CopyBox
