### PR TITLE
Improve wording

### DIFF
--- a/Source/SelfService/Web/components/layout/layoutWithSidebar.tsx
+++ b/Source/SelfService/Web/components/layout/layoutWithSidebar.tsx
@@ -120,7 +120,7 @@ export const getMenuWithApplication = (
         },
         {
             href: `/documentation/application/${applicationId}/${environment}/overview`,
-            name: 'Documentation',
+            name: 'Setup',
             icon: <Icon icon='FindInPageRounded' size='medium' />,
         },
     ];

--- a/Source/SelfService/Web/components/layout/workSpaceLayout/workSpaceLayoutLinks.tsx
+++ b/Source/SelfService/Web/components/layout/workSpaceLayout/workSpaceLayoutLinks.tsx
@@ -46,7 +46,7 @@ const PrimaryNavigation = () => {
 };
 
 const SecondaryNavigation = () => {
-    const { hasOneCustomer, currentApplicationId } = useGlobalContext();
+    const { hasOneCustomer } = useGlobalContext();
 
     const secondaryNavigationItems: MenuItemProps[] = [
         {
@@ -54,8 +54,9 @@ const SecondaryNavigation = () => {
             label: 'Documentation',
             icon: 'DescriptionRounded',
             overrides: {
-                component: Link,
-                to: `/documentation/application/${currentApplicationId}/Dev/overview`,
+                component: 'a',
+                href: 'https://dolittle.io/docs/',
+                target: '_blank',
             },
         },
         {


### PR DESCRIPTION
## Summary

Made links clearer to improve UX.

### Changed

- LayoutWithSidebar 'Documentation' link label to 'Setup'
- WorkSpaceLayout SelectMenu 'Documentation' Link href to open 'https://dolittle.io/docs/' in new tab


