### PR TITLE
Application selection

### DIFF
--- a/Source/DesignSystem/theming/theme.ts
+++ b/Source/DesignSystem/theming/theme.ts
@@ -184,7 +184,6 @@ const components: Components & DataGridProComponents = {
                     'backgroundColor': 'rgba(140, 154, 248, 0.08)',
                     'color': '#8C9AF8',
                     'width': '100%',
-                    'minHeight': 30,
                     '&:hover': { backgroundColor: 'rgba(140, 154, 248, 0.15)' },
                 },
             },

--- a/Source/SelfService/Web/App.tsx
+++ b/Source/SelfService/Web/App.tsx
@@ -3,7 +3,7 @@
 
 import React from 'react';
 
-import { Route, Routes, Navigate } from 'react-router-dom';
+import { Route, Routes } from 'react-router-dom';
 import { SnackbarProvider } from 'notistack';
 import { GlobalContextProvider } from './context/globalContext';
 
@@ -19,6 +19,7 @@ import { useViewportResize } from './utils/useViewportResize';
 
 import { RouteNotFound } from './components/notfound';
 import { DieAndRestart } from './components/dieAndRestart';
+import { LandingPageDesider } from './components/layout/landingPageDesider';
 import { LayoutWithSidebar } from './components/layout/layoutWithSidebar';
 
 import { BackupsScreen } from './applications/backupsScreen';
