### PR TITLE
New nav fixes

### DIFF
--- a/Source/DesignSystem/atoms/Forms/Select.tsx
+++ b/Source/DesignSystem/atoms/Forms/Select.tsx
@@ -54,9 +54,10 @@ export const Select = forwardRef<HTMLOptionElement, SelectProps>(({ options, onO
                 {...selectProps as MuiSelectProps}
                 ref={ref}
                 labelId={`${selectProps.id}-select`}
+                onOpen={onOpen}
                 value={field.value}
                 disabled={selectProps.disabled}
-                onOpen={onOpen}
+                required={isRequired(selectProps.required)}
                 size='small'
                 sx={{ typography: 'body2' }}
                 autoWidth

--- a/Source/SelfService/Web/App.tsx
+++ b/Source/SelfService/Web/App.tsx
@@ -2,37 +2,36 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 import React from 'react';
-import { Route, Routes, Navigate } from 'react-router-dom';
 
+import { Route, Routes, Navigate } from 'react-router-dom';
 import { SnackbarProvider } from 'notistack';
+import { GlobalContextProvider } from './context/globalContext';
 
 import { LicenseInfo } from '@mui/x-license-pro';
 import CssBaseline from '@mui/material/CssBaseline';
 import { ThemeProvider, StyledEngineProvider } from '@mui/material/styles';
 import { Slide, SlideProps } from '@mui/material';
-import { ErrorRounded } from '@mui/icons-material';
 
 import '@dolittle/design-system/theming/fonts';
-import { themeDark } from '@dolittle/design-system';
+import { themeDark, Icon } from '@dolittle/design-system';
 
 import { useViewportResize } from './utils/useViewportResize';
 
-import { GlobalContextProvider } from './context/globalContext';
-
 import { RouteNotFound } from './components/notfound';
 import { DieAndRestart } from './components/dieAndRestart';
-
 import { LayoutWithSidebar } from './components/layout/layoutWithSidebar';
 
 import { BackupsScreen } from './applications/backupsScreen';
 import { DocumentationScreen } from './applications/documentationScreen';
 import { MicroservicesScreen } from './applications/microservicesScreen';
-import { Screen as AdminScreen } from './admin/adminScreen';
+import { ContainerRegistryScreen } from './applications/containerRegistryScreen';
+import { LogsScreen } from './applications/logsScreen';
+import { M3ConnectorScreen } from './applications/m3connectorScreen';
+
 import { ApplicationsScreen } from './spaces/applications/applicationsScreen';
 import { ApplicationScreen } from './spaces/applications/applicationScreen';
-import { ContainerRegistryScreen } from './applications/containerRegistryScreen';
-import { M3ConnectorScreen } from './applications/m3connectorScreen';
-import { LogsScreen } from './applications/logsScreen';
+
+import { Screen as AdminScreen } from './admin/adminScreen';
 import { HomeScreen } from './home/homeScreen';
 import { IntegrationsIndex } from './integrations';
 
@@ -53,7 +52,7 @@ export const App = () => {
                             autoHideDuration={4000}
                             anchorOrigin={{ horizontal: 'right', vertical: 'bottom' }}
                             TransitionComponent={(props: SlideProps) => <Slide {...props} direction='up' />}
-                            iconVariant={{ error: <ErrorRounded fontSize='small' sx={{ mr: 1 }} /> }}
+                            iconVariant={{ error: <Icon icon='ErrorRounded' sx={{ mr: 1 }} /> }}
                         >
                             <Routes>
                                 <Route path='/' element={<Navigate to='/applications' />} />

--- a/Source/SelfService/Web/components/layout/workSpaceLayout/createSpaceDialog.tsx
+++ b/Source/SelfService/Web/components/layout/workSpaceLayout/createSpaceDialog.tsx
@@ -4,6 +4,7 @@
 import React, { useState } from 'react';
 
 import { useSnackbar } from 'notistack';
+import { useGlobalContext } from '../../../context/globalContext';
 
 import { Guid } from '@dolittle/rudiments';
 
@@ -45,6 +46,7 @@ export type CreateSpaceDialogProps = {
 
 export const CreateSpaceDialog = ({ isOpen, onClose }: CreateSpaceDialogProps) => {
     const { enqueueSnackbar } = useSnackbar();
+    const { setCurrentApplicationId } = useGlobalContext();
 
     const [isLoading, setIsLoading] = useState(false);
 
@@ -72,6 +74,7 @@ export const CreateSpaceDialog = ({ isOpen, onClose }: CreateSpaceDialogProps) =
         // TODO: Should this change current environment?
         try {
             await createApplication(request);
+            setCurrentApplicationId(request.id);
             enqueueSnackbar(`'${form.name}' successfully created.`);
         } catch (error) {
             enqueueSnackbar('Failed to create new space. Please try again.', { variant: 'error' });

--- a/Source/SelfService/Web/components/layout/workSpaceLayout/spaceCreateDialog.tsx
+++ b/Source/SelfService/Web/components/layout/workSpaceLayout/spaceCreateDialog.tsx
@@ -23,7 +23,7 @@ const styles = {
     '& .MuiCheckbox-root': { pointerEvents: 'auto' },
 };
 
-type CreateSpaceParameters = {
+type SpaceCreateParameters = {
     name: string;
     environments: {
         Dev: boolean;
@@ -32,7 +32,7 @@ type CreateSpaceParameters = {
     };
 };
 
-export type CreateSpaceDialogProps = {
+export type SpaceCreateDialogProps = {
     /**
      * Whether or not the dialog is open.
      */
@@ -44,13 +44,13 @@ export type CreateSpaceDialogProps = {
     onClose: () => void;
 };
 
-export const CreateSpaceDialog = ({ isOpen, onClose }: CreateSpaceDialogProps) => {
+export const SpaceCreateDialog = ({ isOpen, onClose }: SpaceCreateDialogProps) => {
     const { enqueueSnackbar } = useSnackbar();
     const { setCurrentApplicationId } = useGlobalContext();
 
     const [isLoading, setIsLoading] = useState(false);
 
-    const handleSpaceCreate = async (form: CreateSpaceParameters) => {
+    const handleSpaceCreate = async (form: SpaceCreateParameters) => {
         setIsLoading(true);
 
         const request: HttpApplicationRequest = {
@@ -97,7 +97,7 @@ export const CreateSpaceDialog = ({ isOpen, onClose }: CreateSpaceDialogProps) =
                     Test: false,
                     Prod: true,
                 }
-            } as CreateSpaceParameters}
+            } as SpaceCreateParameters}
             confirmBtnText='Create'
             onCancel={onClose}
             onConfirm={handleSpaceCreate}

--- a/Source/SelfService/Web/components/layout/workSpaceLayout/spaceCreateDialog.tsx
+++ b/Source/SelfService/Web/components/layout/workSpaceLayout/spaceCreateDialog.tsx
@@ -107,6 +107,7 @@ export const SpaceCreateDialog = ({ isOpen, onClose }: SpaceCreateDialogProps) =
                 id='name'
                 label='Space Name'
                 required='Space name required.'
+                autoFocus
                 pattern={{
                     value: alphaNumericLowerCasedCharsRegex,
                     message: 'Name can only contain lowercase alphanumeric characters.'

--- a/Source/SelfService/Web/components/layout/workSpaceLayout/spaceSelectMenu.tsx
+++ b/Source/SelfService/Web/components/layout/workSpaceLayout/spaceSelectMenu.tsx
@@ -11,7 +11,7 @@ import { ShortInfoWithEnvironment } from '../../../apis/solutions/api';
 
 import { getSelectionMenuItems, DropdownMenuProps, MenuItemProps } from '@dolittle/design-system';
 
-import { CreateSpaceDialog } from './createSpaceDialog';
+import { SpaceCreateDialog } from './spaceCreateDialog';
 
 export const SpaceSelectMenu = () => {
     const { enqueueSnackbar } = useSnackbar();
@@ -75,7 +75,7 @@ export const SpaceSelectMenu = () => {
 
     return (
         <>
-            <CreateSpaceDialog isOpen={createSpaceDialogOpen} onClose={() => setCreateSpaceDialogOpen(false)} />
+            <SpaceCreateDialog isOpen={createSpaceDialogOpen} onClose={() => setCreateSpaceDialogOpen(false)} />
             {getSelectionMenuItems(applicationMenuItems(), currentApplication?.name)}
         </>
     );

--- a/Source/SelfService/Web/components/layout/workSpaceLayout/spaceSelectMenu.tsx
+++ b/Source/SelfService/Web/components/layout/workSpaceLayout/spaceSelectMenu.tsx
@@ -34,7 +34,7 @@ export const SpaceSelectMenu = () => {
                 setIsLoading(false);
             })
             .catch(() => enqueueSnackbar('Failed getting data from the server.', { variant: 'error' }));
-    }, []);
+    }, [currentApplicationId]);
 
     if (isLoading) return null;
 

--- a/Source/SelfService/Web/components/layout/workSpaceLayout/workSpaceLayout.tsx
+++ b/Source/SelfService/Web/components/layout/workSpaceLayout/workSpaceLayout.tsx
@@ -16,7 +16,17 @@ export type WorkSpaceLayoutProps = {
     children: React.ReactNode;
 };
 
-export const WorkSpaceLayout = ({ pageTitle, sidePanelMode, breadcrumbs, children }: WorkSpaceLayoutProps) => {
+export const WorkSpaceLayout = ({ pageTitle, children }: WorkSpaceLayoutProps) => {
+    usePageTitle(pageTitle);
+
+    return (
+        <Layout navigationBar={mainNavigationItems}>
+            {children}
+        </Layout>
+    );
+};
+
+export const WorkSpaceLayoutWithSidePanel = ({ pageTitle, sidePanelMode, breadcrumbs, children }: WorkSpaceLayoutProps) => {
     usePageTitle(pageTitle);
 
     return (
@@ -25,17 +35,6 @@ export const WorkSpaceLayout = ({ pageTitle, sidePanelMode, breadcrumbs, childre
             sidePanel={sidePanelMode === 'applications' ? applicationsSidePanel : integrationsSidePanel}
             breadcrumbs={breadcrumbs}
         >
-            {children}
-        </Layout>
-    );
-};
-
-// TODO: Needs renaming and seperate component?
-export const WorkSpaceWithoutSideBarLayout = ({ pageTitle, children }: WorkSpaceLayoutProps) => {
-    usePageTitle(pageTitle);
-
-    return (
-        <Layout navigationBar={mainNavigationItems}>
             {children}
         </Layout>
     );

--- a/Source/SelfService/Web/components/layout/workSpaceLayout/workSpaceLayout.tsx
+++ b/Source/SelfService/Web/components/layout/workSpaceLayout/workSpaceLayout.tsx
@@ -10,26 +10,28 @@ import { usePageTitle } from '../../../utils/usePageTitle';
 import { mainNavigationItems, applicationsSidePanel, integrationsSidePanel } from './workSpaceLayoutLinks';
 
 export type WorkSpaceLayoutProps = {
+    pageTitle: string;
     sidePanelMode?: 'applications' | 'integrations';
     breadcrumbs?: LayoutProps['breadcrumbs'];
     children: React.ReactNode;
 };
 
-export type WorkSpaceWithoutSideBarLayoutProps = WorkSpaceLayoutProps & {
-    pageTitle: string;
+export const WorkSpaceLayout = ({ pageTitle, sidePanelMode, breadcrumbs, children }: WorkSpaceLayoutProps) => {
+    usePageTitle(pageTitle);
+
+    return (
+        <Layout
+            navigationBar={mainNavigationItems}
+            sidePanel={sidePanelMode === 'applications' ? applicationsSidePanel : integrationsSidePanel}
+            breadcrumbs={breadcrumbs}
+        >
+            {children}
+        </Layout>
+    );
 };
 
-export const WorkSpaceLayout = ({ sidePanelMode, breadcrumbs, children }: WorkSpaceLayoutProps) =>
-    <Layout
-        navigationBar={mainNavigationItems}
-        sidePanel={sidePanelMode === 'applications' ? applicationsSidePanel : integrationsSidePanel}
-        breadcrumbs={breadcrumbs}
-    >
-        {children}
-    </Layout>;
-
 // TODO: Needs renaming and seperate component?
-export const WorkSpaceWithoutSideBarLayout = ({ pageTitle, children }: WorkSpaceWithoutSideBarLayoutProps) => {
+export const WorkSpaceWithoutSideBarLayout = ({ pageTitle, children }: WorkSpaceLayoutProps) => {
     usePageTitle(pageTitle);
 
     return (

--- a/Source/SelfService/Web/components/layout/workSpaceLayout/workSpaceLayoutLinks.tsx
+++ b/Source/SelfService/Web/components/layout/workSpaceLayout/workSpaceLayoutLinks.tsx
@@ -140,7 +140,7 @@ const SidePanelIntegrationItems = () => {
             sx: { my: 1 },
             overrides: {
                 component: Link,
-                to: `/m3connector/application/${currentApplicationId}/${currentEnvironment}/details`,
+                to: '/integrations/connections',
             },
         },
     ];

--- a/Source/SelfService/Web/home/homeScreen.tsx
+++ b/Source/SelfService/Web/home/homeScreen.tsx
@@ -10,10 +10,10 @@ import { HomeScreenCardGridItems } from './homeScreenCardGridItems';
 
 export const HomeScreen = () =>
     <WorkSpaceWithoutSideBarLayout pageTitle='Home'>
-        <Typography variant='h1' sx={{ my: 3 }}>Welcome to Dolittle Studio!</Typography>
+        <Typography variant='h1' sx={{ my: 3 }}>Welcome to Aigonix!</Typography>
 
         <Typography variant='subtitle1' sx={{ maxWidth: 1018, mb: 4 }}>
-            Dolittle Studio is a decentralized, distributed, event-driven, microservice platform built to harness the power of events.
+            Aigonix is a decentralized, distributed, event-driven, microservice platform built to harness the power of events.
             Our goal is to enable your company to build and run microservice based solutions that react in real-time whenever meaningful
             changes occur with a guaranteed uptime.
         </Typography>

--- a/Source/SelfService/Web/home/homeScreen.tsx
+++ b/Source/SelfService/Web/home/homeScreen.tsx
@@ -5,11 +5,11 @@ import React from 'react';
 
 import { Typography } from '@mui/material';
 
-import { WorkSpaceWithoutSideBarLayout } from '../components/layout/workSpaceLayout/workSpaceLayout';
+import { WorkSpaceLayout } from '../components/layout/workSpaceLayout/workSpaceLayout';
 import { HomeScreenCardGridItems } from './homeScreenCardGridItems';
 
 export const HomeScreen = () =>
-    <WorkSpaceWithoutSideBarLayout pageTitle='Home'>
+    <WorkSpaceLayout pageTitle='Home'>
         <Typography variant='h1' sx={{ my: 3 }}>Welcome to Aigonix!</Typography>
 
         <Typography variant='subtitle1' sx={{ maxWidth: 1018, mb: 4 }}>
@@ -19,4 +19,4 @@ export const HomeScreen = () =>
         </Typography>
 
         <HomeScreenCardGridItems />
-    </WorkSpaceWithoutSideBarLayout>;
+    </WorkSpaceLayout>;

--- a/Source/SelfService/Web/home/homeScreen.tsx
+++ b/Source/SelfService/Web/home/homeScreen.tsx
@@ -3,60 +3,10 @@
 
 import React from 'react';
 
-import { Link } from 'react-router-dom';
-import { useGlobalContext } from '../context/globalContext';
-
 import { Typography } from '@mui/material';
 
-import { SimpleCardGrid, SimpleCardGridProps } from '@dolittle/design-system';
-
 import { WorkSpaceWithoutSideBarLayout } from '../components/layout/workSpaceLayout/workSpaceLayout';
-
-const getStartedCardGridItems = () => {
-    const { currentApplicationId } = useGlobalContext();
-
-    const items: SimpleCardGridProps['simpleCardItems'] = [
-        {
-            title: 'I want to deploy and host a service',
-            description: `We offer a runtime with event sourcing and the tools needed to build out distributed systems through event
-        driven architecture. We then manage the infrastructure for you.`,
-            primaryButton: {
-                label: 'Deploy a microservice',
-                overrides: {
-                    component: Link,
-                    to: `/microservices/application/${currentApplicationId}/Dev/overview`,
-                },
-            },
-            buttonAlignment: 'right',
-        },
-        {
-            title: 'I want to model data from M3',
-            description: `Our integrations module lets you unlock existing data and works well with our event driven hosted platform,
-        where you can also create apps that consume these integrations.`,
-            primaryButton: {
-                label: 'Connect to m3',
-                overrides: {
-                    component: Link,
-                    to: '/integrations',
-                },
-            },
-            buttonAlignment: 'right',
-        },
-        {
-            title: `I'm new here!`,
-            subtitle: 'Coming soon!',
-            description: `Get started by setting up your first application and the environments you need to deploy your first
-        microservice or integration service using our runtime and hosting platform.`,
-            primaryButton: {
-                label: 'Get Started',
-                disabled: true,
-            },
-            buttonAlignment: 'right',
-        },
-    ];
-
-    return <SimpleCardGrid simpleCardItems={items} />;
-};
+import { HomeScreenCardGridItems } from './homeScreenCardGridItems';
 
 export const HomeScreen = () =>
     <WorkSpaceWithoutSideBarLayout pageTitle='Home'>
@@ -68,5 +18,5 @@ export const HomeScreen = () =>
             changes occur with a guaranteed uptime.
         </Typography>
 
-        {getStartedCardGridItems()}
+        <HomeScreenCardGridItems />
     </WorkSpaceWithoutSideBarLayout>;

--- a/Source/SelfService/Web/home/homeScreenCardGridItems.tsx
+++ b/Source/SelfService/Web/home/homeScreenCardGridItems.tsx
@@ -1,0 +1,55 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import React from 'react';
+
+import { Link } from 'react-router-dom';
+import { useGlobalContext } from '../context/globalContext';
+
+import { SimpleCardGrid, SimpleCardGridProps } from '@dolittle/design-system';
+
+export const HomeScreenCardGridItems = () => {
+    const { currentApplicationId } = useGlobalContext();
+
+    const items: SimpleCardGridProps['simpleCardItems'] = [
+        {
+            title: 'I want to deploy and host a service',
+            description: `We offer a runtime with event sourcing and the tools needed to build out distributed systems through event
+        driven architecture. We then manage the infrastructure for you.`,
+            primaryButton: {
+                label: 'Deploy a microservice',
+                overrides: {
+                    component: Link,
+                    to: `/microservices/application/${currentApplicationId}/Dev/overview`,
+                },
+            },
+            buttonAlignment: 'right',
+        },
+        {
+            title: 'I want to model data from M3',
+            description: `Our integrations module lets you unlock existing data and works well with our event driven hosted platform,
+        where you can also create apps that consume these integrations.`,
+            primaryButton: {
+                label: 'Connect to m3',
+                overrides: {
+                    component: Link,
+                    to: '/integrations',
+                },
+            },
+            buttonAlignment: 'right',
+        },
+        {
+            title: `I'm new here!`,
+            subtitle: 'Coming soon!',
+            description: `Get started by setting up your first application and the environments you need to deploy your first
+        microservice or integration service using our runtime and hosting platform.`,
+            primaryButton: {
+                label: 'Get Started',
+                disabled: true,
+            },
+            buttonAlignment: 'right',
+        },
+    ];
+
+    return <SimpleCardGrid simpleCardItems={items} />;
+};

--- a/Source/SelfService/Web/integrations/connection/configuration/MainM3ConnectionInfo.tsx
+++ b/Source/SelfService/Web/integrations/connection/configuration/MainM3ConnectionInfo.tsx
@@ -56,7 +56,13 @@ export const MainM3ConnectionInfo = ({ connectionIdLinks, hasSelectedDeploymentT
             <MaxWidthTextBlock>{newConnectionDescription}</MaxWidthTextBlock>
 
             <Tooltip tooltipTitle='Connector Name' tooltipText={<ConnectorNameTooltipText />} sx={{ top: 16 }}>
-                <Input id='connectorName' label='Connector Name' placeholder='M3 Connector Test' required='Please enter the connector name' disabled={!canEdit} />
+                <Input
+                    id='connectorName'
+                    label='Connector Name'
+                    placeholder='M3 Connector Test'
+                    required='Please enter the connector name.'
+                    disabled={!canEdit}
+                />
             </Tooltip>
 
             <Tooltip tooltipTitle='Hosting' tooltipText={hostingTooltipText} displayOnHover={hasSelectedDeploymentType} sx={{ top: 38 }}>
@@ -65,7 +71,7 @@ export const MainM3ConnectionInfo = ({ connectionIdLinks, hasSelectedDeploymentT
                     label='Hosting'
                     options={selectValues}
                     disabled={!canEdit || hasSelectedDeploymentType}
-                    required='Please select the hosting type'
+                    required='Please select the hosting type.'
                 />
             </Tooltip>
         </Stack>

--- a/Source/SelfService/Web/integrations/connection/configuration/MetadataPublisherCredentials.tsx
+++ b/Source/SelfService/Web/integrations/connection/configuration/MetadataPublisherCredentials.tsx
@@ -16,6 +16,7 @@ export const MetadataPublisherCredentials = ({ canEdit }: MetadataPublisherCrede
     const { watch } = useFormContext();
     const [metadataPublisherUrl, metadataPublisherPassword] = watch(['metadataPublisherUrl', 'metadataPublisherPassword']);
 
+    // TODO: Run again when input loses focus.
     const required = !!metadataPublisherUrl || !!metadataPublisherPassword;
 
     return (
@@ -30,14 +31,14 @@ export const MetadataPublisherCredentials = ({ canEdit }: MetadataPublisherCrede
                     label='Your Metadata Publisher URL'
                     placeholder='Your metadata publisher URL goes here...'
                     sx={{ width: 1, maxWidth: 500 }}
-                    required={{ value: required, message: 'Please enter your metadata publisher URL' }}
+                    required={required}
                     disabled={!canEdit}
                 />
                 <PasswordInput
                     id='metadataPublisherPassword'
                     label='Password'
                     placeholder='Your password'
-                    required={{ value: required, message: 'Please enter the metadata publisher password' }}
+                    required={required}
                     disabled={!canEdit}
                 />
             </Stack>

--- a/Source/SelfService/Web/integrations/connections/index.tsx
+++ b/Source/SelfService/Web/integrations/connections/index.tsx
@@ -46,12 +46,11 @@ export const Connections = () => {
             onSuccess: () => {
                 //TODO: Move the generating of this url to a "well-known" place.
                 const href = `${newConnectionId}`;
-                enqueueSnackbar('Connection created.');
+                enqueueSnackbar(`Connection '${newConnectionId}' created.`);
                 navigate(href);
             },
-            onError: (error) => {
+            onError: () => {
                 enqueueSnackbar('Could not create new connection at this time.', { variant: 'error' });
-                console.log('Error creating connection.', error);
             },
         });
     };

--- a/Source/SelfService/Web/integrations/connections/index.tsx
+++ b/Source/SelfService/Web/integrations/connections/index.tsx
@@ -46,7 +46,7 @@ export const Connections = () => {
             onSuccess: () => {
                 //TODO: Move the generating of this url to a "well-known" place.
                 const href = `${newConnectionId}`;
-                enqueueSnackbar('Connection created.', { variant: 'success' });
+                enqueueSnackbar('Connection created.');
                 navigate(href);
             },
             onError: (error) => {

--- a/Source/SelfService/Web/integrations/index.tsx
+++ b/Source/SelfService/Web/integrations/index.tsx
@@ -11,7 +11,7 @@ import { buildQueryClient } from '../apis/integrations/queryClient';
 
 import { integrationsBreadcrumbsNameMap, routes } from './routes';
 
-import { WorkSpaceLayout } from '../components/layout/workSpaceLayout/workSpaceLayout';
+import { WorkSpaceLayoutWithSidePanel } from '../components/layout/workSpaceLayout/workSpaceLayout';
 import { DebugRouter } from '../components/debugRouter';
 
 export const IntegrationsIndex = () => {
@@ -20,7 +20,7 @@ export const IntegrationsIndex = () => {
     const routesElement = useRoutes(routes);
 
     return (
-        <WorkSpaceLayout
+        <WorkSpaceLayoutWithSidePanel
             pageTitle='Integrations'
         // breadcrumbs={{
         //     currentPath: location.pathname,
@@ -33,6 +33,6 @@ export const IntegrationsIndex = () => {
                 </DebugRouter>
                 <ReactQueryDevtools initialIsOpen={false} />
             </QueryClientProvider>
-        </WorkSpaceLayout>
+        </WorkSpaceLayoutWithSidePanel>
     );
 };

--- a/Source/SelfService/Web/integrations/index.tsx
+++ b/Source/SelfService/Web/integrations/index.tsx
@@ -21,10 +21,10 @@ export const IntegrationsIndex = () => {
 
     return (
         <WorkSpaceLayout
-            breadcrumbs={{
-                currentPath: location.pathname,
-                breadcrumbsNameMap: integrationsBreadcrumbsNameMap,
-            }}
+        // breadcrumbs={{
+        //     currentPath: location.pathname,
+        //     breadcrumbsNameMap: integrationsBreadcrumbsNameMap,
+        // }}
         >
             <QueryClientProvider client={queryClient}>
                 <DebugRouter>

--- a/Source/SelfService/Web/integrations/index.tsx
+++ b/Source/SelfService/Web/integrations/index.tsx
@@ -21,6 +21,7 @@ export const IntegrationsIndex = () => {
 
     return (
         <WorkSpaceLayout
+            pageTitle='Integrations'
         // breadcrumbs={{
         //     currentPath: location.pathname,
         //     breadcrumbsNameMap: integrationsBreadcrumbsNameMap,


### PR DESCRIPTION
## Summary

Few fixes and code refactoring for new layout.

### Added

- Auto focus on SpaceCreateDialog input field
- Required 'pageTitle' prop to WorkSpaceLayout

### Changed

- Replaced HomeScreen 'Dolittle' text with 'Aigonix'
- Renamed CreateSpaceDialog to SpaceCreateDialog
- Added WorkSpaceLayoutWithSidePanel and changed naming on them

### Fixed

- Select new space after creating it
- Comment out the 'Breadcrumbs' as they are not working correctly at the moment
- SidePanel 'ErpConnections' link path so it would take to main Integrations page
- Connections Form errors from required prop

### Removed

- Variant 'success' from Integrations Snackbar

