### PR TITLE
Create and list out kafka service accounts for event streams

### DIFF
--- a/Source/SelfService/Web/apis/integrations/CacheKeys.ts
+++ b/Source/SelfService/Web/apis/integrations/CacheKeys.ts
@@ -20,4 +20,8 @@ export enum CACHE_KEYS {
 
     //ServiceAccountsApi
     ConnectionServiceAccounts_GET = 'connection_service_accounts_get',
+
+    //KafkaServiceAccountsApi
+    ConnectionKafkaServiceAccounts_GET = 'connection_kafka_service_accounts_get',
+    ConnectionKafkaServiceAccountsName_GET = 'connection_kafka_service_accounts_name_get',
 };

--- a/Source/SelfService/Web/apis/integrations/kafkaServiceAccountApi.hooks.ts
+++ b/Source/SelfService/Web/apis/integrations/kafkaServiceAccountApi.hooks.ts
@@ -1,0 +1,54 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { useQuery, useMutation } from '@tanstack/react-query';
+
+import { API_CONFIGURATION } from './api';
+import { CACHE_KEYS } from './CacheKeys';
+import {
+    KafkaServiceAccountApi,
+    ConnectionsIdKafkaServiceAccountsGetRequest,
+    ConnectionsIdKafkaServiceAccountsServiceAccountNameGetRequest,
+    ConnectionsIdKafkaServiceAccountsServiceAccountNamePostRequest,
+    ConnectionsIdKafkaServiceAccountsServiceAccountNameDeleteRequest,
+} from './generated';
+
+let apiInstance: KafkaServiceAccountApi | undefined;
+
+const getOrCreateApi = () => {
+    if (!apiInstance) {
+        apiInstance = new KafkaServiceAccountApi(API_CONFIGURATION);
+    }
+    return apiInstance;
+};
+
+export const useConnectionsIdKafkaServiceAccountsGet = (params: ConnectionsIdKafkaServiceAccountsGetRequest) => {
+    const api = getOrCreateApi();
+    return useQuery({
+        queryKey: [CACHE_KEYS.ConnectionKafkaServiceAccounts_GET, params.id],
+        queryFn: api.connectionsIdKafkaServiceAccountsGet.bind(api, params)
+    });
+};
+
+export const useConnectionsIdKafkaServiceAccountsServiceAccountNameGet = (params: ConnectionsIdKafkaServiceAccountsServiceAccountNameGetRequest) => {
+    const api = getOrCreateApi();
+    return useQuery({
+        queryKey: [CACHE_KEYS.ConnectionKafkaServiceAccountsName_GET, params.id],
+        queryFn: api.connectionsIdKafkaServiceAccountsServiceAccountNameGet.bind(api, params)
+    });
+};
+
+
+export const useConnectionsIdKafkaServiceAccountsServiceAccountNamePost = () => {
+    const api = getOrCreateApi();
+    return useMutation({
+        mutationFn: (params: ConnectionsIdKafkaServiceAccountsServiceAccountNamePostRequest) => api.connectionsIdKafkaServiceAccountsServiceAccountNamePost(params),
+    });
+};
+
+export const useConnectionsIdKafkaServiceAccountsServiceAccountNameDelete = () => {
+    const api = getOrCreateApi();
+    return useMutation({
+        mutationFn: (params: ConnectionsIdKafkaServiceAccountsServiceAccountNameDeleteRequest) => api.connectionsIdKafkaServiceAccountsServiceAccountNameDelete(params),
+    });
+};

