### PR TITLE
Fix name and deployment triggering save for new connector

### DIFF
--- a/Source/DesignSystem/atoms/Forms/Forms.stories.tsx
+++ b/Source/DesignSystem/atoms/Forms/Forms.stories.tsx
@@ -1,0 +1,73 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import React from 'react';
+import { Box, Divider } from '@mui/material';
+import { componentStories, Checkbox, Form, Switch, Input, Select, Button } from '@dolittle/design-system';
+import { useFormContext, useFormState } from 'react-hook-form';
+
+type FormData = {
+    textValue: string;
+    selectOption: 'default' | 'cat' | 'dog' | 'bird' | undefined;
+    checkedValue: boolean;
+    switchedValue: boolean;
+};
+
+
+type FormUIProps = {
+    inputProps?: Partial<React.ComponentProps<typeof Input>>;
+    selectProps?: Partial<React.ComponentProps<typeof Select>>;
+    checkboxProps?: Partial<React.ComponentProps<typeof Checkbox>>;
+    switchProps?: Partial<React.ComponentProps<typeof Switch>>;
+};
+
+const FormUI = ({ inputProps, selectProps, checkboxProps, switchProps }: FormUIProps) => {
+    const { isValid } = useFormState();
+
+    return (
+        <>
+            <Box display='flex' flexDirection='column' gap={2} sx={{ my: 2 }}>
+                <Input id="textValue" label="Text" {...inputProps} required />
+                <Select id='selectOption' label='Select Option' options={[
+                    { value: '', displayValue: 'Default' },
+                    { value: 'cat', displayValue: 'Cat' },
+                    { value: 'dog', displayValue: 'Dog' },
+                    { value: 'bird', displayValue: 'Bird' },
+                ]}
+                    {...selectProps}
+                    required
+                ></Select>
+                <Checkbox id="checkedValue" label="Checked value" {...checkboxProps} required />
+                <Switch id="switchedValue" label="Switched value" {...switchProps} required />
+            </Box>
+            <Button label='Submit' type='submit' disabled={!isValid} variant='filled' />
+        </>
+    );
+};
+
+const { metadata, createStory } = componentStories(Form<FormData>, {
+    decorator: (Story) => (
+        <Form<FormData>
+            initialValues={{
+                textValue: 'default',
+                selectOption: undefined,
+                checkedValue: false,
+                switchedValue: false,
+            }}>
+            {Story()}
+        </Form>
+    ),
+});
+
+metadata.parameters = {
+    docs: {
+        description: {
+            component: `The Form component is a wrapper around the \`react-hook-form\` library. It provides a way to create a form with input validation.
+            All the form components in the Design System are built to work with the Form component, and require it to be used. This is a limitation in the current implementation, and a point of improvement for the future.`
+        }
+    }
+};
+
+export default metadata;
+
+export const Default = () => <FormUI />;