@@ -55,7 +56,7 @@ export const App = () => {
                             iconVariant={{ error: <Icon icon='ErrorRounded' sx={{ mr: 1 }} /> }}
                         >
                             <Routes>
-                                <Route path='/' element={<Navigate to='/applications' />} />
+                                <Route path='/' element={<LandingPageDesider />} />
 
                                 <Route path='/applications' element={<ApplicationsScreen />} />
 

--- a/Source/SelfService/Web/App.tsx
+++ b/Source/SelfService/Web/App.tsx
@@ -86,7 +86,7 @@ export const App = () => {
 
                                 <Route path='/integrations/*' element={<IntegrationsIndex />} />
 
-                                <Route path='*' element={<RouteNotFound redirectUrl='/applications' auto={true} />} />
+                                <Route path='*' element={<RouteNotFound redirectUrl='/' auto={true} />} />
                             </Routes>
                         </SnackbarProvider>
                     </GlobalContextProvider>

--- a/Source/SelfService/Web/App.tsx
+++ b/Source/SelfService/Web/App.tsx
@@ -3,17 +3,17 @@
 
 import React from 'react';
 
-import { Route, Routes } from 'react-router-dom';
-import { SnackbarProvider } from 'notistack';
 import { GlobalContextProvider } from './context/globalContext';
+import { SnackbarProvider } from 'notistack';
+import { Route, Routes } from 'react-router-dom';
 
-import { LicenseInfo } from '@mui/x-license-pro';
+import { Slide, SlideProps } from '@mui/material';
 import CssBaseline from '@mui/material/CssBaseline';
 import { ThemeProvider, StyledEngineProvider } from '@mui/material/styles';
-import { Slide, SlideProps } from '@mui/material';
+import { LicenseInfo } from '@mui/x-license-pro';
 
-import '@dolittle/design-system/theming/fonts';
 import { themeDark, Icon } from '@dolittle/design-system';
+import '@dolittle/design-system/theming/fonts';
 
 import { useViewportResize } from './utils/useViewportResize';
 
@@ -82,9 +82,9 @@ export const App = () => {
                                     </LayoutWithSidebar>
                                 } />
 
-                                <Route path="/home" element={<HomeScreen />} />
+                                <Route path='/home' element={<HomeScreen />} />
 
-                                <Route path="/integrations/*" element={<IntegrationsIndex />} />
+                                <Route path='/integrations/*' element={<IntegrationsIndex />} />
 
                                 <Route path='*' element={<RouteNotFound redirectUrl='/applications' auto={true} />} />
                             </Routes>

--- a/Source/SelfService/Web/components/layout/landingPageDesider.tsx
+++ b/Source/SelfService/Web/components/layout/landingPageDesider.tsx
@@ -1,0 +1,47 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import React, { useEffect, useState } from 'react';
+
+import { useGlobalContext } from '../../context/globalContext';
+import { useSnackbar } from 'notistack';
+import { Navigate } from 'react-router-dom';
+
+import { ShortInfoWithEnvironment } from '../../apis/solutions/api';
+import { getApplications, HttpResponseApplications } from '../../apis/solutions/application';
+
+export const LandingPageDesider = () => {
+    const { setCurrentApplicationId, setCurrentEnvironment } = useGlobalContext();
+    const { enqueueSnackbar } = useSnackbar();
+
+    const [applicationInfos, setApplicationInfos] = useState([] as ShortInfoWithEnvironment[]);
+    const [isLoaded, setIsLoaded] = useState(false);
+
+    // TODO handle when not 200!
+    useEffect(() => {
+        Promise.all([getApplications()])
+            .then(values => {
+                const response = values[0] as HttpResponseApplications;
+
+                if (response.applications.length === 1) {
+                    const { environment, id } = response.applications[0];
+
+                    setCurrentApplicationId(id);
+                    setCurrentEnvironment(environment);
+                    setApplicationInfos(response.applications);
+                }
+
+                setIsLoaded(true);
+            })
+            .catch(() => enqueueSnackbar('Failed getting data from the server.', { variant: 'error' }));
+    }, []);
+
+    if (!isLoaded) return null;
+
+    // Should be '/home'.
+    const href = `/microservices/application/${applicationInfos[0].id}/${applicationInfos[0].environment}/overview`;
+
+    return (
+        applicationInfos.length === 1 ? <Navigate to={href} /> : <Navigate to='/applications' />
+    );
+};

--- a/Source/SelfService/Web/components/layout/layoutWithSidebar.tsx
+++ b/Source/SelfService/Web/components/layout/layoutWithSidebar.tsx
@@ -37,10 +37,10 @@ export const LayoutWithSidebar = ({ navigation, children }: LayoutWithSidebarPro
         <div>
             <Paper elevation={4} className='sidebar'>
                 <Box
-                    sx={{ mb: 4, color: 'text.secondary', textAlign: 'center', cursor: 'pointer' }}
+                    sx={{ my: 2, color: 'text.secondary', textAlign: 'center', cursor: 'pointer' }}
                     onClick={() => window.location.pathname = '/selfservice/'}
                 >
-                    <Icon icon='AigonixLightLogo' sx={{ width: 100 }} />
+                    <Icon icon='AigonixLightLogo' sx={{ width: 150 }} />
                 </Box>
                 {navigation}
             </Paper>

--- a/Source/SelfService/Web/components/layout/workSpaceLayout/spaceSelectMenu.tsx
+++ b/Source/SelfService/Web/components/layout/workSpaceLayout/spaceSelectMenu.tsx
@@ -3,11 +3,11 @@
 
 import React, { useState, useEffect } from 'react';
 
-import { useSnackbar } from 'notistack';
 import { useGlobalContext } from '../../../context/globalContext';
+import { useSnackbar } from 'notistack';
 
-import { getApplications, HttpResponseApplications } from '../../../apis/solutions/application';
 import { ShortInfoWithEnvironment } from '../../../apis/solutions/api';
+import { getApplications, HttpResponseApplications } from '../../../apis/solutions/application';
 
 import { getSelectionMenuItems, DropdownMenuProps, MenuItemProps } from '@dolittle/design-system';
 
@@ -22,8 +22,6 @@ export const SpaceSelectMenu = () => {
     const [createSpaceDialogOpen, setCreateSpaceDialogOpen] = useState(false);
     const [isLoading, setIsLoading] = useState(true);
 
-    const currentApplication = applicationInfos.find(application => application.id === currentApplicationId) || applicationInfos[0];
-
     useEffect(() => {
         Promise.all([getApplications()])
             .then(values => {
@@ -37,6 +35,8 @@ export const SpaceSelectMenu = () => {
     }, [currentApplicationId]);
 
     if (isLoading) return null;
+
+    const currentApplication = applicationInfos.find(application => application.id === currentApplicationId) || applicationInfos[0];
 
     const applicationMenuItems = () => {
         const menuItems: DropdownMenuProps['menuItems'] = applicationInfos.filter(application => application.environment === currentEnvironment)

--- a/Source/SelfService/Web/components/layout/workSpaceLayout/spaceSelectMenu.tsx
+++ b/Source/SelfService/Web/components/layout/workSpaceLayout/spaceSelectMenu.tsx
@@ -11,7 +11,7 @@ import { ShortInfoWithEnvironment } from '../../../apis/solutions/api';
 
 import { getSelectionMenuItems, DropdownMenuProps, MenuItemProps } from '@dolittle/design-system';
 
-import { SpaceCreateDialog } from './spaceCreateDialog';
+import { SpaceCreateDialog } from '../../spaceCreateDialog';
 
 export const SpaceSelectMenu = () => {
     const { enqueueSnackbar } = useSnackbar();

--- a/Source/SelfService/Web/components/layout/workSpaceLayout/spaceSelectMenu.tsx
+++ b/Source/SelfService/Web/components/layout/workSpaceLayout/spaceSelectMenu.tsx
@@ -27,6 +27,10 @@ export const SpaceSelectMenu = () => {
             .then(values => {
                 const response = values[0] as HttpResponseApplications;
 
+                if (!currentApplicationId) {
+                    setCurrentApplicationId(response.applications[0].id);
+                }
+
                 setCanCreateApplication(response.canCreateApplication);
                 setApplicationInfos(response.applications);
                 setIsLoading(false);

--- a/Source/SelfService/Web/components/spaceCreateDialog.tsx
+++ b/Source/SelfService/Web/components/spaceCreateDialog.tsx
@@ -4,7 +4,7 @@
 import React, { useState } from 'react';
 
 import { useSnackbar } from 'notistack';
-import { useGlobalContext } from '../../../context/globalContext';
+import { useGlobalContext } from '../context/globalContext';
 
 import { Guid } from '@dolittle/rudiments';
 
@@ -12,9 +12,9 @@ import { Stack, Typography } from '@mui/material';
 
 import { DialogForm, Checkbox, Input } from '@dolittle/design-system';
 
-import { createApplication, HttpApplicationRequest } from '../../../apis/solutions/application';
+import { createApplication, HttpApplicationRequest } from '../apis/solutions/application';
 
-import { alphaNumericLowerCasedCharsRegex } from '../../../utils/helpers/regex';
+import { alphaNumericLowerCasedCharsRegex } from '../utils/helpers/regex';
 
 // Remove click events from the form controls and enable them for the checkboxes.
 // TODO: Maybe we should move this to the design system?

--- a/Source/SelfService/Web/components/spaceCreateDialog.tsx
+++ b/Source/SelfService/Web/components/spaceCreateDialog.tsx
@@ -69,7 +69,7 @@ export const SpaceCreateDialog = ({ isOpen, onClose }: SpaceCreateDialogProps) =
             setCurrentApplicationId(request.id);
             enqueueSnackbar(`'${form.name}' successfully created.`);
         } catch (error) {
-            enqueueSnackbar('Failed to create new space. Please try again.', { variant: 'error' });
+            enqueueSnackbar('Failed to create new application. Please try again.', { variant: 'error' });
         } finally {
             onClose();
             setIsLoading(false);
@@ -81,7 +81,7 @@ export const SpaceCreateDialog = ({ isOpen, onClose }: SpaceCreateDialogProps) =
             id='create-space'
             isOpen={isOpen}
             isLoading={isLoading}
-            title='Create new Space'
+            title='Create new Application'
             formInitialValues={{
                 name: '',
                 environments: {
@@ -94,11 +94,11 @@ export const SpaceCreateDialog = ({ isOpen, onClose }: SpaceCreateDialogProps) =
             onCancel={onClose}
             onConfirm={handleSpaceCreate}
         >
-            <Typography variant='body1' sx={{ my: 2 }}>Provide a name for your new space.</Typography>
+            <Typography variant='body1' sx={{ my: 2 }}>Provide a name for your new application.</Typography>
             <Input
                 id='name'
-                label='Space Name'
-                required='Space name required.'
+                label='Application name'
+                required
                 pattern={{
                     value: alphaNumericLowerCasedCharsRegex,
                     message: 'Name can only contain lowercase alphanumeric characters.'
@@ -106,7 +106,7 @@ export const SpaceCreateDialog = ({ isOpen, onClose }: SpaceCreateDialogProps) =
             />
 
             <Typography variant='body1' sx={{ mt: 4 }}>
-                Select the environments you would like available in your new space.
+                Select the environments you would like available in your new application.
             </Typography>
             <Stack sx={{ '& .MuiFormControl-root': { display: 'inline' } }}>
                 <Checkbox id='environments.Dev' label='Development' />

--- a/Source/SelfService/Web/components/spaceCreateDialog.tsx
+++ b/Source/SelfService/Web/components/spaceCreateDialog.tsx
@@ -16,13 +16,6 @@ import { createApplication, HttpApplicationRequest } from '../apis/solutions/app
 
 import { alphaNumericLowerCasedCharsRegex } from '../utils/helpers/regex';
 
-// Remove click events from the form controls and enable them for the checkboxes.
-// TODO: Maybe we should move this to the design system?
-const styles = {
-    '& .MuiFormControl-root': { pointerEvents: 'none' },
-    '& .MuiCheckbox-root': { pointerEvents: 'auto' },
-};
-
 type SpaceCreateParameters = {
     name: string;
     environments: {
@@ -106,7 +99,6 @@ export const SpaceCreateDialog = ({ isOpen, onClose }: SpaceCreateDialogProps) =
                 id='name'
                 label='Space Name'
                 required='Space name required.'
-                autoFocus
                 pattern={{
                     value: alphaNumericLowerCasedCharsRegex,
                     message: 'Name can only contain lowercase alphanumeric characters.'
@@ -116,7 +108,7 @@ export const SpaceCreateDialog = ({ isOpen, onClose }: SpaceCreateDialogProps) =
             <Typography variant='body1' sx={{ mt: 4 }}>
                 Select the environments you would like available in your new space.
             </Typography>
-            <Stack sx={styles}>
+            <Stack sx={{ '& .MuiFormControl-root': { display: 'inline' } }}>
                 <Checkbox id='environments.Dev' label='Development' />
                 <Checkbox id='environments.Test' label='Test' />
                 <Checkbox id='environments.Prod' label='Production *' disabled />

--- a/Source/SelfService/Web/components/spaceCreateDialog.tsx
+++ b/Source/SelfService/Web/components/spaceCreateDialog.tsx
@@ -71,7 +71,6 @@ export const SpaceCreateDialog = ({ isOpen, onClose }: SpaceCreateDialogProps) =
             });
         }
 
-        // TODO: Should this change current environment?
         try {
             await createApplication(request);
             setCurrentApplicationId(request.id);

--- a/Source/SelfService/Web/spaces/applications/applicationsList.tsx
+++ b/Source/SelfService/Web/spaces/applications/applicationsList.tsx
@@ -43,4 +43,5 @@ export const ApplicationsList = ({ data, onChoose }: ApplicationsListProps) =>
                 />
             ))
         }
+        <Button label='Create new Application' variant='outlined' isFullWidth />
     </List>;

--- a/Source/SelfService/Web/spaces/applications/applicationsList.tsx
+++ b/Source/SelfService/Web/spaces/applications/applicationsList.tsx
@@ -11,16 +11,16 @@ import { ApplicationsListItem } from './applicationsListItem';
 
 export type ApplicationsListProps = {
     data: ShortInfoWithEnvironment[];
-    onChoose: (application: ShortInfoWithEnvironment) => void;
+    onSelect: (application: ShortInfoWithEnvironment) => void;
 };
 
-export const ApplicationsList = ({ data, onChoose }: ApplicationsListProps) =>
+export const ApplicationsList = ({ data, onSelect }: ApplicationsListProps) =>
     <List>
         {data.map(application =>
             <ApplicationsListItem
                 key={`${application.id}-${application.environment}`}
                 application={application}
-                onChoose={() => onChoose(application)}
+                onClick={() => onSelect(application)}
             />
         )}
     </List>;

--- a/Source/SelfService/Web/spaces/applications/applicationsList.tsx
+++ b/Source/SelfService/Web/spaces/applications/applicationsList.tsx
@@ -7,22 +7,7 @@ import { ShortInfoWithEnvironment } from '../../apis/solutions/api';
 
 import { List } from '@mui/material';
 
-import { Button } from '@dolittle/design-system';
-
-// Make buttons as wide as the longest one
-const styles = {
-    list: {
-        p: 0,
-        mt: 2.5,
-        display: 'inline-block',
-    },
-    button: {
-        mb: 2,
-        minWidth: 155,
-        minHeight: 36,
-        display: 'block',
-    },
-};
+import { ApplicationsListItem } from './applicationsListItem';
 
 export type ApplicationsListProps = {
     data: ShortInfoWithEnvironment[];
@@ -30,18 +15,12 @@ export type ApplicationsListProps = {
 };
 
 export const ApplicationsList = ({ data, onChoose }: ApplicationsListProps) =>
-    <List sx={styles.list}>
-        {
-            data.map(application => (
-                <Button
-                    variant='filled'
-                    key={`${application.id}-${application.environment}`}
-                    label={`${application.name}-${application.environment}`}
-                    isFullWidth
-                    onClick={() => onChoose(application)}
-                    sx={styles.button}
-                />
-            ))
-        }
-        <Button label='Create new Application' variant='outlined' isFullWidth />
+    <List>
+        {data.map(application =>
+            <ApplicationsListItem
+                key={`${application.id}-${application.environment}`}
+                application={application}
+                onChoose={() => onChoose(application)}
+            />
+        )}
     </List>;

--- a/Source/SelfService/Web/spaces/applications/applicationsList.tsx
+++ b/Source/SelfService/Web/spaces/applications/applicationsList.tsx
@@ -14,17 +14,17 @@ const styles = {
     list: {
         p: 0,
         mt: 2.5,
-        display: 'inline-block'
+        display: 'inline-block',
     },
     button: {
         mb: 2,
         minWidth: 155,
         minHeight: 36,
-        display: 'block'
-    }
+        display: 'block',
+    },
 };
 
-type ApplicationsListProps = {
+export type ApplicationsListProps = {
     data: ShortInfoWithEnvironment[];
     onChoose: (application: ShortInfoWithEnvironment) => void;
 };

--- a/Source/SelfService/Web/spaces/applications/applicationsListItem.tsx
+++ b/Source/SelfService/Web/spaces/applications/applicationsListItem.tsx
@@ -1,0 +1,34 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import React from 'react';
+
+import { ListItem } from '@mui/material';
+
+import { Button } from '@dolittle/design-system';
+
+import { ShortInfoWithEnvironment } from '../../apis/solutions/api';
+
+// Makes ListItem buttons as wide as the longest one.
+const styles = {
+    mb: 2,
+    minWidth: 155,
+    minHeight: 36,
+    display: 'block',
+};
+
+export type ApplicationsListItemProps = {
+    application: ShortInfoWithEnvironment;
+    onChoose: () => void;
+};
+
+export const ApplicationsListItem = ({ application, onChoose }: ApplicationsListItemProps) =>
+    <ListItem sx={{ p: 0 }}>
+        <Button
+            variant='filled'
+            label={`${application.name}-${application.environment}`}
+            isFullWidth
+            onClick={onChoose}
+            sx={styles}
+        />
+    </ListItem>;

--- a/Source/SelfService/Web/spaces/applications/applicationsListItem.tsx
+++ b/Source/SelfService/Web/spaces/applications/applicationsListItem.tsx
@@ -19,16 +19,16 @@ const styles = {
 
 export type ApplicationsListItemProps = {
     application: ShortInfoWithEnvironment;
-    onChoose: () => void;
+    onClick: () => void;
 };
 
-export const ApplicationsListItem = ({ application, onChoose }: ApplicationsListItemProps) =>
+export const ApplicationsListItem = ({ application, onClick }: ApplicationsListItemProps) =>
     <ListItem sx={{ p: 0 }}>
         <Button
             variant='filled'
             label={`${application.name}-${application.environment}`}
             isFullWidth
-            onClick={onChoose}
+            onClick={onClick}
             sx={styles}
         />
     </ListItem>;

--- a/Source/SelfService/Web/spaces/applications/applicationsScreen.tsx
+++ b/Source/SelfService/Web/spaces/applications/applicationsScreen.tsx
@@ -7,9 +7,9 @@ import { useNavigate } from 'react-router-dom';
 import { useSnackbar } from 'notistack';
 import { useGlobalContext } from '../../context/globalContext';
 
-import { Box, Typography } from '@mui/material';
+import { Box, Stack, Typography } from '@mui/material';
 
-import { Button } from '@dolittle/design-system';
+import { Button, Link } from '@dolittle/design-system';
 
 import { ShortInfoWithEnvironment } from '../../apis/solutions/api';
 import { HttpResponseApplications, getApplications } from '../../apis/solutions/application';
@@ -72,12 +72,21 @@ export const ApplicationsScreen = () => {
 
             <ApplicationsList data={applicationInfos} onChoose={onEnvironmentChoose} />
 
-            <Box sx={{ mt: 12.5, display: 'flex', justifyContent: 'space-around' }}>
+            <Stack sx={{ mt: 12, gap: 4 }}>
                 {!hasOneCustomer &&
-                    <Button label='Back to Customers' color='subtle' startWithIcon='ArrowBack' href='/.auth/cookies/initiate' />
+                    <Box>
+                        <Button label='Back to Customers' color='subtle' startWithIcon='ArrowBack' href='/.auth/cookies/initiate' />
+                    </Box>
                 }
-                <Button label='Log out' color='subtle' href='/.auth/cookies/logout' />
-            </Box>
+
+                <Typography>
+                    Don’t have access to a applications? <Link message='Contact us' href='mailto: support@dolittle.com' /> to get started.
+                </Typography>
+
+                <Box>
+                    <Button label='Log out' color='subtle' href='/.auth/cookies/logout' />
+                </Box>
+            </Stack>
         </LoginWrapper>
     );
 };

--- a/Source/SelfService/Web/spaces/applications/applicationsScreen.tsx
+++ b/Source/SelfService/Web/spaces/applications/applicationsScreen.tsx
@@ -42,7 +42,7 @@ export const ApplicationsScreen = () => {
 
     if (!isLoaded) return null;
 
-    const onEnvironmentChoose = (application: ShortInfoWithEnvironment) => {
+    const onApplicationSelect = (application: ShortInfoWithEnvironment) => {
         const { environment, id } = application;
         setCurrentEnvironment(environment);
         const href = `/microservices/application/${id}/${environment}/overview`;
@@ -67,7 +67,7 @@ export const ApplicationsScreen = () => {
             </Typography>
 
             <Box sx={{ display: 'inline-block' }}>
-                <ApplicationsList data={applicationInfos} onChoose={onEnvironmentChoose} />
+                <ApplicationsList data={applicationInfos} onSelect={onApplicationSelect} />
 
                 <Button
                     label='Create new Application'

--- a/Source/SelfService/Web/spaces/applications/applicationsScreen.tsx
+++ b/Source/SelfService/Web/spaces/applications/applicationsScreen.tsx
@@ -3,9 +3,9 @@
 
 import React, { useState, useEffect } from 'react';
 
-import { useNavigate } from 'react-router-dom';
-import { useSnackbar } from 'notistack';
 import { useGlobalContext } from '../../context/globalContext';
+import { useSnackbar } from 'notistack';
+import { useNavigate } from 'react-router-dom';
 
 import { Box, Stack, Typography } from '@mui/material';
 
@@ -14,9 +14,9 @@ import { Button, Link } from '@dolittle/design-system';
 import { ShortInfoWithEnvironment } from '../../apis/solutions/api';
 import { HttpResponseApplications, getApplications } from '../../apis/solutions/application';
 
+import { ApplicationsList } from './applicationsList';
 import { LoginWrapper } from '../../components/layout/loginWrapper';
 import { SpaceCreateDialog } from '../../components/spaceCreateDialog';
-import { ApplicationsList } from './applicationsList';
 
 export const ApplicationsScreen = () => {
     const navigate = useNavigate();

--- a/Source/SelfService/Web/spaces/applications/applicationsScreen.tsx
+++ b/Source/SelfService/Web/spaces/applications/applicationsScreen.tsx
@@ -37,7 +37,7 @@ export const ApplicationsScreen = () => {
             setLoaded(true);
         }).catch(error => {
             console.log(error);
-            enqueueSnackbar('Failed getting data from the server', { variant: 'error' });
+            enqueueSnackbar('Failed getting data from the server.', { variant: 'error' });
         });
     }, []);
 


### PR DESCRIPTION
## Summary

Improved log in pages appearance.

Create new applications in a Dialog, not on a separate page.

If the user has only one application, navigate directly to the Microservices page, otherwise navigate to the Applications page.

<img width="956" alt="Screenshot 2023-07-28 at 12 05 18" src="https://github.com/dolittle/Studio/assets/19160439/eff17a7d-8839-4632-baf4-abac0660d8bb">

### Added

- LandingPageDesider that navigates to the starting page

### Changed

- ApplicationsScreen 'create new application' appearance

### Fixed

- Style fixes
- Add currentApplicationId to store if navigated directly to Home page and application is not selected yet