--- a/Source/SelfService/Web/apis/integrations/kafkaServiceAccountApi.hooks.ts
+++ b/Source/SelfService/Web/apis/integrations/kafkaServiceAccountApi.hooks.ts
@@ -33,7 +33,7 @@ export const useConnectionsIdKafkaServiceAccountsGet = (params: ConnectionsIdKaf
 export const useConnectionsIdKafkaServiceAccountsServiceAccountNameGet = (params: ConnectionsIdKafkaServiceAccountsServiceAccountNameGetRequest) => {
     const api = getOrCreateApi();
     return useQuery({
-        queryKey: [CACHE_KEYS.ConnectionKafkaServiceAccountsName_GET, params.id],
+        queryKey: [CACHE_KEYS.ConnectionKafkaServiceAccounts_GET, params.id, CACHE_KEYS.ConnectionKafkaServiceAccountsName_GET],
         queryFn: api.connectionsIdKafkaServiceAccountsServiceAccountNameGet.bind(api, params)
     });
 };

--- a/Source/SelfService/Web/integrations/connection/connectionDetails/configuration/index.tsx
+++ b/Source/SelfService/Web/integrations/connection/connectionDetails/configuration/index.tsx
@@ -24,7 +24,7 @@ export const ConfigurationView = () => {
     const [canEdit, setEditMode] = useState(false);
     const connectionId = useConnectionIdFromRoute();
     const query = useConnectionsIdGet(
-        { id: connectionId || '' },
+        { id: connectionId },
         { refetchInterval: (data) => data?.value?.status.name !== 'Connected' ? 5000 : false }
     );
 
@@ -71,7 +71,7 @@ export const ConfigurationView = () => {
     };
 
     if (query.isLoading) return <>Loading</>;
-    if (!connection || !connectionId) return null;
+    if (!connection) return null;
 
     return (
         <Box sx={{ mt: 6, ml: 2 }}>

--- a/Source/SelfService/Web/integrations/connection/connectionDetails/consumeDataEventStreams/index.tsx
+++ b/Source/SelfService/Web/integrations/connection/connectionDetails/consumeDataEventStreams/index.tsx
@@ -7,6 +7,7 @@ import { Box, Typography } from '@mui/material';
 import { useHref, generatePath } from 'react-router-dom';
 import { ContentContainer, ContentHeader, ContentSection, IconButton, Link } from '@dolittle/design-system';
 import { useConnectionIdFromRoute } from '../../../routes.hooks';
+import { ServiceAccountsSection } from './serviceAccounts/ServiceAccountsSection';
 
 const asyncApiSpecificationUrlTemplate = '/api/bridge/connections/:id/asyncapi/spec.json';
 
@@ -44,6 +45,7 @@ export const ConsumeDataEventStreamsView = () => {
                         />
                     </Box>
                 </ContentSection>
+                <ServiceAccountsSection />
             </ContentContainer>
         </>
     );

--- a/Source/SelfService/Web/integrations/connection/connectionDetails/consumeDataEventStreams/index.tsx
+++ b/Source/SelfService/Web/integrations/connection/connectionDetails/consumeDataEventStreams/index.tsx
@@ -12,7 +12,7 @@ const asyncApiSpecificationUrlTemplate = '/api/bridge/connections/:id/asyncapi/s
 
 export const ConsumeDataEventStreamsView = () => {
     const connectionId = useConnectionIdFromRoute();
-    const generatedPath = generatePath(asyncApiSpecificationUrlTemplate, { id: connectionId || '' });
+    const generatedPath = generatePath(asyncApiSpecificationUrlTemplate, { id: connectionId });
     const resolvedPathWithBasename = useHref(generatedPath);
     const asyncApiSpecificationUrl = `${window.location.origin}${resolvedPathWithBasename}`;
 

--- a/Source/SelfService/Web/integrations/connection/connectionDetails/consumeDataEventStreams/index.tsx
+++ b/Source/SelfService/Web/integrations/connection/connectionDetails/consumeDataEventStreams/index.tsx
@@ -28,7 +28,7 @@ export const ConsumeDataEventStreamsView = () => {
             <ContentContainer>
                 <ContentHeader title='Consuming your data' />
                 <ContentSection title='Async API Specification'>
-                    <Typography sx={{ pt: 1.5 }}>Our API for consuming event streams are defined using AsyncAPI.</Typography>
+                    <Typography>Our API for consuming event streams are defined using AsyncAPI.</Typography>
                     <Box sx={{ display: 'flex', alignItems: 'center', pt: 2, gap: 1 }}>
                         <Link
                             target

--- a/Source/SelfService/Web/integrations/connection/connectionDetails/consumeDataEventStreams/serviceAccounts/GenerateServiceAccountForm.tsx
+++ b/Source/SelfService/Web/integrations/connection/connectionDetails/consumeDataEventStreams/serviceAccounts/GenerateServiceAccountForm.tsx
@@ -41,11 +41,6 @@ export const GenerateServiceAccountForm = (props: GenerateServiceAccountFormProp
     const generateServiceAccountMutation = useConnectionsIdKafkaServiceAccountsServiceAccountNamePost();
     const hasResult = !!token;
 
-    const handleTokenCopy = () => {
-        navigator.clipboard.writeText(token || '');
-        enqueueSnackbar('Token copied to clipboard.');
-    };
-
     const handleGenerate = (fieldValues: GenerateKafkaServiceAccountFormParameters) => {
         setFormSubmitError(undefined);
         generateServiceAccountMutation.mutate({
@@ -57,6 +52,7 @@ export const GenerateServiceAccountForm = (props: GenerateServiceAccountFormProp
             onSuccess: (data: KafkaServiceAccountCreatedDto) => {
                 props.onFormComplete(data.serviceAccountName!);
                 queryClient.invalidateQueries([CACHE_KEYS.ConnectionKafkaServiceAccounts_GET, props.connectionId]);
+                enqueueSnackbar(`Service account ${data.serviceAccountName} created`);
             },
             onError: async (error) => {
                 let message = `Error while generating service account.`;

--- a/Source/SelfService/Web/integrations/connection/connectionDetails/consumeDataEventStreams/serviceAccounts/GenerateServiceAccountForm.tsx
+++ b/Source/SelfService/Web/integrations/connection/connectionDetails/consumeDataEventStreams/serviceAccounts/GenerateServiceAccountForm.tsx
@@ -1,0 +1,117 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import React, { useEffect, useState, useRef } from 'react';
+
+import { useSnackbar } from 'notistack';
+import { useQueryClient } from '@tanstack/react-query';
+
+import { Box, FormHelperText, Typography } from '@mui/material';
+
+import { Button, Form, FormRef, Input, MaxWidthTextBlock } from '@dolittle/design-system';
+
+// import { useConnectionsIdServiceAccountsServiceAccountNamePost } from '../../../../../apis/integrations/serviceAccountApi.hooks';
+import { ResponseError, ServiceAccountCreatedDto } from '../../../../../apis/integrations/generated';
+import { CACHE_KEYS } from '../../../../../apis/integrations/CacheKeys';
+
+import { GenerateServiceAccountFormSubmitButton } from './GenerateServiceAccountFormSubmitButton';
+
+export type GenerateServiceAccountFormParameters = {
+    name: string;
+};
+
+export type GenerateServiceAccountFormProps = {
+    resetForm: boolean;
+    connectionId: string;
+    onFormComplete(tokenName: string): void;
+    onFormCancelled(): void;
+    canCancel: boolean;
+};
+
+export const GenerateServiceAccountForm = (props: GenerateServiceAccountFormProps) => {
+    const { enqueueSnackbar } = useSnackbar();
+    const queryClient = useQueryClient();
+    const formRef = useRef<FormRef<GenerateServiceAccountFormParameters>>(null);
+
+    const [token, setToken] = useState<string | undefined>(undefined);
+    const [formSubmitError, setFormSubmitError] = useState<string | undefined>(undefined);
+
+    // const generateTokenMutation = useConnectionsIdServiceAccountsServiceAccountNamePost();
+    const hasResult = !!token;
+
+    const handleTokenCopy = () => {
+        navigator.clipboard.writeText(token || '');
+        enqueueSnackbar('Token copied to clipboard.');
+    };
+
+    const handleGenerate = (fieldValues: GenerateServiceAccountFormParameters) => {
+        setFormSubmitError(undefined);
+        // generateTokenMutation.mutate({
+        //     id: props.connectionId,
+        //     serviceAccountName: fieldValues.name,
+        // }, {
+        //     onSuccess: (data: ServiceAccountCreatedDto) => {
+        //         setToken(data.token);
+        //         formRef.current?.setValue('token', data.token);
+        //         queryClient.invalidateQueries([CACHE_KEYS.ConnectionServiceAccounts_GET, props.connectionId]);
+        //     },
+        //     onError: async (error) => {
+        //         let message = `Error while generating token.`;
+        //         if (error instanceof ResponseError) {
+        //             if (error.response.body) {
+        //                 const body = await error.response.text();
+        //                 message = `${message} error: ${body}`;
+        //             }
+        //         }
+        //         setFormSubmitError(message);
+        //         enqueueSnackbar(message, { variant: 'error' });
+        //     }
+        // });
+        setToken('token');
+        props.onFormComplete(fieldValues.name);
+    };
+    const resetForm = () => {
+        setFormSubmitError(undefined);
+        setToken(undefined);
+        formRef.current?.reset();
+    };
+
+    useEffect(() => {
+        if (props.resetForm) {
+            resetForm();
+        }
+    }, [props.resetForm]);
+
+    return (
+        <>
+            <Form<GenerateServiceAccountFormParameters>
+                initialValues={{
+                    name: '',
+                }}
+                onSubmit={handleGenerate}
+                fRef={formRef}
+            >
+                <Box>
+                    <MaxWidthTextBlock sx={{ mb: 3 }}>
+                        Who or what is the service account for?
+                    </MaxWidthTextBlock>
+                    <Box
+                        display='flex'
+                        gap={1}
+                        sx={{ mb: 6 }}
+                    >
+                        <Input id='name' label='Name' required disabled={hasResult && !formSubmitError} sx={{ mr: 10 }} />
+                    </Box>
+                    <Box display='flex' justifyContent='flex-end'>
+                        {props.canCancel && <Button
+                            label='Cancel'
+                            sx={{ mr: 6 }}
+                            onClick={() => props.onFormCancelled()}
+                        />}
+                        <GenerateServiceAccountFormSubmitButton disabled={hasResult} />
+                    </Box>
+                </Box>
+            </Form>
+        </>
+    );
+};

--- a/Source/SelfService/Web/integrations/connection/connectionDetails/consumeDataEventStreams/serviceAccounts/GenerateServiceAccountForm.tsx
+++ b/Source/SelfService/Web/integrations/connection/connectionDetails/consumeDataEventStreams/serviceAccounts/GenerateServiceAccountForm.tsx
@@ -8,7 +8,7 @@ import { useQueryClient } from '@tanstack/react-query';
 
 import { Box, FormHelperText, Typography } from '@mui/material';
 
-import { Button, Form, FormRef, Input, MaxWidthTextBlock } from '@dolittle/design-system';
+import { Button, Form, FormRef, Input, MaxWidthTextBlock, Select } from '@dolittle/design-system';
 
 import { useConnectionsIdKafkaServiceAccountsServiceAccountNamePost } from '../../../../../apis/integrations/kafkaServiceAccountApi.hooks';
 import { AccountAccess, KafkaServiceAccountCreatedDto, ResponseError, ServiceAccountCreatedDto } from '../../../../../apis/integrations/generated';
@@ -47,7 +47,7 @@ export const GenerateServiceAccountForm = (props: GenerateServiceAccountFormProp
             id: props.connectionId,
             serviceAccountName: fieldValues.name,
             description: fieldValues.description,
-            access: fieldValues.access
+            access: fieldValues.access ?? undefined
         }, {
             onSuccess: (data: KafkaServiceAccountCreatedDto) => {
                 props.onFormComplete(data.serviceAccountName!);
@@ -79,6 +79,13 @@ export const GenerateServiceAccountForm = (props: GenerateServiceAccountFormProp
         }
     }, [props.resetForm]);
 
+    const accessOptions = [
+        { displayValue: 'Default', value: ''},
+        { displayValue: 'Read', value: AccountAccess.Read},
+        { displayValue: 'Read & Write', value: AccountAccess.ReadWrite},
+        { displayValue: 'Debug', value: AccountAccess.Debug}
+    ];
+
     return (
         <>
             <Form<GenerateKafkaServiceAccountFormParameters>
@@ -98,7 +105,8 @@ export const GenerateServiceAccountForm = (props: GenerateServiceAccountFormProp
                         sx={{ mb: 6 }}
                     >
                         <Input id='name' label='Name' required disabled={hasResult && !formSubmitError} sx={{ mr: 10 }} />
-                        <Input id='description' label='Description' disabled={hasResult && !formSubmitError} />
+                        <Input id='description' label='Description' disabled={hasResult && !formSubmitError} sx={{ mr: 10 }}/>
+                        <Select id='access' label='Access' options={accessOptions} />
                     </Box>
                     <Box display='flex' justifyContent='flex-end'>
                         {props.canCancel && <Button

--- a/Source/SelfService/Web/integrations/connection/connectionDetails/consumeDataEventStreams/serviceAccounts/GenerateServiceAccountForm.tsx
+++ b/Source/SelfService/Web/integrations/connection/connectionDetails/consumeDataEventStreams/serviceAccounts/GenerateServiceAccountForm.tsx
@@ -10,14 +10,16 @@ import { Box, FormHelperText, Typography } from '@mui/material';
 
 import { Button, Form, FormRef, Input, MaxWidthTextBlock } from '@dolittle/design-system';
 
-// import { useConnectionsIdServiceAccountsServiceAccountNamePost } from '../../../../../apis/integrations/serviceAccountApi.hooks';
-import { ResponseError, ServiceAccountCreatedDto } from '../../../../../apis/integrations/generated';
+import { useConnectionsIdKafkaServiceAccountsServiceAccountNamePost } from '../../../../../apis/integrations/kafkaServiceAccountApi.hooks';
+import { AccountAccess, KafkaServiceAccountCreatedDto, ResponseError, ServiceAccountCreatedDto } from '../../../../../apis/integrations/generated';
 import { CACHE_KEYS } from '../../../../../apis/integrations/CacheKeys';
 
 import { GenerateServiceAccountFormSubmitButton } from './GenerateServiceAccountFormSubmitButton';
 
-export type GenerateServiceAccountFormParameters = {
+export type GenerateKafkaServiceAccountFormParameters = {
     name: string;
+    description?: string;
+    access?: AccountAccess;
 };
 
 export type GenerateServiceAccountFormProps = {
@@ -31,12 +33,12 @@ export type GenerateServiceAccountFormProps = {
 export const GenerateServiceAccountForm = (props: GenerateServiceAccountFormProps) => {
     const { enqueueSnackbar } = useSnackbar();
     const queryClient = useQueryClient();
-    const formRef = useRef<FormRef<GenerateServiceAccountFormParameters>>(null);
+    const formRef = useRef<FormRef<GenerateKafkaServiceAccountFormParameters>>(null);
 
     const [token, setToken] = useState<string | undefined>(undefined);
     const [formSubmitError, setFormSubmitError] = useState<string | undefined>(undefined);
 
-    // const generateTokenMutation = useConnectionsIdServiceAccountsServiceAccountNamePost();
+    const generateServiceAccountMutation = useConnectionsIdKafkaServiceAccountsServiceAccountNamePost();
     const hasResult = !!token;
 
     const handleTokenCopy = () => {
@@ -44,31 +46,30 @@ export const GenerateServiceAccountForm = (props: GenerateServiceAccountFormProp
         enqueueSnackbar('Token copied to clipboard.');
     };
 
-    const handleGenerate = (fieldValues: GenerateServiceAccountFormParameters) => {
+    const handleGenerate = (fieldValues: GenerateKafkaServiceAccountFormParameters) => {
         setFormSubmitError(undefined);
-        // generateTokenMutation.mutate({
-        //     id: props.connectionId,
-        //     serviceAccountName: fieldValues.name,
-        // }, {
-        //     onSuccess: (data: ServiceAccountCreatedDto) => {
-        //         setToken(data.token);
-        //         formRef.current?.setValue('token', data.token);
-        //         queryClient.invalidateQueries([CACHE_KEYS.ConnectionServiceAccounts_GET, props.connectionId]);
-        //     },
-        //     onError: async (error) => {
-        //         let message = `Error while generating token.`;
-        //         if (error instanceof ResponseError) {
-        //             if (error.response.body) {
-        //                 const body = await error.response.text();
-        //                 message = `${message} error: ${body}`;
-        //             }
-        //         }
-        //         setFormSubmitError(message);
-        //         enqueueSnackbar(message, { variant: 'error' });
-        //     }
-        // });
-        setToken('token');
-        props.onFormComplete(fieldValues.name);
+        generateServiceAccountMutation.mutate({
+            id: props.connectionId,
+            serviceAccountName: fieldValues.name,
+            description: fieldValues.description,
+            access: fieldValues.access
+        }, {
+            onSuccess: (data: KafkaServiceAccountCreatedDto) => {
+                props.onFormComplete(data.serviceAccountName!);
+                queryClient.invalidateQueries([CACHE_KEYS.ConnectionKafkaServiceAccounts_GET, props.connectionId]);
+            },
+            onError: async (error) => {
+                let message = `Error while generating service account.`;
+                if (error instanceof ResponseError) {
+                    if (error.response.body) {
+                        const body = await error.response.text();
+                        message = `${message} error: ${body}`;
+                    }
+                }
+                setFormSubmitError(message);
+                enqueueSnackbar(message, { variant: 'error' });
+            }
+        });
     };
     const resetForm = () => {
         setFormSubmitError(undefined);
@@ -84,7 +85,7 @@ export const GenerateServiceAccountForm = (props: GenerateServiceAccountFormProp
 
     return (
         <>
-            <Form<GenerateServiceAccountFormParameters>
+            <Form<GenerateKafkaServiceAccountFormParameters>
                 initialValues={{
                     name: '',
                 }}
@@ -101,6 +102,7 @@ export const GenerateServiceAccountForm = (props: GenerateServiceAccountFormProp
                         sx={{ mb: 6 }}
                     >
                         <Input id='name' label='Name' required disabled={hasResult && !formSubmitError} sx={{ mr: 10 }} />
+                        <Input id='description' label='Description' disabled={hasResult && !formSubmitError} />
                     </Box>
                     <Box display='flex' justifyContent='flex-end'>
                         {props.canCancel && <Button

--- a/Source/SelfService/Web/integrations/connection/connectionDetails/consumeDataEventStreams/serviceAccounts/GenerateServiceAccountFormSubmitButton.tsx
+++ b/Source/SelfService/Web/integrations/connection/connectionDetails/consumeDataEventStreams/serviceAccounts/GenerateServiceAccountFormSubmitButton.tsx
@@ -1,0 +1,25 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import React from 'react';
+
+import { useFormState } from 'react-hook-form';
+
+import { Button } from '@dolittle/design-system';
+
+export type GenerateServiceAccountFormSubmitButtonProps =  {
+    disabled: boolean;
+};
+
+export const GenerateServiceAccountFormSubmitButton = ({ disabled }: GenerateServiceAccountFormSubmitButtonProps) => {
+    const { isValid } = useFormState();
+
+    return (
+        <Button
+            label='Generate Service Account'
+            type='submit'
+            variant='outlined'
+            disabled={disabled || !isValid}
+        />
+    );
+};

--- a/Source/SelfService/Web/integrations/connection/connectionDetails/consumeDataEventStreams/serviceAccounts/ServiceAccountsSection.tsx
+++ b/Source/SelfService/Web/integrations/connection/connectionDetails/consumeDataEventStreams/serviceAccounts/ServiceAccountsSection.tsx
@@ -86,11 +86,9 @@ export const ServiceAccountsSection = (props: ServiceAccountsSectionProps) => {
                     />
                 </ContentSection>
             </Collapse>
-            {items.length > 0 && (
-                <ContentSection>
-                    <ServiceAccountsTable items={items} isLoading={isLoading} />
-                </ContentSection>
-            )}
+            <ContentSection>
+                <ServiceAccountsTable items={items} isLoading={isLoading} />
+            </ContentSection>
 
 
         </ContentSection>

--- a/Source/SelfService/Web/integrations/connection/connectionDetails/consumeDataEventStreams/serviceAccounts/ServiceAccountsSection.tsx
+++ b/Source/SelfService/Web/integrations/connection/connectionDetails/consumeDataEventStreams/serviceAccounts/ServiceAccountsSection.tsx
@@ -15,7 +15,6 @@ export const ServiceAccountsSection = (props: ServiceAccountsSectionProps) => {
     const { enqueueSnackbar } = useSnackbar();
     const connectionId = useConnectionIdFromRoute();
     const [expandForm, setExpandForm] = useState(false);
-    const [activeEntry, setActiveEntry] = useState<string | undefined>(undefined);
     const [resetForm, setResetForm] = useState(false);
 
     const isLoading = false;
@@ -24,14 +23,13 @@ export const ServiceAccountsSection = (props: ServiceAccountsSectionProps) => {
 
     const items = [];
 
-    const allowGenerateNew = !expandForm || (expandForm && !!activeEntry);
+    const allowGenerateNew = !expandForm;
 
     const handleNewGenerated = (tokenName: string) => {
-        setActiveEntry(tokenName);
+        setExpandForm(false);
     };
 
     const handleGenerateNewEntry = () => {
-        setActiveEntry(undefined);
         setResetForm(true);
         setExpandForm(true);
     };
@@ -47,11 +45,11 @@ export const ServiceAccountsSection = (props: ServiceAccountsSectionProps) => {
         if (expandForm && !isLoading) {
             setExpandForm(true);
         } else {
-            const shouldExpand = !isLoading && (items.length === 0 || activeEntry !== undefined);
+            const shouldExpand = !isLoading && (items.length === 0);
             setExpandForm(shouldExpand);
         }
 
-    }, [items, activeEntry, expandForm, isLoading]);
+    }, [items, expandForm, isLoading]);
 
     useEffect(() => {
         //TODO: Pav - no like this

--- a/Source/SelfService/Web/integrations/connection/connectionDetails/consumeDataEventStreams/serviceAccounts/ServiceAccountsSection.tsx
+++ b/Source/SelfService/Web/integrations/connection/connectionDetails/consumeDataEventStreams/serviceAccounts/ServiceAccountsSection.tsx
@@ -1,0 +1,93 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import React, { useState, useEffect } from 'react';
+import { useSnackbar } from 'notistack';
+import { Collapse, Box, Typography } from '@mui/material';
+import { AlertBox, ContentSection } from '@dolittle/design-system';
+import { useConnectionIdFromRoute } from '../../../../routes.hooks';
+import { GenerateServiceAccountForm } from './GenerateServiceAccountForm';
+
+export type ServiceAccountsSectionProps = {};
+
+export const ServiceAccountsSection = (props: ServiceAccountsSectionProps) => {
+    const { enqueueSnackbar } = useSnackbar();
+    const connectionId = useConnectionIdFromRoute();
+    const [expandForm, setExpandForm] = useState(false);
+    const [activeEntry, setActiveEntry] = useState<string | undefined>(undefined);
+    const [resetForm, setResetForm] = useState(false);
+
+    const isLoading = false;
+    const isError = false;
+    const error = '';
+
+    const items = [];
+
+    const allowGenerateNew = !expandForm || (expandForm && !!activeEntry);
+
+    const handleNewGenerated = (tokenName: string) => {
+        setActiveEntry(tokenName);
+    };
+
+    const handleGenerateNewEntry = () => {
+        setActiveEntry(undefined);
+        setResetForm(true);
+        setExpandForm(true);
+    };
+
+    const handleFormCancelled = () => {
+        if (items.length) {
+            setExpandForm(false);
+        }
+        setResetForm(true);
+    };
+
+    useEffect(() => {
+        if (expandForm && !isLoading) {
+            setExpandForm(true);
+        } else {
+            const shouldExpand = !isLoading && (items.length === 0 || activeEntry !== undefined);
+            setExpandForm(shouldExpand);
+        }
+
+    }, [items, activeEntry, expandForm, isLoading]);
+
+    useEffect(() => {
+        //TODO: Pav - no like this
+        if (resetForm) {
+            setResetForm(false);
+        }
+    }, [resetForm]);
+
+    if (isError) return <AlertBox message={`Error while fetching credentials list. ${error}`} />;
+
+    return (
+        <ContentSection
+            title='Service Accounts'
+            headerProps={{
+                buttons:[
+                    {
+                        label: 'Generate new service account',
+                        variant: 'outlined',
+                        onClick: handleGenerateNewEntry,
+                        disabled: !allowGenerateNew
+                    }
+                ]
+            }}
+        >
+             <Collapse in={expandForm}>
+                <ContentSection hideDivider={!expandForm} title='Generate New Credentials'>
+                    <GenerateServiceAccountForm
+                        resetForm={resetForm}
+                        connectionId={connectionId}
+                        onFormComplete={handleNewGenerated}
+                        onFormCancelled={handleFormCancelled}
+                        canCancel={items.length > 0}
+                    />
+                </ContentSection>
+            </Collapse>
+
+
+        </ContentSection>
+    );
+};

--- a/Source/SelfService/Web/integrations/connection/connectionDetails/consumeDataEventStreams/serviceAccounts/ServiceAccountsSection.tsx
+++ b/Source/SelfService/Web/integrations/connection/connectionDetails/consumeDataEventStreams/serviceAccounts/ServiceAccountsSection.tsx
@@ -1,11 +1,12 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
 import { useSnackbar } from 'notistack';
 import { Collapse, Box, Typography } from '@mui/material';
 import { AlertBox, ContentSection } from '@dolittle/design-system';
 import { useConnectionIdFromRoute } from '../../../../routes.hooks';
+import { useConnectionsIdKafkaServiceAccountsGet } from '../../../../../apis/integrations/kafkaServiceAccountApi.hooks';
 import { GenerateServiceAccountForm } from './GenerateServiceAccountForm';
 import { ServiceAccountsTable } from './ServiceAccountsTable';
 
@@ -17,11 +18,11 @@ export const ServiceAccountsSection = (props: ServiceAccountsSectionProps) => {
     const [expandForm, setExpandForm] = useState(false);
     const [resetForm, setResetForm] = useState(false);
 
-    const isLoading = false;
-    const isError = false;
-    const error = '';
+    const { data, isLoading, isError, error } = useConnectionsIdKafkaServiceAccountsGet({ id: connectionId });
 
-    const items = [];
+    const items = useMemo(
+        () => data?.sort((a, b) => b.createdAt! > a.createdAt! ? 1 : -1) || [], [data]
+    );
 
     const allowGenerateNew = !expandForm;
 
@@ -64,7 +65,7 @@ export const ServiceAccountsSection = (props: ServiceAccountsSectionProps) => {
         <ContentSection
             title='Service Accounts'
             headerProps={{
-                buttons:[
+                buttons: [
                     {
                         label: 'Generate new service account',
                         variant: 'outlined',
@@ -74,7 +75,7 @@ export const ServiceAccountsSection = (props: ServiceAccountsSectionProps) => {
                 ]
             }}
         >
-             <Collapse in={expandForm}>
+            <Collapse in={expandForm}>
                 <ContentSection hideDivider={!expandForm} title='Generate New Credentials'>
                     <GenerateServiceAccountForm
                         resetForm={resetForm}

--- a/Source/SelfService/Web/integrations/connection/connectionDetails/consumeDataEventStreams/serviceAccounts/ServiceAccountsSection.tsx
+++ b/Source/SelfService/Web/integrations/connection/connectionDetails/consumeDataEventStreams/serviceAccounts/ServiceAccountsSection.tsx
@@ -3,7 +3,7 @@
 
 import React, { useState, useEffect, useMemo } from 'react';
 import { useSnackbar } from 'notistack';
-import { Collapse, Box, Typography } from '@mui/material';
+import { Collapse } from '@mui/material';
 import { AlertBox, ContentSection } from '@dolittle/design-system';
 import { useConnectionIdFromRoute } from '../../../../routes.hooks';
 import { useConnectionsIdKafkaServiceAccountsGet } from '../../../../../apis/integrations/kafkaServiceAccountApi.hooks';
@@ -65,18 +65,18 @@ export const ServiceAccountsSection = (props: ServiceAccountsSectionProps) => {
         <ContentSection
             title='Service Accounts'
             headerProps={{
-                buttons: [
+                buttons: allowGenerateNew ? [
                     {
                         label: 'Generate new service account',
                         variant: 'outlined',
                         onClick: handleGenerateNewEntry,
                         disabled: !allowGenerateNew
                     }
-                ]
+                ] : []
             }}
         >
             <Collapse in={expandForm}>
-                <ContentSection hideDivider={!expandForm} title='Generate New Credentials'>
+                <ContentSection hideDivider title='Generate New Service Account'>
                     <GenerateServiceAccountForm
                         resetForm={resetForm}
                         connectionId={connectionId}

--- a/Source/SelfService/Web/integrations/connection/connectionDetails/consumeDataEventStreams/serviceAccounts/ServiceAccountsSection.tsx
+++ b/Source/SelfService/Web/integrations/connection/connectionDetails/consumeDataEventStreams/serviceAccounts/ServiceAccountsSection.tsx
@@ -7,6 +7,7 @@ import { Collapse, Box, Typography } from '@mui/material';
 import { AlertBox, ContentSection } from '@dolittle/design-system';
 import { useConnectionIdFromRoute } from '../../../../routes.hooks';
 import { GenerateServiceAccountForm } from './GenerateServiceAccountForm';
+import { ServiceAccountsTable } from './ServiceAccountsTable';
 
 export type ServiceAccountsSectionProps = {};
 
@@ -86,6 +87,11 @@ export const ServiceAccountsSection = (props: ServiceAccountsSectionProps) => {
                     />
                 </ContentSection>
             </Collapse>
+            {items.length > 0 && (
+                <ContentSection>
+                    <ServiceAccountsTable items={items} isLoading={isLoading} />
+                </ContentSection>
+            )}
 
 
         </ContentSection>

--- a/Source/SelfService/Web/integrations/connection/connectionDetails/consumeDataEventStreams/serviceAccounts/ServiceAccountsTable.tsx
+++ b/Source/SelfService/Web/integrations/connection/connectionDetails/consumeDataEventStreams/serviceAccounts/ServiceAccountsTable.tsx
@@ -1,0 +1,52 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import React from 'react';
+
+import { DataGridPro, GridColDef } from '@mui/x-data-grid-pro';
+import { Paper } from '@mui/material';
+
+import { ServiceAccountListDto } from '../../../../../apis/integrations/generated';
+
+
+export type ServiceAccountsTableProps = {
+    items: ServiceAccountListDto[];
+    isLoading: boolean;
+};
+
+export const ServiceAccountsTable = ({ items, isLoading }: ServiceAccountsTableProps) => {
+
+    const columns: GridColDef<ServiceAccountListDto>[] = [
+        {
+            field: 'name',
+            headerName: 'Name',
+            minWidth: 270,
+            flex: 1,
+        },
+        {
+            field: 'description',
+            headerName: 'Description',
+            minWidth: 270,
+            flex: 1,
+        },
+    ];
+
+    return (
+        <Paper sx={{ width: 1 }}>
+            <DataGridPro
+                rows={items}
+                columns={columns}
+                autoHeight
+                disableSelectionOnClick
+                disableColumnMenu
+                disableColumnReorder
+                disableColumnResize
+                disableColumnSelector
+                getRowHeight={() => 'auto'}
+                headerHeight={46}
+                hideFooter
+                loading={isLoading}
+            />
+        </Paper>
+    );
+};

--- a/Source/SelfService/Web/integrations/connection/connectionDetails/consumeDataEventStreams/serviceAccounts/ServiceAccountsTable.tsx
+++ b/Source/SelfService/Web/integrations/connection/connectionDetails/consumeDataEventStreams/serviceAccounts/ServiceAccountsTable.tsx
@@ -6,19 +6,20 @@ import React from 'react';
 import { DataGridPro, GridColDef } from '@mui/x-data-grid-pro';
 import { Paper } from '@mui/material';
 
-import { ServiceAccountListDto } from '../../../../../apis/integrations/generated';
+import { KafkaServiceAccountListDto } from '../../../../../apis/integrations/generated';
+import { formatDate } from '../../../../../utils/helpers/dates';
 
 
 export type ServiceAccountsTableProps = {
-    items: ServiceAccountListDto[];
+    items: KafkaServiceAccountListDto[];
     isLoading: boolean;
 };
 
 export const ServiceAccountsTable = ({ items, isLoading }: ServiceAccountsTableProps) => {
 
-    const columns: GridColDef<ServiceAccountListDto>[] = [
+    const columns: GridColDef<KafkaServiceAccountListDto>[] = [
         {
-            field: 'name',
+            field: 'serviceAccountName',
             headerName: 'Name',
             minWidth: 270,
             flex: 1,
@@ -28,6 +29,13 @@ export const ServiceAccountsTable = ({ items, isLoading }: ServiceAccountsTableP
             headerName: 'Description',
             minWidth: 270,
             flex: 1,
+        },
+        {
+            field: 'createdAd',
+            headerName: 'Created at',
+            minWidth: 270,
+            flex: 1,
+            valueGetter: (params) => params.row.createdAt ? formatDate(params.row.createdAt) : '-'
         },
     ];
 
@@ -46,6 +54,7 @@ export const ServiceAccountsTable = ({ items, isLoading }: ServiceAccountsTableP
                 headerHeight={46}
                 hideFooter
                 loading={isLoading}
+                getRowId={(row) => row.serviceAccountName!}
             />
         </Paper>
     );

--- a/Source/SelfService/Web/integrations/connection/connectionDetails/consumeDataEventStreams/serviceAccounts/ServiceAccountsTable.tsx
+++ b/Source/SelfService/Web/integrations/connection/connectionDetails/consumeDataEventStreams/serviceAccounts/ServiceAccountsTable.tsx
@@ -31,11 +31,14 @@ export const ServiceAccountsTable = ({ items, isLoading }: ServiceAccountsTableP
             flex: 1,
         },
         {
-            field: 'createdAd',
+            field: 'createdAt',
             headerName: 'Created at',
             minWidth: 270,
             flex: 1,
-            valueGetter: (params) => params.row.createdAt ? formatDate(params.row.createdAt) : '-'
+            valueFormatter: (params) => params.value ? formatDate(params.value) : '-',
+            renderCell: (params) => {
+                return <span title={params.value?.toISOString()}>{params.formattedValue}</span>;
+            },
         },
     ];
 

--- a/Source/SelfService/Web/integrations/connection/connectionDetails/consumeDataRestAPI/Credentials/CredentialsContainer.tsx
+++ b/Source/SelfService/Web/integrations/connection/connectionDetails/consumeDataRestAPI/Credentials/CredentialsContainer.tsx
@@ -31,8 +31,6 @@ export const CredentialsContainer = (props: CredentialsContainerProps) => {
     const [activeCredential, setActiveCredential] = useState<string | undefined>(undefined);
     const [resetForm, setResetForm] = useState(false);
 
-    if (!connectionId) return <AlertBox />;
-
     const [deleteDialogState, deleteDialogDispatch] = useReducer(deleteCredentialDialogReducer, { open: false, credentialName: '', connectionId });
 
     const { data, isLoading, isError, error } = useConnectionsIdServiceAccountsGet({ id: connectionId });

--- a/Source/SelfService/Web/integrations/connection/connectionDetails/index.tsx
+++ b/Source/SelfService/Web/integrations/connection/connectionDetails/index.tsx
@@ -60,13 +60,13 @@ const tabs = [
 export const ConnectionDetails = () => {
     const location = useLocation();
     const connectionId = useConnectionIdFromRoute();
-    const { isLoading, data } = useConnectionsIdGet({ id: connectionId || '' });
+    const { isLoading, data } = useConnectionsIdGet({ id: connectionId });
 
     const connection = data?.value;
     const redirectPath = useRedirectToTabByStatus(connection?.status);
 
     if (isLoading) return <>Loading</>;
-    if (!connection || !connectionId) return null;
+    if (!connection) return null;
 
     const pageTitle = connection.name || 'Connection Details';
     const status = connection.status?.name;

--- a/Source/SelfService/Web/integrations/connection/connectionDetails/messages/changeMessage/components/TableSearchSection.tsx
+++ b/Source/SelfService/Web/integrations/connection/connectionDetails/messages/changeMessage/components/TableSearchSection.tsx
@@ -24,7 +24,7 @@ export type TableSearchSectionProps = ViewModeProps & {
 export const TableSearchSection = ({ onTableSelected, searchInput, setSearchInput }: TableSearchSectionProps) => {
     const connectionId = useConnectionIdFromRoute();
     const [debouncedSearchTerm] = useDebounce(searchInput, 500);
-    const query = useConnectionsIdMessageMappingsTablesSearchGet({ id: connectionId || '', search: debouncedSearchTerm });
+    const query = useConnectionsIdMessageMappingsTablesSearchGet({ id: connectionId, search: debouncedSearchTerm });
 
     const searchResults = query.data?.value || [];
 

--- a/Source/SelfService/Web/integrations/connection/connectionDetails/messages/changeMessage/components/TableSection.tsx
+++ b/Source/SelfService/Web/integrations/connection/connectionDetails/messages/changeMessage/components/TableSection.tsx
@@ -26,7 +26,7 @@ export const TableSection = ({ selectedTableName, initialSelectedFields, onBackT
     const connectionId = useConnectionIdFromRoute();
     const setMappedFieldsInForm = useUpdateMappedFieldsInForm();
 
-    if (!connectionId || !selectedTableName) return <AlertBox />;
+    if (!selectedTableName) return <AlertBox />;
 
     const initialSelectedRowIds = useMemo(
         () => initialSelectedFields.map(field => field.mappedColumn?.m3ColumnName) || [],

--- a/Source/SelfService/Web/integrations/connection/connectionDetails/messages/changeMessage/index.tsx
+++ b/Source/SelfService/Web/integrations/connection/connectionDetails/messages/changeMessage/index.tsx
@@ -24,10 +24,6 @@ export const Index = () => {
 
     const mode: ViewMode = location.pathname.endsWith('new') ? 'new' : 'edit';
 
-    if (!connectionId) {
-        return <>Cannot create new message without connection id</>;
-    }
-
     if (mode === 'edit' && (!table || !messageId)) {
         return <>Cannot crete new message without table or messageId</>;
     }

--- a/Source/SelfService/Web/integrations/connection/connectionDetails/messages/messagesList/index.tsx
+++ b/Source/SelfService/Web/integrations/connection/connectionDetails/messages/messagesList/index.tsx
@@ -25,7 +25,7 @@ export const MessagesListView = () => {
     const [selectedMessageTypeIds, setSelectedMessageTypeIds] = useState<string[]>([]);
     const queryClient = useQueryClient();
 
-    const { data, isError, isLoading } = useConnectionsIdMessageMappingsGet({ id: connectionId || '' });
+    const { data, isError, isLoading } = useConnectionsIdMessageMappingsGet({ id: connectionId });
 
     const handleCreateNewMessage = () => {
         navigate('new');
@@ -64,7 +64,7 @@ export const MessagesListView = () => {
     };
 
     if (isLoading) return <LoadingSpinner />;
-    if (isError || !connectionId) return <AlertBox />;
+    if (isError) return <AlertBox />;
 
     return (
         messageTypesRows.length ?

--- a/Source/SelfService/Web/integrations/connection/index.tsx
+++ b/Source/SelfService/Web/integrations/connection/index.tsx
@@ -15,7 +15,7 @@ import { DebugRouter } from '../../components/debugRouter';
 export const Connection = () => {
     const connectionId = useConnectionIdFromRoute();
     const routesElement = useRoutes(routes);
-    const query = useConnectionsIdGet({ id: connectionId || '' });
+    const query = useConnectionsIdGet({ id: connectionId });
 
     if (query.isError) return <>Something went wrong. Could not load connection details for {connectionId}</>;
 

--- a/Source/SelfService/Web/integrations/connection/new/index.tsx
+++ b/Source/SelfService/Web/integrations/connection/new/index.tsx
@@ -19,7 +19,7 @@ import { M3ConfigurationForm } from '../configuration/M3ConfigurationForm';
 export const NewConnectionView = () => {
     const connectionId = useConnectionIdFromRoute();
     const query = useConnectionsIdGet(
-        { id: connectionId || '' },
+        { id: connectionId },
         { refetchInterval: (data) => data?.value?.status.name !== 'Connected' ? 5000 : false }
     );
 
@@ -35,7 +35,7 @@ export const NewConnectionView = () => {
 
 
     if (query.isLoading) return <>Loading</>;
-    if (!connection || !connectionId) return null;
+    if (!connection) return null;
 
     return (
         <Page title='New M3 Connection'>

--- a/Source/SelfService/Web/integrations/routes.hooks.ts
+++ b/Source/SelfService/Web/integrations/routes.hooks.ts
@@ -5,5 +5,6 @@ import { useParams } from 'react-router-dom';
 
 export const useConnectionIdFromRoute = () => {
     const { connectionId } = useParams();
+    if (!connectionId) throw new Error('No connectionId in route');
     return connectionId;
 };


### PR DESCRIPTION
## Summary

- Ability to create Kafka Service Accounts from the Consume Data (Event Streams) page for a connection
- Listing out of existing Kafka Service Accounts
- UX details
  - Hide Generate button from header when form is visible
  - Show the ISODate time on hover over the created at column for a service account