--- a/Source/DesignSystem/atoms/Forms/Forms.stories.tsx
+++ b/Source/DesignSystem/atoms/Forms/Forms.stories.tsx
@@ -49,8 +49,8 @@ const { metadata, createStory } = componentStories(Form<FormData>, {
     decorator: (Story) => (
         <Form<FormData>
             initialValues={{
-                textValue: 'default',
-                selectOption: undefined,
+                textValue: '',
+                selectOption: 'cat',
                 checkedValue: false,
                 switchedValue: false,
             }}>

--- a/Source/DesignSystem/atoms/Forms/Select.tsx
+++ b/Source/DesignSystem/atoms/Forms/Select.tsx
@@ -37,6 +37,18 @@ export type SelectProps<T = string> = {
 export const Select = forwardRef<HTMLOptionElement, SelectProps>(({ options, onOpen, sx, ...selectProps }, ref) => {
     const { field } = useController(selectProps);
 
+    /**
+     * Override the default validation mode of the field.
+     * Select should validate on every 'onChange'. Rest of form defaults to 'onTouched'. Set in {@link Form}.
+     * 'onTouched' behaviour is onBlur for first validation, then onChange for subsequent validations.
+     * Great for input fields, less great for selects
+     * More Info: https://www.react-hook-form.com/api/useform/#mode
+     * @param e the event triggered
+     */
+    const overrideDefaultValidationMode = (e) => {
+        field.onChange(e);
+        field.onBlur();
+    };
     return (
         <FormControl size='small' sx={{ width: 220, ...sx }}>
             <InputLabel
@@ -52,6 +64,7 @@ export const Select = forwardRef<HTMLOptionElement, SelectProps>(({ options, onO
             <MuiSelect
                 {...selectProps}
                 {...field}
+                onChange={overrideDefaultValidationMode}
                 required={isRequired(selectProps.required)}
                 ref={ref}
                 labelId={`${selectProps.id}-select`}

--- a/Source/DesignSystem/atoms/Forms/Select.tsx
+++ b/Source/DesignSystem/atoms/Forms/Select.tsx
@@ -50,8 +50,8 @@ export const Select = forwardRef<HTMLOptionElement, SelectProps>(({ options, onO
             </InputLabel>
 
             <MuiSelect
+                {...selectProps}
                 {...field}
-                {...selectProps as MuiSelectProps}
                 required={isRequired(selectProps.required)}
                 ref={ref}
                 labelId={`${selectProps.id}-select`}

--- a/Source/DesignSystem/atoms/Forms/Select.tsx
+++ b/Source/DesignSystem/atoms/Forms/Select.tsx
@@ -3,7 +3,7 @@
 
 import React, { forwardRef } from 'react';
 
-import { FormControl, InputLabel, MenuItem, Select as MuiSelect, SelectProps as MuiSelectProps, SxProps } from '@mui/material';
+import { FormControl, FormHelperText, InputLabel, MenuItem, Select as MuiSelect, SelectProps as MuiSelectProps, SxProps, Typography } from '@mui/material';
 
 import { useController, isRequired, FieldProps } from './helpers';
 
@@ -35,7 +35,7 @@ export type SelectProps<T = string> = {
  * @returns A {@link Select} component.
  */
 export const Select = forwardRef<HTMLOptionElement, SelectProps>(({ options, onOpen, sx, ...selectProps }, ref) => {
-    const { field } = useController(selectProps);
+    const { field, hasError, errorMessage } = useController(selectProps);
 
     /**
      * Override the default validation mode of the field.
@@ -56,6 +56,7 @@ export const Select = forwardRef<HTMLOptionElement, SelectProps>(({ options, onO
                 disabled={selectProps.disabled}
                 required={isRequired(selectProps.required)}
                 size='small'
+                error={hasError}
                 sx={{ typography: 'body2' }}
             >
                 {selectProps.label}
@@ -85,6 +86,9 @@ export const Select = forwardRef<HTMLOptionElement, SelectProps>(({ options, onO
                     </MenuItem>
                 ))}
             </MuiSelect>
+            <FormHelperText error={hasError} id={`${selectProps.id}-helper-text`}>
+                <Typography variant='caption' sx={{ color: 'error.light' }}>{errorMessage}</Typography>
+            </FormHelperText>
         </FormControl>
     );
 });

--- a/Source/SelfService/Web/integrations/connection/configuration/MainM3ConnectionInfo.tsx
+++ b/Source/SelfService/Web/integrations/connection/configuration/MainM3ConnectionInfo.tsx
@@ -3,7 +3,7 @@
 
 import React, { useMemo } from 'react';
 
-import { Stack } from '@mui/material';
+import { Typography, Stack } from '@mui/material';
 
 import { Input, MaxWidthTextBlock, Select, SelectPropsOptions, Tooltip } from '@dolittle/design-system';
 
@@ -19,6 +19,7 @@ const ConnectorNameTooltipText = () =>
     </>;
 
 const hostingTooltipText = `Select between hosting the connector bundle on premise or allowing a platform-managed solution in the cloud. The cloud setup takes care of hosting, establishing backups and making sure the connector is running.`;
+const hostingSelectedTooltipText = `Once selected, the hosting type cannot be changed. Create a new connector to change the hosting type.`;
 
 export type MainM3ConnectionInfoProps = {
     hasSelectedDeploymentType: boolean;
@@ -64,7 +65,12 @@ export const MainM3ConnectionInfo = ({ connectionIdLinks, hasSelectedDeploymentT
                 />
             </Tooltip>
 
-            <Tooltip tooltipTitle='Hosting' tooltipText={hostingTooltipText} displayOnHover={hasSelectedDeploymentType} sx={{ top: 38 }}>
+            <Tooltip
+                tooltipTitle='Hosting'
+                tooltipText={hasSelectedDeploymentType ? hostingSelectedTooltipText : hostingTooltipText}
+                displayOnHover={hasSelectedDeploymentType}
+                sx={{ top: 38 }}
+            >
                 <Select
                     id='selectHosting'
                     label='Hosting'

--- a/Source/SelfService/Web/integrations/connection/connectionDetails/configuration/ActionToolbar.tsx
+++ b/Source/SelfService/Web/integrations/connection/connectionDetails/configuration/ActionToolbar.tsx
@@ -39,6 +39,7 @@ export const ActionToolbar = ({ connectionId, connectorName, onEditAction, onDel
             <Button
                 label='Delete Connection'
                 startWithIcon='DeleteRounded'
+                color='error'
                 onClick={
                     () => dispatch({
                         type: 'open',


### PR DESCRIPTION
### Summary
- Fix: Save button did not enable after selecting the deployment type and name. The issue was with the Select component not firing the validation rules.

### Design System
- Form: Create a Form.story for easier testing and future documentation of Forms
- Select: Fix bug where validation rules were not fired for Select changes.
- Select: Improve validation evaluation for Select to happen onChange, even when form is onTouched
- Sleect: Add validation error messages to the Select component
