### PR TITLE
Application select fixes

### DIFF
--- a/Source/SelfService/Web/App.tsx
+++ b/Source/SelfService/Web/App.tsx
@@ -19,7 +19,7 @@ import { useViewportResize } from './utils/useViewportResize';
 
 import { RouteNotFound } from './components/notfound';
 import { DieAndRestart } from './components/dieAndRestart';
-import { LandingPageDesider } from './components/layout/landingPageDesider';
+import { LandingPageDecider } from './components/layout/landingPageDecider';
 import { LayoutWithSidebar } from './components/layout/layoutWithSidebar';
 
 import { BackupsScreen } from './applications/backupsScreen';
@@ -56,7 +56,7 @@ export const App = () => {
                             iconVariant={{ error: <Icon icon='ErrorRounded' sx={{ mr: 1 }} /> }}
                         >
                             <Routes>
-                                <Route path='/' element={<LandingPageDesider />} />
+                                <Route path='/' element={<LandingPageDecider />} />
 
                                 <Route path='/applications' element={<ApplicationsScreen />} />
 

--- a/Source/SelfService/Web/components/layout/landingPageDecider.tsx
+++ b/Source/SelfService/Web/components/layout/landingPageDecider.tsx
@@ -9,7 +9,7 @@ import { Navigate } from 'react-router-dom';
 
 import { getApplications, HttpResponseApplications } from '../../apis/solutions/application';
 
-export const LandingPageDesider = () => {
+export const LandingPageDecider = () => {
     const { currentApplicationId, currentEnvironment, setCurrentApplicationId, setCurrentEnvironment } = useGlobalContext();
     const { enqueueSnackbar } = useSnackbar();
 

--- a/Source/SelfService/Web/components/layout/landingPageDecider.tsx
+++ b/Source/SelfService/Web/components/layout/landingPageDecider.tsx
@@ -39,7 +39,8 @@ export const LandingPageDecider = () => {
 
     return (
         hasOneApplication ? (
-            <Navigate to={`/microservices/application/${currentApplicationId}/${currentEnvironment}/overview`} />) : (
+            <Navigate to={`/microservices/application/${currentApplicationId}/${currentEnvironment}/overview`} />
+        ) : (
             <Navigate to='/applications' />
         )
     );

--- a/Source/SelfService/Web/components/layout/landingPageDesider.tsx
+++ b/Source/SelfService/Web/components/layout/landingPageDesider.tsx
@@ -7,14 +7,13 @@ import { useGlobalContext } from '../../context/globalContext';
 import { useSnackbar } from 'notistack';
 import { Navigate } from 'react-router-dom';
 
-import { ShortInfoWithEnvironment } from '../../apis/solutions/api';
 import { getApplications, HttpResponseApplications } from '../../apis/solutions/application';
 
 export const LandingPageDesider = () => {
-    const { setCurrentApplicationId, setCurrentEnvironment } = useGlobalContext();
+    const { currentApplicationId, currentEnvironment, setCurrentApplicationId, setCurrentEnvironment } = useGlobalContext();
     const { enqueueSnackbar } = useSnackbar();
 
-    const [applicationInfos, setApplicationInfos] = useState([] as ShortInfoWithEnvironment[]);
+    const [hasOneApplication, setHasOneApplication] = useState(false);
     const [isLoaded, setIsLoaded] = useState(false);
 
     // TODO handle when not 200!
@@ -28,7 +27,7 @@ export const LandingPageDesider = () => {
 
                     setCurrentApplicationId(id);
                     setCurrentEnvironment(environment);
-                    setApplicationInfos(response.applications);
+                    setHasOneApplication(true);
                 }
 
                 setIsLoaded(true);
@@ -38,10 +37,10 @@ export const LandingPageDesider = () => {
 
     if (!isLoaded) return null;
 
-    // Should be '/home'.
-    const href = `/microservices/application/${applicationInfos[0].id}/${applicationInfos[0].environment}/overview`;
-
     return (
-        applicationInfos.length === 1 ? <Navigate to={href} /> : <Navigate to='/applications' />
+        hasOneApplication ? (
+            <Navigate to={`/microservices/application/${currentApplicationId}/${currentEnvironment}/overview`} />) : (
+            <Navigate to='/applications' />
+        )
     );
 };

--- a/Source/SelfService/Web/components/layout/workSpaceLayout/spaceSelectMenu.tsx
+++ b/Source/SelfService/Web/components/layout/workSpaceLayout/spaceSelectMenu.tsx
@@ -54,7 +54,7 @@ export const SpaceSelectMenu = () => {
 
         menuItems.push({
             id: 'create-new-application',
-            label: 'Create New Space',
+            label: 'Create New application',
             icon: 'AddBoxRounded',
             onSelect: () => handleApplicationCreate(),
         });


### PR DESCRIPTION
## Summary

Fix LandingPageDecider errors.

![MicrosoftTeams-image (1)](https://github.com/dolittle/Studio/assets/19160439/ba8f4fc2-bede-4be5-b30f-5c1ccef05223)

### Changed

- Rename create new 'Space' to 'application' in NavigationBar

### Fixed

- Get current application ID from GlobalContext
- Typo in 'LandingPageDecider'

