### PR TITLE
Add new layout

### DIFF
--- a/Source/DesignSystem/helpers/DummyContents/DummyNavigationItems.tsx
+++ b/Source/DesignSystem/helpers/DummyContents/DummyNavigationItems.tsx
@@ -18,31 +18,27 @@ import {
 
 import { CurrentPath, Link } from '../../helpers/ReactRouter';
 
-const dummyLayoutBreadcrumbsNameMap: { [key: string]: string } = {
-    '/primary-1': 'Primary 1',
-    '/primary-2': 'Primary 2',
-    '/primary-3': 'Primary 3',
-    '/secondary-1': 'Secondary 1',
-    '/secondary-2': 'Secondary 2',
-    '/secondary-3': 'Secondary 3',
-    '/primary-1/side-panel-link-1': 'Side panel link 1',
-    '/primary-1/side-panel-link-2': 'Side panel link 2',
-    '/primary-1/side-panel-link-3': 'Side panel link 3',
-    '/primary-1/side-panel-link-4': 'Side panel link 4',
-    '/primary-1/side-panel-link-5': 'Side panel link  5',
-};
+// const dummyLayoutBreadcrumbsNameMap: { [key: string]: string } = {
+//     '/primary-1': 'Primary 1',
+//     '/primary-2': 'Primary 2',
+//     '/primary-3': 'Primary 3',
+//     '/secondary-1': 'Secondary 1',
+//     '/secondary-2': 'Secondary 2',
+//     '/secondary-3': 'Secondary 3',
+//     '/primary-1/side-panel-link-1': 'Side panel link 1',
+//     '/primary-1/side-panel-link-2': 'Side panel link 2',
+//     '/primary-1/side-panel-link-3': 'Side panel link 3',
+//     '/primary-1/side-panel-link-4': 'Side panel link 4',
+//     '/primary-1/side-panel-link-5': 'Side panel link  5',
+// };
 
 export const DummyLayoutBreadcrumbs = () => {
-    const location = useLocation();
+    //const location = useLocation();
 
     return (
         <Layout
             navigationBar={dummyNavigationBar}
             sidePanel={dummySidePanel}
-            breadcrumbs={{
-                currentPath: location.pathname,
-                breadcrumbsNameMap: dummyLayoutBreadcrumbsNameMap,
-            }}
             sx={{ minHeight: 300 }}
         >
             <CurrentPath />

--- a/Source/DesignSystem/molecules/SidePanel/SidePanel.tsx
+++ b/Source/DesignSystem/molecules/SidePanel/SidePanel.tsx
@@ -10,7 +10,7 @@ import { MenuList, MenuListProps } from '@dolittle/design-system';
 import { Drawer } from './StyledCompenents';
 
 export const getSidePanelItems = (sidePanelItems: MenuListProps['listItems']) =>
-    <MenuList listItems={sidePanelItems} withSelectedItem dense withIcons />;
+    <MenuList listItems={sidePanelItems} dense withIcons />;
 
 /**
  * The props for a {@link SidePanel} component.

--- a/Source/DesignSystem/templates/Layout/Layout.tsx
+++ b/Source/DesignSystem/templates/Layout/Layout.tsx
@@ -32,11 +32,6 @@ export type LayoutProps = {
     sidePanel?: SidePanelProps;
 
     /**
-     * The breadcrumbs items that will be displayed at the top of the layout.
-     */
-    breadcrumbs?: BreadcrumbsProps;
-
-    /**
      * The main content of the layout.
      */
     children: React.ReactNode;
@@ -52,18 +47,13 @@ export type LayoutProps = {
  * @param {LayoutProps} props - The {@link LayoutProps}.
  * @returns A {@link Layout} component.
  */
-export const Layout = ({ navigationBar, sidePanel, breadcrumbs, children, sx }: LayoutProps) =>
+export const Layout = ({ navigationBar, sidePanel, children, sx }: LayoutProps) =>
     <Grid container sx={{ flexFlow: 'nowrap' }}>
         <NavigationBar {...navigationBar} />
 
         {sidePanel && <SidePanel {...sidePanel} />}
 
         <Box component='main' sx={{ ...styles, ...sx }}>
-            {sidePanel &&
-                <Toolbar>
-                    {breadcrumbs && <Breadcrumbs {...breadcrumbs} />}
-                </Toolbar>
-            }
             {children}
         </Box>
     </Grid>;

--- a/Source/SelfService/Web/admin/adminScreen.tsx
+++ b/Source/SelfService/Web/admin/adminScreen.tsx
@@ -9,39 +9,35 @@ import { Typography } from '@mui/material';
 
 import { Button } from '@dolittle/design-system';
 
+import { WorkSpaceLayoutWithSidePanel } from '../components/layout/workSpaceLayout';
 import { Create as CreateCustomer } from './customer/create';
 import { ViewAll as ViewAllCustomers } from './customer/viewAll';
 import { View as ViewCustomer } from './customer/view';
 import { View as ViewApplicationAccess } from './application/view';
-import { LayoutWithSidebar } from '../components/layout/layoutWithSidebar';
 
-export const Screen: React.FunctionComponent = () => {
-    const nav = [];
+const welcome = (
+    <>
+        <Typography variant='h1' my={2}>Hello Admin</Typography>
+        <Button
+            label='Take me to the Customers'
+            variant='filled'
+            endWithIcon='KeyboardDoubleArrowRight'
+            overrides={{
+                component: Link,
+                to: '/admin/customers'
+            }}
+        />
+    </>
+);
 
-    const welcome = (
-        <>
-            <Typography variant='h1' my={2}>Hello Admin</Typography>
-            <Button
-                label='Take me to the Customers'
-                variant='filled'
-                endWithIcon='KeyboardDoubleArrowRight'
-                overrides={{
-                    component: Link,
-                    to: '/admin/customers'
-                }}
-            />
-        </>
-    );
+export const Screen = () =>
+    <WorkSpaceLayoutWithSidePanel pageTitle='Administrator' sidePanelMode='applications'>
+        <Routes>
+            <Route path='/' element={welcome} />
+            <Route path='/customers' element={<ViewAllCustomers />} />
+            <Route path='/customer/create' element={<CreateCustomer />} />
+            <Route path='/customer/:customerId' element={<ViewCustomer />} />
+            <Route path='/customer/:customerId/application/:applicationId/user/access' element={<ViewApplicationAccess />} />
+        </Routes>
+    </WorkSpaceLayoutWithSidePanel>;
 
-    return (
-        <LayoutWithSidebar navigation={nav}>
-            <Routes>
-                <Route path="/" element={welcome} />
-                <Route path="/customers" element={<ViewAllCustomers />} />
-                <Route path="/customer/create" element={<CreateCustomer />} />
-                <Route path="/customer/:customerId" element={<ViewCustomer />} />
-                <Route path="/customer/:customerId/application/:applicationId/user/access" element={<ViewApplicationAccess />} />
-            </Routes>
-        </LayoutWithSidebar>
-    );
-};

--- a/Source/SelfService/Web/applications/backup/backupsList.tsx
+++ b/Source/SelfService/Web/applications/backup/backupsList.tsx
@@ -13,17 +13,16 @@ import { BackupsListItems } from './backupsListItems';
 export type BackupsListProps = {
     data: BackupLinkWithName[];
     application: HttpResponseApplication;
-    setCurrentEnvironment: React.Dispatch<React.SetStateAction<string>>;
 };
 
-export const BackupsList = ({ data, application, setCurrentEnvironment }: BackupsListProps) =>
+export const BackupsList = ({ data, application }: BackupsListProps) =>
     <>
         <Typography variant='h1' sx={{ my: 3 }}>Backups</Typography>
 
         <Grid container spacing={3} sx={{ maxWidth: { md: 930, xl: 1400 } }}>
             {data.map(file =>
                 <Grid key={file.name} item xs={12} md={6} xl={4}>
-                    <BackupsListItems {...file} application={application} setCurrentEnvironment={setCurrentEnvironment} />
+                    <BackupsListItems {...file} application={application} />
                 </Grid>
             )}
         </Grid>

--- a/Source/SelfService/Web/applications/backup/backupsListItems.tsx
+++ b/Source/SelfService/Web/applications/backup/backupsListItems.tsx
@@ -15,19 +15,18 @@ export type BackupsListItemsProps = {
     application: HttpResponseApplication;
     environment: string;
     name: string;
-    setCurrentEnvironment: React.Dispatch<React.SetStateAction<string>>;
 };
 
-export const BackupsListItems = ({ application, environment, name, setCurrentEnvironment }: BackupsListItemsProps) => {
+export const BackupsListItems = ({ application, environment, name }: BackupsListItemsProps) => {
     const navigate = useNavigate();
-    const { setCurrentApplicationId } = useGlobalContext();
+    const { setCurrentApplicationId, setCurrentEnvironment } = useGlobalContext();
 
     const handleBackupsView = async () => {
         // Do we need to set the current application id here?
         setCurrentApplicationId(application.id);
         setCurrentEnvironment(environment);
 
-        const href = `/backups/application/${application.id}/${environment}/list`;
+        const href = `/backups/application/${application.id}/list`;
         navigate(href);
     };
 

--- a/Source/SelfService/Web/applications/backupsScreen.tsx
+++ b/Source/SelfService/Web/applications/backupsScreen.tsx
@@ -3,7 +3,7 @@
 
 import React, { useEffect, useState } from 'react';
 
-import { generatePath, Route, Routes, useNavigate } from 'react-router-dom';
+import { Route, Routes, useNavigate } from 'react-router-dom';
 import { useGlobalContext } from '../context/globalContext';
 
 import { Typography } from '@mui/material';
@@ -14,7 +14,6 @@ import { useRouteApplicationParams } from '../utils/route';
 import { getApplication, HttpResponseApplication } from '../apis/solutions/application';
 import { BackupLinkWithName, getLatestBackupLinkByApplication } from '../apis/solutions/backups';
 
-import { BreadCrumbContainer } from '../components/layout/breadcrumbs';
 import { WorkSpaceLayoutWithSidePanel } from '../components/layout/workSpaceLayout';
 import { BackupsList } from './backup/backupsList';
 import { BackupsListView } from './backup/backupsListView';
@@ -61,33 +60,8 @@ export const BackupsScreen = () => {
         return <Typography variant='h1' my={2}>Application not found.</Typography>;
     }
 
-    const routes = [
-        {
-            path: '/backups/application/:applicationId',
-            to: generatePath('/backups/application/:applicationId/overview', {
-                applicationId: application.id,
-            }),
-            name: 'Backups',
-        },
-        {
-            path: '/backups/application/:applicationId/overview',
-            to: generatePath('/backups/application/:applicationId/overview', {
-                applicationId: application.id,
-            }),
-            name: 'Overview',
-        },
-        {
-            path: '/backups/application/:applicationId/list',
-            to: generatePath('/backups/application/:applicationId/list', {
-                applicationId: application.id,
-            }),
-            name: application.name,
-        },
-    ];
-
     return (
         <WorkSpaceLayoutWithSidePanel pageTitle='Backups' sidePanelMode='applications'>
-            <BreadCrumbContainer routes={routes} />
             <Routes>
                 <Route path='overview' element={<BackupsList data={backupLinksForEnvironment} application={application} />} />
                 <Route path='list' element={<BackupsListView application={application} environment={currentEnvironment} />} />

--- a/Source/SelfService/Web/applications/backupsScreen.tsx
+++ b/Source/SelfService/Web/applications/backupsScreen.tsx
@@ -3,7 +3,7 @@
 
 import React, { useEffect, useState } from 'react';
 
-import { Route, Routes, useNavigate, generatePath } from 'react-router-dom';
+import { generatePath, Route, Routes, useNavigate } from 'react-router-dom';
 import { useGlobalContext } from '../context/globalContext';
 
 import { Typography } from '@mui/material';
@@ -21,11 +21,10 @@ import { BackupsListView } from './backup/backupsListView';
 
 export const BackupsScreen = () => {
     const navigate = useNavigate();
-    const { hasOneCustomer } = useGlobalContext();
+    const { currentEnvironment, hasOneCustomer } = useGlobalContext();
 
     const [application, setApplication] = useState({} as HttpResponseApplication);
     const [backupLinksForEnvironment, setBackupLinksForEnvironment] = useState<BackupLinkWithName[]>([]);
-    const [currentEnvironment, setCurrentEnvironment] = useState('');
     const [isLoading, setIsLoading] = useState(true);
 
     const routeApplicationProps = useRouteApplicationParams();
@@ -80,12 +79,11 @@ export const BackupsScreen = () => {
             name: 'Overview',
         },
         {
-            path: '/backups/application/:applicationId/:environment/list',
-            to: generatePath('/backups/application/:applicationId/:environment/list', {
+            path: '/backups/application/:applicationId/list',
+            to: generatePath('/backups/application/:applicationId/list', {
                 applicationId: application.id,
-                environment: currentEnvironment,
             }),
-            name: currentEnvironment,
+            name: application.name,
         },
     ];
 
@@ -93,7 +91,7 @@ export const BackupsScreen = () => {
         <LayoutWithSidebar navigation={nav}>
             <BreadCrumbContainer routes={routes} />
             <Routes>
-                <Route path='overview' element={<BackupsList data={backupLinksForEnvironment} application={application} setCurrentEnvironment={setCurrentEnvironment} />} />
+                <Route path='overview' element={<BackupsList data={backupLinksForEnvironment} application={application} />} />
                 <Route path='list' element={<BackupsListView application={application} environment={currentEnvironment} />} />
                 <Route element={<Typography variant='h1' my={2}>Something has gone wrong: backups.</Typography>} />
             </Routes>

--- a/Source/SelfService/Web/applications/backupsScreen.tsx
+++ b/Source/SelfService/Web/applications/backupsScreen.tsx
@@ -15,13 +15,13 @@ import { getApplication, HttpResponseApplication } from '../apis/solutions/appli
 import { BackupLinkWithName, getLatestBackupLinkByApplication } from '../apis/solutions/backups';
 
 import { BreadCrumbContainer } from '../components/layout/breadcrumbs';
-import { getMenuWithApplication, LayoutWithSidebar } from '../components/layout/layoutWithSidebar';
+import { WorkSpaceLayoutWithSidePanel } from '../components/layout/workSpaceLayout';
 import { BackupsList } from './backup/backupsList';
 import { BackupsListView } from './backup/backupsListView';
 
 export const BackupsScreen = () => {
     const navigate = useNavigate();
-    const { currentEnvironment, hasOneCustomer } = useGlobalContext();
+    const { currentEnvironment } = useGlobalContext();
 
     const [application, setApplication] = useState({} as HttpResponseApplication);
     const [backupLinksForEnvironment, setBackupLinksForEnvironment] = useState<BackupLinkWithName[]>([]);
@@ -58,10 +58,8 @@ export const BackupsScreen = () => {
     if (isLoading) return <LoadingSpinner />;
 
     if (application.id === '') {
-        return <Typography variant='h1' my={2}>Application with this environment not found.</Typography>;
+        return <Typography variant='h1' my={2}>Application not found.</Typography>;
     }
-
-    const nav = getMenuWithApplication(navigate, application, hasOneCustomer);
 
     const routes = [
         {
@@ -88,13 +86,13 @@ export const BackupsScreen = () => {
     ];
 
     return (
-        <LayoutWithSidebar navigation={nav}>
+        <WorkSpaceLayoutWithSidePanel pageTitle='Backups' sidePanelMode='applications'>
             <BreadCrumbContainer routes={routes} />
             <Routes>
                 <Route path='overview' element={<BackupsList data={backupLinksForEnvironment} application={application} />} />
                 <Route path='list' element={<BackupsListView application={application} environment={currentEnvironment} />} />
                 <Route element={<Typography variant='h1' my={2}>Something has gone wrong: backups.</Typography>} />
             </Routes>
-        </LayoutWithSidebar>
+        </WorkSpaceLayoutWithSidePanel>
     );
 };

--- a/Source/SelfService/Web/applications/containerRegistryScreen.tsx
+++ b/Source/SelfService/Web/applications/containerRegistryScreen.tsx
@@ -10,7 +10,6 @@ import { Typography } from '@mui/material';
 import { getApplication, getApplicationsListing, HttpResponseApplication } from '../apis/solutions/application';
 
 import { WorkSpaceLayoutWithSidePanel } from '../components/layout/workSpaceLayout';
-import { BreadCrumbContainer } from '../components/layout/breadcrumbs';
 import { RegistryContainer } from './containerregistry/registryContainer';
 import { RouteNotFound } from '../components/notfound';
 
@@ -50,11 +49,8 @@ export const ContainerRegistryScreen = withRouteApplicationState(({ routeApplica
         return <Typography variant='h1' my={2}>Application not found</Typography>;
     }
 
-    const routes = [];
-
     return (
         <WorkSpaceLayoutWithSidePanel pageTitle='Container Registry' sidePanelMode='applications'>
-            <BreadCrumbContainer routes={routes} />
             <Routes>
                 <Route path='/overview/*' element={<RegistryContainer application={application} />} />
                 <Route path='*' element={<RouteNotFound redirectUrl={'overview'} auto={true} />} />

--- a/Source/SelfService/Web/applications/containerRegistryScreen.tsx
+++ b/Source/SelfService/Web/applications/containerRegistryScreen.tsx
@@ -10,6 +10,7 @@ import { Typography } from '@mui/material';
 import { getApplication, getApplicationsListing, HttpResponseApplication } from '../apis/solutions/application';
 
 import { WorkSpaceLayoutWithSidePanel } from '../components/layout/workSpaceLayout';
+import { BreadCrumbContainer } from '../components/layout/breadcrumbs';
 import { RegistryContainer } from './containerregistry/registryContainer';
 import { RouteNotFound } from '../components/notfound';
 
@@ -49,10 +50,11 @@ export const ContainerRegistryScreen = withRouteApplicationState(({ routeApplica
         return <Typography variant='h1' my={2}>Application not found</Typography>;
     }
 
-    //const routes = [];
+    const routes = [];
 
     return (
-        <WorkSpaceLayoutWithSidePanel pageTitle='Backups' sidePanelMode='applications'>
+        <WorkSpaceLayoutWithSidePanel pageTitle='Container Registry' sidePanelMode='applications'>
+            <BreadCrumbContainer routes={routes} />
             <Routes>
                 <Route path='/overview/*' element={<RegistryContainer application={application} />} />
                 <Route path='*' element={<RouteNotFound redirectUrl={'overview'} auto={true} />} />

--- a/Source/SelfService/Web/applications/containerRegistryScreen.tsx
+++ b/Source/SelfService/Web/applications/containerRegistryScreen.tsx
@@ -4,13 +4,12 @@
 import React, { useEffect, useState } from 'react';
 
 import { Route, useNavigate, Routes } from 'react-router-dom';
-import { useGlobalContext } from '../context/globalContext';
 
 import { Typography } from '@mui/material';
 
 import { getApplication, getApplicationsListing, HttpResponseApplication } from '../apis/solutions/application';
 
-import { getMenuWithApplication, LayoutWithSidebar } from '../components/layout/layoutWithSidebar';
+import { WorkSpaceLayoutWithSidePanel } from '../components/layout/workSpaceLayout';
 import { RegistryContainer } from './containerregistry/registryContainer';
 import { RouteNotFound } from '../components/notfound';
 
@@ -18,7 +17,6 @@ import { withRouteApplicationState } from '../spaces/applications/withRouteAppli
 
 export const ContainerRegistryScreen = withRouteApplicationState(({ routeApplicationParams }) => {
     const navigate = useNavigate();
-    const { hasOneCustomer } = useGlobalContext();
 
     const [application, setApplication] = useState({} as HttpResponseApplication);
     const [isLoaded, setIsLoaded] = useState(false);
@@ -51,16 +49,14 @@ export const ContainerRegistryScreen = withRouteApplicationState(({ routeApplica
         return <Typography variant='h1' my={2}>Application not found</Typography>;
     }
 
-    const nav = getMenuWithApplication(navigate, application, hasOneCustomer);
-
     //const routes = [];
 
     return (
-        <LayoutWithSidebar navigation={nav}>
+        <WorkSpaceLayoutWithSidePanel pageTitle='Backups' sidePanelMode='applications'>
             <Routes>
                 <Route path='/overview/*' element={<RegistryContainer application={application} />} />
                 <Route path='*' element={<RouteNotFound redirectUrl={'overview'} auto={true} />} />
             </Routes>
-        </LayoutWithSidebar>
+        </WorkSpaceLayoutWithSidePanel>
     );
 });

--- a/Source/SelfService/Web/applications/containerRegistryScreen.tsx
+++ b/Source/SelfService/Web/applications/containerRegistryScreen.tsx
@@ -8,13 +8,11 @@ import { useGlobalContext } from '../context/globalContext';
 
 import { Typography } from '@mui/material';
 
-import { ShortInfo } from '../apis/solutions/api';
-import { getApplication, getApplicationsListing, HttpResponseApplication, HttpResponseApplications } from '../apis/solutions/application';
+import { getApplication, getApplicationsListing, HttpResponseApplication } from '../apis/solutions/application';
 
-import { RouteNotFound } from '../components/notfound';
-import { TopNavBar } from '../components/layout/topNavBar';
 import { getMenuWithApplication, LayoutWithSidebar } from '../components/layout/layoutWithSidebar';
 import { RegistryContainer } from './containerregistry/registryContainer';
+import { RouteNotFound } from '../components/notfound';
 
 import { withRouteApplicationState } from '../spaces/applications/withRouteApplicationState';
 
@@ -22,7 +20,6 @@ export const ContainerRegistryScreen = withRouteApplicationState(({ routeApplica
     const navigate = useNavigate();
     const { hasOneCustomer } = useGlobalContext();
 
-    //const [applications, setApplications] = useState([] as ShortInfo[]);
     const [application, setApplication] = useState({} as HttpResponseApplication);
     const [isLoaded, setIsLoaded] = useState(false);
 
@@ -35,7 +32,6 @@ export const ContainerRegistryScreen = withRouteApplicationState(({ routeApplica
             getApplicationsListing(),
             getApplication(currentApplicationId),
         ]).then(values => {
-            //const applicationsData = values[0] as HttpResponseApplications;
             const applicationData = values[1];
 
             if (!applicationData?.id) {
@@ -44,8 +40,6 @@ export const ContainerRegistryScreen = withRouteApplicationState(({ routeApplica
                 return;
             }
 
-            // TODO this should be unique
-            //setApplications(applicationsData.applications);
             setApplication(applicationData);
             setIsLoaded(true);
         }).catch(error => console.log(error));
@@ -63,8 +57,6 @@ export const ContainerRegistryScreen = withRouteApplicationState(({ routeApplica
 
     return (
         <LayoutWithSidebar navigation={nav}>
-            {/* <TopNavBar routes={routes} applications={applications} applicationId={currentApplicationId} /> */}
-
             <Routes>
                 <Route path='/overview/*' element={<RegistryContainer application={application} />} />
                 <Route path='*' element={<RouteNotFound redirectUrl={'overview'} auto={true} />} />

--- a/Source/SelfService/Web/applications/containerregistry/registryContainer.tsx
+++ b/Source/SelfService/Web/applications/containerregistry/registryContainer.tsx
@@ -52,7 +52,7 @@ export const RegistryContainer = ({ application }: RegistryContainerProps) => {
     return (
         <>
             <div>
-                <Typography variant='h1' my={2}>Container Registry</Typography>
+                <Typography variant='h1' sx={{ my: 3 }}>Container Registry</Typography>
             </div>
 
             <div>

--- a/Source/SelfService/Web/applications/documentationScreen.tsx
+++ b/Source/SelfService/Web/applications/documentationScreen.tsx
@@ -4,18 +4,15 @@
 import React, { useEffect, useState } from 'react';
 
 import { generatePath, Route, useNavigate, Routes } from 'react-router-dom';
-import { useGlobalContext } from '../context/globalContext';
 
 import { HttpResponseApplication, getApplicationsListing, getApplication } from '../apis/solutions/application';
 
-import { TopNavBar } from '../components/layout/topNavBar';
-import { getMenuWithApplication, LayoutWithSidebar } from '../components/layout/layoutWithSidebar';
+import { WorkSpaceLayoutWithSidePanel } from '../components/layout/workSpaceLayout';
 import { SetupContainerScreen } from './setup/setupContainerScreen';
 
 import { withRouteApplicationState } from '../spaces/applications/withRouteApplicationState';
 
 export const DocumentationScreen = withRouteApplicationState(({ routeApplicationParams }) => {
-    const { hasOneCustomer } = useGlobalContext();
     const navigate = useNavigate();
 
     const currentApplicationId = routeApplicationParams.applicationId;
@@ -54,8 +51,6 @@ export const DocumentationScreen = withRouteApplicationState(({ routeApplication
         return null;
     }
 
-    const nav = getMenuWithApplication(navigate, application, hasOneCustomer);
-
     // const routes = [
     //     {
     //         path: '/documentation/application/:applicationId/',
@@ -88,12 +83,10 @@ export const DocumentationScreen = withRouteApplicationState(({ routeApplication
     // ];
 
     return (
-        <LayoutWithSidebar navigation={nav}>
-            {/* <TopNavBar routes={routes} applications={applications} applicationId={currentApplicationId} /> */}
-
+        <WorkSpaceLayoutWithSidePanel pageTitle='Setup' sidePanelMode='applications'>
             <Routes>
                 <Route path='/*' element={<SetupContainerScreen application={application} />} />
             </Routes>
-        </LayoutWithSidebar>
+        </WorkSpaceLayoutWithSidePanel>
     );
 });

--- a/Source/SelfService/Web/applications/documentationScreen.tsx
+++ b/Source/SelfService/Web/applications/documentationScreen.tsx
@@ -51,37 +51,6 @@ export const DocumentationScreen = withRouteApplicationState(({ routeApplication
         return <Typography variant='h1' my={2}>Application not found.</Typography>;
     }
 
-    // const routes = [
-    //     {
-    //         path: '/documentation/application/:applicationId/',
-    //         to: generatePath('/documentation/application/:applicationId/overview', {
-    //             applicationId: application.id,
-    //         }),
-    //         name: 'Documentation',
-    //     },
-    //     {
-    //         path: '/documentation/application/:applicationId/overview',
-    //         to: generatePath('/documentation/application/:applicationId/overview', {
-    //             applicationId: application.id,
-    //         }),
-    //         name: 'Overview',
-    //     },
-    //     {
-    //         path: '/documentation/application/:applicationId/container-registry-info',
-    //         to: generatePath('/documentation/application/:applicationId/container-registry-info', {
-    //             applicationId: application.id,
-    //         }),
-    //         name: 'Container Registry Info',
-    //     },
-    //     {
-    //         path: '/documentation/application/:applicationId/verify-kubernetes-access',
-    //         to: generatePath('/documentation/application/:applicationId/verify-kubernetes-access', {
-    //             applicationId: application.id,
-    //         }),
-    //         name: 'Verify access to kubernetes',
-    //     },
-    // ];
-
     return (
         <WorkSpaceLayoutWithSidePanel pageTitle='Setup' sidePanelMode='applications'>
             <Routes>

--- a/Source/SelfService/Web/applications/documentationScreen.tsx
+++ b/Source/SelfService/Web/applications/documentationScreen.tsx
@@ -3,14 +3,9 @@
 
 import React, { useEffect, useState } from 'react';
 
-import { Route, useNavigate, Routes, generatePath } from 'react-router-dom';
+import { generatePath, Route, useNavigate, Routes } from 'react-router-dom';
 import { useGlobalContext } from '../context/globalContext';
 
-// I wonder if scss is scoped like svelte. I hope so!
-// Not scoped like svelte
-import '../spaces/applications/applicationScreen.scss';
-
-import { ShortInfo } from '../apis/solutions/api';
 import { HttpResponseApplication, getApplicationsListing, getApplication } from '../apis/solutions/application';
 
 import { TopNavBar } from '../components/layout/topNavBar';
@@ -25,22 +20,18 @@ export const DocumentationScreen = withRouteApplicationState(({ routeApplication
 
     const currentApplicationId = routeApplicationParams.applicationId;
 
-    //const [applications, setApplications] = useState([] as ShortInfo[]);
     const [application, setApplication] = useState({} as HttpResponseApplication);
     const [isLoaded, setIsLoaded] = useState(false);
 
     const href = `/problem`;
 
     useEffect(() => {
-        if (!currentApplicationId) {
-            return;
-        }
+        if (!currentApplicationId) return;
 
         Promise.all([
             getApplicationsListing(),
             getApplication(currentApplicationId),
         ]).then(values => {
-            //const applicationsData = values[0] as HttpResponseApplications;
             const applicationData = values[1];
 
             if (!applicationData?.id) {
@@ -48,8 +39,6 @@ export const DocumentationScreen = withRouteApplicationState(({ routeApplication
                 return;
             }
 
-            // TODO this should be unique
-            //setApplications(applicationsData.applications);
             setApplication(applicationData);
             setIsLoaded(true);
         }).catch(() => {
@@ -97,10 +86,6 @@ export const DocumentationScreen = withRouteApplicationState(({ routeApplication
     //         name: 'Verify access to kubernetes',
     //     },
     // ];
-
-    // const redirectUrl = generatePath('/documentation/application/:applicationId/overview', {
-    //     applicationId: currentApplicationId,
-    // });
 
     return (
         <LayoutWithSidebar navigation={nav}>

--- a/Source/SelfService/Web/applications/documentationScreen.tsx
+++ b/Source/SelfService/Web/applications/documentationScreen.tsx
@@ -4,6 +4,9 @@
 import React, { useEffect, useState } from 'react';
 
 import { generatePath, Route, useNavigate, Routes } from 'react-router-dom';
+import { useSnackbar } from 'notistack';
+
+import { Typography } from '@mui/material';
 
 import { HttpResponseApplication, getApplicationsListing, getApplication } from '../apis/solutions/application';
 
@@ -14,13 +17,12 @@ import { withRouteApplicationState } from '../spaces/applications/withRouteAppli
 
 export const DocumentationScreen = withRouteApplicationState(({ routeApplicationParams }) => {
     const navigate = useNavigate();
+    const { enqueueSnackbar } = useSnackbar();
 
     const currentApplicationId = routeApplicationParams.applicationId;
 
     const [application, setApplication] = useState({} as HttpResponseApplication);
     const [isLoaded, setIsLoaded] = useState(false);
-
-    const href = `/problem`;
 
     useEffect(() => {
         if (!currentApplicationId) return;
@@ -31,24 +33,22 @@ export const DocumentationScreen = withRouteApplicationState(({ routeApplication
         ]).then(values => {
             const applicationData = values[1];
 
-            if (!applicationData?.id) {
-                navigate(href);
+            if (!applicationData.id) {
+                navigate('/problem');
                 return;
             }
 
             setApplication(applicationData);
             setIsLoaded(true);
         }).catch(() => {
-            navigate(href);
-            return;
+            enqueueSnackbar('Failed getting data from the server.', { variant: 'error' });
         });
     }, [currentApplicationId]);
 
     if (!isLoaded) return null;
 
     if (application.id === '') {
-        navigate(href);
-        return null;
+        return <Typography variant='h1' my={2}>Application not found.</Typography>;
     }
 
     // const routes = [

--- a/Source/SelfService/Web/applications/logsScreen.tsx
+++ b/Source/SelfService/Web/applications/logsScreen.tsx
@@ -8,12 +8,11 @@ import { useGlobalContext } from '../context/globalContext';
 
 import { Box, Typography } from '@mui/material';
 
-import { ShortInfo, HttpResponseMicroservices, getMicroservices } from '../apis/solutions/api';
-import { HttpResponseApplication, getApplicationsListing, getApplication, HttpResponseApplications } from '../apis/solutions/application';
+import { HttpResponseMicroservices, getMicroservices } from '../apis/solutions/api';
+import { HttpResponseApplication, getApplicationsListing, getApplication } from '../apis/solutions/application';
 
 import { mergeMicroservicesFromGit, mergeMicroservicesFromK8s } from './stores/microservice';
 import { LayoutWithSidebar, getMenuWithApplication } from '../components/layout/layoutWithSidebar';
-import { TopNavBar } from '../components/layout/topNavBar';
 
 import { LogFilterMicroservice, LogFilterPanel } from './logging/logFilter/logFilterPanel';
 import { useLogFilters } from './logging/logFilter/useLogFilters';
@@ -32,7 +31,6 @@ export const LogsScreen = withRouteApplicationState(({ routeApplicationParams })
     const navigate = useNavigate();
     const { hasOneCustomer } = useGlobalContext();
 
-    //const [applications, setApplications] = useState({} as ShortInfo[]);
     const [application, setApplication] = useState({} as HttpResponseApplication);
     const [isLoaded, setIsLoaded] = useState(false);
 
@@ -64,7 +62,6 @@ export const LogsScreen = withRouteApplicationState(({ routeApplicationParams })
             getApplication(currentApplicationId),
             getMicroservices(currentApplicationId),
         ]).then(values => {
-            //const applicationsData = values[0] as HttpResponseApplications;
             const applicationData = values[1];
 
             if (!applicationData?.id) {
@@ -72,12 +69,10 @@ export const LogsScreen = withRouteApplicationState(({ routeApplicationParams })
                 return;
             }
 
-            //setApplications(applicationsData.applications);
             setApplication(applicationData);
             mergeMicroservicesFromGit(applicationData.microservices);
 
             const microservicesData = values[2] as HttpResponseMicroservices;
-            //const microservices = microservicesData.microservices.filter(microservice => microservice.environment === currentEnvironment);
 
             mergeMicroservicesFromK8s(microservicesData.microservices);
             setIsLoaded(true);
@@ -98,7 +93,6 @@ export const LogsScreen = withRouteApplicationState(({ routeApplicationParams })
 
     return (
         <LayoutWithSidebar navigation={nav}>
-            {/* <TopNavBar routes={[]} applications={applications} applicationId={currentApplicationId} /> */}
             <Typography variant='h1'>Logs</Typography>
 
             <Box sx={{ minWidth: 640, mt: 3 }}>

--- a/Source/SelfService/Web/applications/logsScreen.tsx
+++ b/Source/SelfService/Web/applications/logsScreen.tsx
@@ -4,6 +4,7 @@
 import React, { useEffect, useState } from 'react';
 
 import { useNavigate } from 'react-router-dom';
+import { useSnackbar } from 'notistack';
 
 import { Box, Typography } from '@mui/material';
 
@@ -28,12 +29,12 @@ const DAY = 86_400_000_000_000n;
 
 export const LogsScreen = withRouteApplicationState(({ routeApplicationParams }) => {
     const navigate = useNavigate();
+    const { enqueueSnackbar } = useSnackbar();
 
     const [application, setApplication] = useState({} as HttpResponseApplication);
     const [isLoaded, setIsLoaded] = useState(false);
 
     const currentApplicationId = routeApplicationParams.applicationId;
-    const href = `/problem`;
 
     const availableMicroservices: LogFilterMicroservice[] = application?.microservices !== undefined ? application.microservices.map(microservice => ({
         id: microservice.dolittle.microserviceId,
@@ -76,8 +77,7 @@ export const LogsScreen = withRouteApplicationState(({ routeApplicationParams })
             mergeMicroservicesFromK8s(microservicesData.microservices);
             setIsLoaded(true);
         }).catch(() => {
-            navigate(href);
-            return;
+            enqueueSnackbar('Failed getting data from the server.', { variant: 'error' });
         });
     }, [currentApplicationId]);
 

--- a/Source/SelfService/Web/applications/logsScreen.tsx
+++ b/Source/SelfService/Web/applications/logsScreen.tsx
@@ -62,7 +62,8 @@ export const LogsScreen = withRouteApplicationState(({ routeApplicationParams })
         ]).then(values => {
             const applicationData = values[1];
 
-            if (!applicationData?.id) {
+            if (!applicationData.id) {
+                const href = `/problem`;
                 navigate(href);
                 return;
             }
@@ -83,8 +84,7 @@ export const LogsScreen = withRouteApplicationState(({ routeApplicationParams })
     if (!isLoaded) return null;
 
     if (application.id === '') {
-        navigate(href);
-        return null;
+        return <Typography variant='h1' my={2}>Application  not found.</Typography>;
     }
 
     return (

--- a/Source/SelfService/Web/applications/logsScreen.tsx
+++ b/Source/SelfService/Web/applications/logsScreen.tsx
@@ -4,7 +4,6 @@
 import React, { useEffect, useState } from 'react';
 
 import { useNavigate } from 'react-router-dom';
-import { useGlobalContext } from '../context/globalContext';
 
 import { Box, Typography } from '@mui/material';
 
@@ -12,8 +11,8 @@ import { HttpResponseMicroservices, getMicroservices } from '../apis/solutions/a
 import { HttpResponseApplication, getApplicationsListing, getApplication } from '../apis/solutions/application';
 
 import { mergeMicroservicesFromGit, mergeMicroservicesFromK8s } from './stores/microservice';
-import { LayoutWithSidebar, getMenuWithApplication } from '../components/layout/layoutWithSidebar';
 
+import { WorkSpaceLayoutWithSidePanel } from '../components/layout/workSpaceLayout';
 import { LogFilterMicroservice, LogFilterPanel } from './logging/logFilter/logFilterPanel';
 import { useLogFilters } from './logging/logFilter/useLogFilters';
 import { LogsInRange } from './logging/logsInRange';
@@ -29,7 +28,6 @@ const DAY = 86_400_000_000_000n;
 
 export const LogsScreen = withRouteApplicationState(({ routeApplicationParams }) => {
     const navigate = useNavigate();
-    const { hasOneCustomer } = useGlobalContext();
 
     const [application, setApplication] = useState({} as HttpResponseApplication);
     const [isLoaded, setIsLoaded] = useState(false);
@@ -89,11 +87,9 @@ export const LogsScreen = withRouteApplicationState(({ routeApplicationParams })
         return null;
     }
 
-    const nav = getMenuWithApplication(navigate, application, hasOneCustomer);
-
     return (
-        <LayoutWithSidebar navigation={nav}>
-            <Typography variant='h1'>Logs</Typography>
+        <WorkSpaceLayoutWithSidePanel pageTitle='Logs' sidePanelMode='applications'>
+            <Typography variant='h1' sx={{ my: 3 }}>Logs</Typography>
 
             <Box sx={{ minWidth: 640, mt: 3 }}>
                 <LogFilterPanel
@@ -123,6 +119,6 @@ export const LogsScreen = withRouteApplicationState(({ routeApplicationParams })
                     />
                 }
             </Box>
-        </LayoutWithSidebar>
+        </WorkSpaceLayoutWithSidePanel>
     );
 });

--- a/Source/SelfService/Web/applications/m3connectorScreen.tsx
+++ b/Source/SelfService/Web/applications/m3connectorScreen.tsx
@@ -4,7 +4,6 @@
 import React, { useEffect, useState } from 'react';
 
 import { Route, Routes, useNavigate } from 'react-router-dom';
-import { useGlobalContext } from '../context/globalContext';
 
 import { Typography } from '@mui/material';
 
@@ -12,13 +11,11 @@ import { getApplication, HttpResponseApplication } from '../apis/solutions/appli
 import { useRouteApplicationParams } from '../utils/route';
 import { Container } from './m3connector/container';
 
-import { getMenuWithApplication, LayoutWithSidebar } from '../components/layout/layoutWithSidebar';
-//import { BreadCrumbContainer } from '../components/layout/breadcrumbs';
+import { WorkSpaceLayoutWithSidePanel } from '../components/layout/workSpaceLayout';
 
 export const M3ConnectorScreen = () => {
     const navigate = useNavigate();
     const routeApplicationProps = useRouteApplicationParams();
-    const { hasOneCustomer } = useGlobalContext();
 
     const [application, setApplication] = useState({} as HttpResponseApplication);
     const [isLoaded, setIsLoaded] = useState(false);
@@ -26,6 +23,7 @@ export const M3ConnectorScreen = () => {
     const applicationId = routeApplicationProps.applicationId;
 
     useEffect(() => {
+        // TODO ENV: getApplication should be getApplicationsListing?
         Promise.all([getApplication(applicationId)])
             .then(values => {
                 const applicationData = values[0];
@@ -47,21 +45,11 @@ export const M3ConnectorScreen = () => {
         return <Typography variant='h1' my={2}>Application  not found.</Typography>;
     }
 
-    const nav = getMenuWithApplication(navigate, application, hasOneCustomer);
-
-    //const routes = [];
-
     return (
-        <LayoutWithSidebar navigation={nav}>
-            {/* <div id="topNavBar" className="nav flex-container">
-                <div className="left flex-start">
-                    <BreadCrumbContainer routes={routes} />
-                </div>
-            </div> */}
-
+        <WorkSpaceLayoutWithSidePanel pageTitle='M3 connector' sidePanelMode='applications'>
             <Routes>
                 <Route path='/*' element={<Container application={application} />} />
             </Routes>
-        </LayoutWithSidebar>
+        </WorkSpaceLayoutWithSidePanel>
     );
 };

--- a/Source/SelfService/Web/applications/microservice/microserviceDetails/configurationFilesSection/environmentSection/environmentVariableSection.tsx
+++ b/Source/SelfService/Web/applications/microservice/microserviceDetails/configurationFilesSection/environmentSection/environmentVariableSection.tsx
@@ -249,7 +249,6 @@ export const EnvironmentVariablesSection = ({ applicationId, currentMicroservice
                         description={`To add your first environment variable, select 'add variable'. Provide a name, value and set its secrecy.`}
                         label='Add Variable'
                         handleOnClick={handleEnvVariableAdd} // TODO: Sometimes throws error when clicked
-                        sx={{ mb: 8 }}
                     /> :
                     <Paper sx={{ width: 1 }}>
                         <DataGridPro

--- a/Source/SelfService/Web/applications/microservice/microserviceDetails/microserviceDetails.tsx
+++ b/Source/SelfService/Web/applications/microservice/microserviceDetails/microserviceDetails.tsx
@@ -129,7 +129,7 @@ export const MicroserviceDetails = ({ application, currentMicroservice, microser
     }
 
     return (
-        <Box>
+        <Box sx={{ my: 2 }}>
             <Box sx={{ display: 'flex', alignItems: 'center', mb: 3.25 }}>
                 <Typography variant='h1' sx={{ mr: 3 }}>{microserviceName}</Typography>
                 <StatusIndicator variantFilled status={microserviceHealthStatus.status} label={microserviceHealthStatus.label} />

--- a/Source/SelfService/Web/applications/microservice/microserviceDetails/microserviceDetails.tsx
+++ b/Source/SelfService/Web/applications/microservice/microserviceDetails/microserviceDetails.tsx
@@ -129,13 +129,13 @@ export const MicroserviceDetails = ({ application, currentMicroservice, microser
     }
 
     return (
-        <>
+        <Box>
             <Box sx={{ display: 'flex', alignItems: 'center', mb: 3.25 }}>
                 <Typography variant='h1' sx={{ mr: 3 }}>{microserviceName}</Typography>
                 <StatusIndicator variantFilled status={microserviceHealthStatus.status} label={microserviceHealthStatus.label} />
             </Box>
 
             <Tabs id='microservice-details-tabs' selectedTab={getLastOpenTab} tabs={tabs} />
-        </>
+        </Box>
     );
 };

--- a/Source/SelfService/Web/applications/microservice/microservices/microservices.tsx
+++ b/Source/SelfService/Web/applications/microservice/microservices/microservices.tsx
@@ -45,7 +45,7 @@ export const Microservice = ({ application }: MicroserviceProps) => {
 
     return (
         <>
-            <Typography variant='h1' sx={{ my: 2 }}>Microservices</Typography>
+            <Typography variant='h1' sx={{ my: 3 }}>Microservices</Typography>
 
             {$microservices.length > 0 ? (
                 <>

--- a/Source/SelfService/Web/applications/microservicesScreen.tsx
+++ b/Source/SelfService/Web/applications/microservicesScreen.tsx
@@ -3,7 +3,7 @@
 
 import React, { useEffect, useState } from 'react';
 
-import { Route, useNavigate, Routes, generatePath } from 'react-router-dom';
+import { Route, Routes, useNavigate } from 'react-router-dom';
 import { useSnackbar } from 'notistack';
 import { useGlobalContext } from '../context/globalContext';
 
@@ -12,7 +12,7 @@ import { Typography } from '@mui/material';
 import { mergeMicroservicesFromGit, mergeMicroservicesFromK8s } from './stores/microservice';
 
 import { getMicroservices } from '../apis/solutions/api';
-import { getApplicationsListing, getApplication, HttpResponseApplication, HttpResponseApplications } from '../apis/solutions/application';
+import { getApplicationsListing, getApplication, HttpResponseApplication } from '../apis/solutions/application';
 
 import { Microservice } from './microservice/microservices/microservices';
 import { MicroserviceNewScreen } from './microservice/microserviceNewScreen';
@@ -27,7 +27,6 @@ export const MicroservicesScreen = withRouteApplicationState(({ routeApplication
     const { enqueueSnackbar } = useSnackbar();
     const { hasOneCustomer } = useGlobalContext();
 
-    //const [applications, setApplications] = useState({} as ShortInfo[]);
     const [application, setApplication] = useState({} as HttpResponseApplication);
     const [isLoaded, setIsLoaded] = useState(false);
 
@@ -41,7 +40,6 @@ export const MicroservicesScreen = withRouteApplicationState(({ routeApplication
             getApplication(currentApplicationId),
             getMicroservices(currentApplicationId),
         ]).then(values => {
-            //const applicationsData = values[0] as HttpResponseApplications;
             const applicationData = values[1];
 
             if (!applicationData.id) {
@@ -49,7 +47,6 @@ export const MicroservicesScreen = withRouteApplicationState(({ routeApplication
                 return;
             }
 
-            //setApplications(applicationsData.applications);
             setApplication(applicationData);
 
             mergeMicroservicesFromGit(applicationData.microservices);
@@ -68,46 +65,6 @@ export const MicroservicesScreen = withRouteApplicationState(({ routeApplication
     }
 
     const nav = getMenuWithApplication(navigate, application, hasOneCustomer);
-
-    // TODO DEV: This is used by breadcrumbs?
-    // const routes = [
-    //     {
-    //         path: '/microservices/application/:applicationId/',
-    //         to: generatePath('/microservices/application/:applicationId/overview', {
-    //             applicationId: application.id,
-    //         }),
-    //         name: 'Microservices',
-    //     },
-    //     {
-    //         path: '/microservices/application/:applicationId/overview',
-    //         to: generatePath('/microservices/application/:applicationId/overview', {
-    //             applicationId: application.id,
-    //         }),
-    //         name: 'Overview',
-    //     },
-    //     {
-    //         path: '/microservices/application/:applicationId/create',
-    //         to: generatePath('/microservices/application/:applicationId/create', {
-    //             applicationId: application.id,
-    //         }),
-    //         name: 'Create',
-    //     },
-    //     {
-    //         path: '/microservices/application/:applicationId/edit',
-    //         to: generatePath('/microservices/application/:applicationId/edit', {
-    //             applicationId: application.id,
-    //         }),
-    //         name: 'Edit',
-    //     },
-    //     {
-    //         path: '/microservices/application/:applicationId/view',
-    //         to: generatePath('/microservices/application/:applicationId/view', {
-    //             applicationId: application.id,
-    //         }),
-    //         name: 'View',
-    //     },
-    // ];
-    {/* <TopNavBar routes={routes} applications={applications} applicationId={currentApplicationId} /> */ }
 
     return (
         <LayoutWithSidebar navigation={nav}>

--- a/Source/SelfService/Web/applications/microservicesScreen.tsx
+++ b/Source/SelfService/Web/applications/microservicesScreen.tsx
@@ -5,7 +5,6 @@ import React, { useEffect, useState } from 'react';
 
 import { Route, Routes, useNavigate } from 'react-router-dom';
 import { useSnackbar } from 'notistack';
-import { useGlobalContext } from '../context/globalContext';
 
 import { Typography } from '@mui/material';
 
@@ -17,7 +16,7 @@ import { getApplicationsListing, getApplication, HttpResponseApplication } from 
 import { Microservice } from './microservice/microservices/microservices';
 import { MicroserviceNewScreen } from './microservice/microserviceNewScreen';
 import { MicroserviceViewScreen } from './microservice/microserviceViewScreen';
-import { LayoutWithSidebar, getMenuWithApplication } from '../components/layout/layoutWithSidebar';
+import { WorkSpaceLayoutWithSidePanel } from '../components/layout/workSpaceLayout';
 import { RouteNotFound } from '../components/notfound';
 
 import { withRouteApplicationState } from '../spaces/applications/withRouteApplicationState';
@@ -25,7 +24,6 @@ import { withRouteApplicationState } from '../spaces/applications/withRouteAppli
 export const MicroservicesScreen = withRouteApplicationState(({ routeApplicationParams }) => {
     const navigate = useNavigate();
     const { enqueueSnackbar } = useSnackbar();
-    const { hasOneCustomer } = useGlobalContext();
 
     const [application, setApplication] = useState({} as HttpResponseApplication);
     const [isLoaded, setIsLoaded] = useState(false);
@@ -54,26 +52,24 @@ export const MicroservicesScreen = withRouteApplicationState(({ routeApplication
 
             setIsLoaded(true);
         }).catch(() => {
-            enqueueSnackbar('Failed getting data from the server', { variant: 'error' });
+            enqueueSnackbar('Failed getting data from the server.', { variant: 'error' });
         });
     }, [currentApplicationId]);
 
     if (!isLoaded) return null;
 
     if (application.id === '') {
-        return <Typography variant='h1' my={2}>Application not found</Typography>;
+        return <Typography variant='h1' my={2}>Application not found.</Typography>;
     }
 
-    const nav = getMenuWithApplication(navigate, application, hasOneCustomer);
-
     return (
-        <LayoutWithSidebar navigation={nav}>
+        <WorkSpaceLayoutWithSidePanel pageTitle='Microservices' sidePanelMode='applications'>
             <Routes>
                 <Route path='/overview' element={<Microservice application={application} />} />
                 <Route path='/create' element={<MicroserviceNewScreen application={application} />} />
                 <Route path='view/:microserviceId' element={<MicroserviceViewScreen application={application} />} />
                 <Route path='*' element={<RouteNotFound redirectUrl={'overview'} auto={true} />} />
             </Routes>
-        </LayoutWithSidebar>
+        </WorkSpaceLayoutWithSidePanel>
     );
 });

--- a/Source/SelfService/Web/applications/microservicesScreen.tsx
+++ b/Source/SelfService/Web/applications/microservicesScreen.tsx
@@ -6,10 +6,6 @@ import React, { useEffect, useState } from 'react';
 import { Route, useNavigate, Routes, generatePath } from 'react-router-dom';
 import { useGlobalContext } from '../context/globalContext';
 
-// I wonder if scss is scoped like svelte. I hope so!
-// Not scoped like svelte
-import '../spaces/applications/applicationScreen.scss';
-
 import { mergeMicroservicesFromGit, mergeMicroservicesFromK8s } from './stores/microservice';
 
 import { getMicroservices } from '../apis/solutions/api';
@@ -20,7 +16,6 @@ import { MicroserviceNewScreen } from './microservice/microserviceNewScreen';
 import { MicroserviceViewScreen } from './microservice/microserviceViewScreen';
 import { LayoutWithSidebar, getMenuWithApplication } from '../components/layout/layoutWithSidebar';
 import { RouteNotFound } from '../components/notfound';
-//import { TopNavBar } from '../components/layout/topNavBar';
 
 import { withRouteApplicationState } from '../spaces/applications/withRouteApplicationState';
 
@@ -46,7 +41,7 @@ export const MicroservicesScreen = withRouteApplicationState(({ routeApplication
             //const applicationsData = values[0] as HttpResponseApplications;
             const applicationData = values[1];
 
-            if (!applicationData?.id) {
+            if (!applicationData.id) {
                 navigate(href);
                 return;
             }
@@ -113,15 +108,14 @@ export const MicroservicesScreen = withRouteApplicationState(({ routeApplication
     //         name: 'View',
     //     },
     // ];
+    {/* <TopNavBar routes={routes} applications={applications} applicationId={currentApplicationId} /> */ }
 
     return (
         <LayoutWithSidebar navigation={nav}>
-            {/* <TopNavBar routes={routes} applications={applications} applicationId={currentApplicationId} /> */}
-
             <Routes>
-                <Route path="/overview" element={<Microservice application={application} />} />
-                <Route path="/create" element={<MicroserviceNewScreen application={application} />} />
-                <Route path="/view/:microserviceId" element={<MicroserviceViewScreen application={application} />} />
+                <Route path='/overview' element={<Microservice application={application} />} />
+                <Route path='/create' element={<MicroserviceNewScreen application={application} />} />
+                <Route path='view/:microserviceId' element={<MicroserviceViewScreen application={application} />} />
                 <Route path='*' element={<RouteNotFound redirectUrl={'overview'} auto={true} />} />
             </Routes>
         </LayoutWithSidebar>

--- a/Source/SelfService/Web/applications/microservicesScreen.tsx
+++ b/Source/SelfService/Web/applications/microservicesScreen.tsx
@@ -4,7 +4,10 @@
 import React, { useEffect, useState } from 'react';
 
 import { Route, useNavigate, Routes, generatePath } from 'react-router-dom';
+import { useSnackbar } from 'notistack';
 import { useGlobalContext } from '../context/globalContext';
+
+import { Typography } from '@mui/material';
 
 import { mergeMicroservicesFromGit, mergeMicroservicesFromK8s } from './stores/microservice';
 
@@ -21,6 +24,7 @@ import { withRouteApplicationState } from '../spaces/applications/withRouteAppli
 
 export const MicroservicesScreen = withRouteApplicationState(({ routeApplicationParams }) => {
     const navigate = useNavigate();
+    const { enqueueSnackbar } = useSnackbar();
     const { hasOneCustomer } = useGlobalContext();
 
     //const [applications, setApplications] = useState({} as ShortInfo[]);
@@ -28,7 +32,6 @@ export const MicroservicesScreen = withRouteApplicationState(({ routeApplication
     const [isLoaded, setIsLoaded] = useState(false);
 
     const currentApplicationId = routeApplicationParams.applicationId;
-    const href = `/problem`;
 
     useEffect(() => {
         if (!currentApplicationId) return;
@@ -42,7 +45,7 @@ export const MicroservicesScreen = withRouteApplicationState(({ routeApplication
             const applicationData = values[1];
 
             if (!applicationData.id) {
-                navigate(href);
+                navigate('/problem');
                 return;
             }
 
@@ -54,18 +57,14 @@ export const MicroservicesScreen = withRouteApplicationState(({ routeApplication
 
             setIsLoaded(true);
         }).catch(() => {
-            // TODO DEV: Remove
-            navigate(href);
-            return;
+            enqueueSnackbar('Failed getting data from the server', { variant: 'error' });
         });
     }, [currentApplicationId]);
 
     if (!isLoaded) return null;
 
-    // TODO DEV: Remove?
     if (application.id === '') {
-        navigate(href);
-        return null;
+        return <Typography variant='h1' my={2}>Application not found</Typography>;
     }
 
     const nav = getMenuWithApplication(navigate, application, hasOneCustomer);

--- a/Source/SelfService/Web/applications/microservicesScreen.tsx
+++ b/Source/SelfService/Web/applications/microservicesScreen.tsx
@@ -3,7 +3,7 @@
 
 import React, { useEffect, useState } from 'react';
 
-import { Route, Routes, useNavigate } from 'react-router-dom';
+import { generatePath, Route, Routes, useNavigate } from 'react-router-dom';
 import { useSnackbar } from 'notistack';
 
 import { Typography } from '@mui/material';
@@ -13,10 +13,11 @@ import { mergeMicroservicesFromGit, mergeMicroservicesFromK8s } from './stores/m
 import { getMicroservices } from '../apis/solutions/api';
 import { getApplicationsListing, getApplication, HttpResponseApplication } from '../apis/solutions/application';
 
+import { WorkSpaceLayoutWithSidePanel } from '../components/layout/workSpaceLayout';
+import { BreadCrumbContainer } from '../components/layout/breadcrumbs';
 import { Microservice } from './microservice/microservices/microservices';
 import { MicroserviceNewScreen } from './microservice/microserviceNewScreen';
 import { MicroserviceViewScreen } from './microservice/microserviceViewScreen';
-import { WorkSpaceLayoutWithSidePanel } from '../components/layout/workSpaceLayout';
 import { RouteNotFound } from '../components/notfound';
 
 import { withRouteApplicationState } from '../spaces/applications/withRouteApplicationState';
@@ -62,8 +63,53 @@ export const MicroservicesScreen = withRouteApplicationState(({ routeApplication
         return <Typography variant='h1' my={2}>Application not found.</Typography>;
     }
 
+    const routes = [
+        {
+            path: '/microservices/application/:applicationId',
+            to: generatePath(
+                '/microservices/application/:applicationId/overview', {
+                applicationId: application.id,
+            }),
+            name: 'Microservices',
+        },
+        {
+            path: '/microservices/application/:applicationId/overview',
+            to: generatePath(
+                '/microservices/application/:applicationId/overview', {
+                applicationId: application.id,
+            }),
+            name: 'Overview',
+        },
+        {
+            path: '/microservices/application/:applicationId/create',
+            to: generatePath(
+                '/microservices/application/:applicationId/create', {
+                applicationId: application.id,
+            }),
+            name: 'Create',
+        },
+        {
+            path: '/microservices/application/:applicationId/edit',
+            to: generatePath(
+                '/microservices/application/:applicationId/edit', {
+                applicationId: application.id,
+            }),
+            name: 'Edit',
+        },
+        {
+            path: '/microservices/application/:applicationId/view/:microserviceId',
+            to: generatePath(
+                // TODO: Needs :microserviceId
+                '/microservices/application/:applicationId/view', {
+                applicationId: application.id,
+            }),
+            name: 'View',
+        },
+    ];
+
     return (
         <WorkSpaceLayoutWithSidePanel pageTitle='Microservices' sidePanelMode='applications'>
+            <BreadCrumbContainer routes={routes} />
             <Routes>
                 <Route path='/overview' element={<Microservice application={application} />} />
                 <Route path='/create' element={<MicroserviceNewScreen application={application} />} />

--- a/Source/SelfService/Web/applications/microservicesScreen.tsx
+++ b/Source/SelfService/Web/applications/microservicesScreen.tsx
@@ -3,7 +3,7 @@
 
 import React, { useEffect, useState } from 'react';
 
-import { generatePath, Route, Routes, useNavigate } from 'react-router-dom';
+import { Route, Routes, useNavigate } from 'react-router-dom';
 import { useSnackbar } from 'notistack';
 
 import { Typography } from '@mui/material';
@@ -14,7 +14,6 @@ import { getMicroservices } from '../apis/solutions/api';
 import { getApplicationsListing, getApplication, HttpResponseApplication } from '../apis/solutions/application';
 
 import { WorkSpaceLayoutWithSidePanel } from '../components/layout/workSpaceLayout';
-import { BreadCrumbContainer } from '../components/layout/breadcrumbs';
 import { Microservice } from './microservice/microservices/microservices';
 import { MicroserviceNewScreen } from './microservice/microserviceNewScreen';
 import { MicroserviceViewScreen } from './microservice/microserviceViewScreen';
@@ -63,53 +62,8 @@ export const MicroservicesScreen = withRouteApplicationState(({ routeApplication
         return <Typography variant='h1' my={2}>Application not found.</Typography>;
     }
 
-    const routes = [
-        {
-            path: '/microservices/application/:applicationId',
-            to: generatePath(
-                '/microservices/application/:applicationId/overview', {
-                applicationId: application.id,
-            }),
-            name: 'Microservices',
-        },
-        {
-            path: '/microservices/application/:applicationId/overview',
-            to: generatePath(
-                '/microservices/application/:applicationId/overview', {
-                applicationId: application.id,
-            }),
-            name: 'Overview',
-        },
-        {
-            path: '/microservices/application/:applicationId/create',
-            to: generatePath(
-                '/microservices/application/:applicationId/create', {
-                applicationId: application.id,
-            }),
-            name: 'Create',
-        },
-        {
-            path: '/microservices/application/:applicationId/edit',
-            to: generatePath(
-                '/microservices/application/:applicationId/edit', {
-                applicationId: application.id,
-            }),
-            name: 'Edit',
-        },
-        {
-            path: '/microservices/application/:applicationId/view/:microserviceId',
-            to: generatePath(
-                // TODO: Needs :microserviceId
-                '/microservices/application/:applicationId/view', {
-                applicationId: application.id,
-            }),
-            name: 'View',
-        },
-    ];
-
     return (
         <WorkSpaceLayoutWithSidePanel pageTitle='Microservices' sidePanelMode='applications'>
-            <BreadCrumbContainer routes={routes} />
             <Routes>
                 <Route path='/overview' element={<Microservice application={application} />} />
                 <Route path='/create' element={<MicroserviceNewScreen application={application} />} />

--- a/Source/SelfService/Web/applications/setup/setupContainerScreen.tsx
+++ b/Source/SelfService/Web/applications/setup/setupContainerScreen.tsx
@@ -60,7 +60,7 @@ export const SetupContainerScreen = ({ application }: SetupContainerScreenProps)
         <Box sx={{ '& a': { color: 'text.primary' }, '& h1': { mt: 4, mb: 2 } }}>
             <Routes>
                 <Route path='/overview' element={
-                    <List sx={{ '& li': { mb: 2 } }}>
+                    <List sx={{ '& li': { my: 2 } }}>
                         <li><Link href={containerRegistryHref} message='Container Registry Info' /></li>
                         <li><Link href={kubernetesAccessHref} message='Verify access to kubernetes' /></li>
                         <li><Link href={azurePipelineHref} message='Setup Azure Pipelines' /></li>
@@ -69,7 +69,7 @@ export const SetupContainerScreen = ({ application }: SetupContainerScreenProps)
 
                 <Route path='/container-registry-info' element={
                     <>
-                        <Button label='Back to setup' startWithIcon='ArrowBack' color='subtle' onClick={handleBackClick} />
+                        <Button label='Back to setup' startWithIcon='ArrowBack' color='subtle' onClick={handleBackClick} sx={{ mt: 2 }} />
                         <Typography variant='h1'>Container Registry Info</Typography>
                         <AccessContainerRegistry info={$info} />
                     </>
@@ -77,7 +77,7 @@ export const SetupContainerScreen = ({ application }: SetupContainerScreenProps)
 
                 <Route path='/verify-kubernetes-access' element={
                     <>
-                        <Button label='Back to setup' startWithIcon='ArrowBack' color='subtle' onClick={handleBackClick} />
+                        <Button label='Back to setup' startWithIcon='ArrowBack' color='subtle' onClick={handleBackClick} sx={{ mt: 2 }} />
                         <Typography variant='h1'>Verify access to kubernetes</Typography>
                         <VerifyKubernetesAccess info={$info} />
                     </>
@@ -85,7 +85,7 @@ export const SetupContainerScreen = ({ application }: SetupContainerScreenProps)
 
                 <Route path='/ci-cd/azure-pipelines' element={
                     <>
-                        <Button label='Back to setup' startWithIcon='ArrowBack' color='subtle' onClick={handleBackClick} />
+                        <Button label='Back to setup' startWithIcon='ArrowBack' color='subtle' onClick={handleBackClick} sx={{ mt: 2 }} />
                         <Typography variant='h1'>Setup Azure Pipelines</Typography>
                         <SetupAzurePipelines info={$info} />
                     </>

--- a/Source/SelfService/Web/components/layout/breadcrumbs.tsx
+++ b/Source/SelfService/Web/components/layout/breadcrumbs.tsx
@@ -2,9 +2,10 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 import React from 'react';
-import { useNavigate, useMatch, Link as RouterLink } from 'react-router-dom';
 
-import { Link, Breadcrumbs, Stack } from '@mui/material';
+import { useMatch, Link as RouterLink } from 'react-router-dom';
+
+import { Link, Breadcrumbs, Toolbar } from '@mui/material';
 import { ChevronRight } from '@mui/icons-material';
 
 const styles = {
@@ -12,7 +13,11 @@ const styles = {
     fontSize: 16,
     lineHeight: '1.25rem',
     color: 'text.primary',
-    textDecoration: 'none'
+    textDecoration: 'none',
+};
+
+type Props = {
+    routes: BreadcrumbsRoute[];
 };
 
 export type BreadcrumbsRoute = {
@@ -21,13 +26,8 @@ export type BreadcrumbsRoute = {
     name: string;
 };
 
-type Props = {
-    routes: BreadcrumbsRoute[]
-};
-
 export const BreadCrumbContainer = (props: Props) => {
-
-    const crumbs = props!.routes.filter((route) => useMatch({path: route.path, end: false}) ? route : false);
+    const crumbs = props!.routes.filter((route) => useMatch({ path: route.path, end: false }) ? route : false);
 
     const breadcrumbs = crumbs.map((item, index) => {
         const links = [
@@ -38,20 +38,20 @@ export const BreadCrumbContainer = (props: Props) => {
                 sx={styles}
             >
                 {item.name}
-            </Link >
+            </Link>
         ];
 
         return links;
     });
 
     return (
-        <Stack spacing={2}>
+        <Toolbar>
             <Breadcrumbs
                 separator={<ChevronRight fontSize="small" sx={{ color: 'rgba(255, 255, 255, 0.38);', }} />}
                 aria-label="breadcrumb"
             >
                 {breadcrumbs}
             </Breadcrumbs>
-        </Stack>
+        </Toolbar>
     );
 };

--- a/Source/SelfService/Web/components/layout/page.tsx
+++ b/Source/SelfService/Web/components/layout/page.tsx
@@ -7,8 +7,6 @@ import { Box, SxProps, Typography } from '@mui/material';
 
 import { StatusIndicator, StatusIndicatorProps } from '@dolittle/design-system';
 
-import { usePageTitle } from '../../utils/usePageTitle';
-
 const styles = {
     display: 'flex',
     alignItems: 'center',
@@ -24,16 +22,11 @@ export type PageProps = {
     sx?: SxProps;
 };
 
-export const Page = ({ title, healthStatus, healthStatusLabel, children, sx }: PageProps) => {
-    usePageTitle(title);
-
-    return (
-        <>
-            <Box sx={{ ...styles, ...sx }}>
-                <Typography variant='h1' sx={{ mr: healthStatus ? 3 : 0 }}>{title}</Typography>
-                {healthStatus && <StatusIndicator status={healthStatus} label={healthStatusLabel} variantFilled />}
-            </Box>
-            {children}
-        </>
-    );
-};
+export const Page = ({ title, healthStatus, healthStatusLabel, children, sx }: PageProps) =>
+    <>
+        <Box sx={{ ...styles, ...sx }}>
+            <Typography variant='h1' sx={{ mr: healthStatus ? 3 : 0 }}>{title}</Typography>
+            {healthStatus && <StatusIndicator status={healthStatus} label={healthStatusLabel} variantFilled />}
+        </Box>
+        {children}
+    </>;

--- a/Source/SelfService/Web/components/layout/workSpaceLayout.tsx
+++ b/Source/SelfService/Web/components/layout/workSpaceLayout.tsx
@@ -3,7 +3,7 @@
 
 import React from 'react';
 
-import { Layout, LayoutProps } from '@dolittle/design-system';
+import { Layout } from '@dolittle/design-system';
 
 import { usePageTitle } from '../../utils/usePageTitle';
 
@@ -12,7 +12,6 @@ import { applicationsSidePanel, integrationsSidePanel, mainNavigationItems } fro
 export type WorkSpaceLayoutProps = {
     pageTitle: string;
     sidePanelMode?: 'applications' | 'integrations';
-    breadcrumbs?: LayoutProps['breadcrumbs'];
     children: React.ReactNode;
 };
 
@@ -26,13 +25,13 @@ export const WorkSpaceLayout = ({ pageTitle, children }: WorkSpaceLayoutProps) =
     );
 };
 
-export const WorkSpaceLayoutWithSidePanel = ({ pageTitle, sidePanelMode, breadcrumbs, children }: WorkSpaceLayoutProps) => {
+export const WorkSpaceLayoutWithSidePanel = ({ pageTitle, sidePanelMode, children }: WorkSpaceLayoutProps) => {
     usePageTitle(pageTitle);
 
     const sidePanelLinks = sidePanelMode === 'applications' ? applicationsSidePanel : integrationsSidePanel;
 
     return (
-        <Layout navigationBar={mainNavigationItems} sidePanel={sidePanelLinks} breadcrumbs={breadcrumbs}>
+        <Layout navigationBar={mainNavigationItems} sidePanel={sidePanelLinks}>
             {children}
         </Layout>
     );

--- a/Source/SelfService/Web/components/layout/workSpaceLayout.tsx
+++ b/Source/SelfService/Web/components/layout/workSpaceLayout.tsx
@@ -5,9 +5,9 @@ import React from 'react';
 
 import { Layout, LayoutProps } from '@dolittle/design-system';
 
-import { usePageTitle } from '../../../utils/usePageTitle';
+import { usePageTitle } from '../../utils/usePageTitle';
 
-import { mainNavigationItems, applicationsSidePanel, integrationsSidePanel } from './workSpaceLayoutLinks';
+import { applicationsSidePanel, integrationsSidePanel, mainNavigationItems } from './workSpaceLayoutLinks';
 
 export type WorkSpaceLayoutProps = {
     pageTitle: string;
@@ -29,12 +29,10 @@ export const WorkSpaceLayout = ({ pageTitle, children }: WorkSpaceLayoutProps) =
 export const WorkSpaceLayoutWithSidePanel = ({ pageTitle, sidePanelMode, breadcrumbs, children }: WorkSpaceLayoutProps) => {
     usePageTitle(pageTitle);
 
+    const sidePanelLinks = sidePanelMode === 'applications' ? applicationsSidePanel : integrationsSidePanel;
+
     return (
-        <Layout
-            navigationBar={mainNavigationItems}
-            sidePanel={sidePanelMode === 'applications' ? applicationsSidePanel : integrationsSidePanel}
-            breadcrumbs={breadcrumbs}
-        >
+        <Layout navigationBar={mainNavigationItems} sidePanel={sidePanelLinks} breadcrumbs={breadcrumbs}>
             {children}
         </Layout>
     );

--- a/Source/SelfService/Web/components/layout/workSpaceLayoutLinks.tsx
+++ b/Source/SelfService/Web/components/layout/workSpaceLayoutLinks.tsx
@@ -5,11 +5,11 @@ import React from 'react';
 
 import { Link, useLocation } from 'react-router-dom';
 
-import { useGlobalContext } from '../../../context/globalContext';
+import { useGlobalContext } from '../../context/globalContext';
 
 import { getPrimaryNavigationItems, getSecondaryNavigationItems, getSidePanelItems, LayoutProps, MenuListProps, MenuItemProps } from '@dolittle/design-system';
 
-import { ApplicationChanger } from '../../../spaces/applications/applicationChanger';
+import { ApplicationChanger } from '../../spaces/applications/applicationChanger';
 
 const PrimaryNavigation = () => {
     const location = useLocation();

--- a/Source/SelfService/Web/components/layout/workSpaceLayoutLinks.tsx
+++ b/Source/SelfService/Web/components/layout/workSpaceLayoutLinks.tsx
@@ -126,6 +126,15 @@ const SidePanelApplicationItems = () => {
                 to: `/logs/application/${currentApplicationId}`,
             },
         },
+        {
+            label: 'Setup',
+            icon: 'FindInPageRounded',
+            sx: { my: 1 },
+            overrides: {
+                component: Link,
+                to: `/documentation/application/${currentApplicationId}/overview`,
+            },
+        },
     ];
 
     return getSidePanelItems(sidePanelItems);

--- a/Source/SelfService/Web/components/layout/workSpaceLayoutLinks.tsx
+++ b/Source/SelfService/Web/components/layout/workSpaceLayoutLinks.tsx
@@ -87,6 +87,7 @@ const SecondaryNavigation = () => {
 };
 
 const SidePanelApplicationItems = () => {
+    const location = useLocation();
     const { currentApplicationId } = useGlobalContext();
 
     const sidePanelItems: MenuListProps['listItems'] = [
@@ -97,6 +98,7 @@ const SidePanelApplicationItems = () => {
             overrides: {
                 component: Link,
                 to: `/microservices/application/${currentApplicationId}/overview`,
+                selected: location.pathname.includes('/microservices'),
             },
         },
         {
@@ -106,6 +108,7 @@ const SidePanelApplicationItems = () => {
             overrides: {
                 component: Link,
                 to: `/backups/application/${currentApplicationId}/overview`,
+                selected: location.pathname.includes('/backups'),
             },
         },
         {
@@ -115,6 +118,7 @@ const SidePanelApplicationItems = () => {
             overrides: {
                 component: Link,
                 to: `/containerregistry/application/${currentApplicationId}/overview`,
+                selected: location.pathname.includes('/containerregistry'),
             },
         },
         {
@@ -124,6 +128,7 @@ const SidePanelApplicationItems = () => {
             overrides: {
                 component: Link,
                 to: `/logs/application/${currentApplicationId}`,
+                selected: location.pathname.includes('/logs'),
             },
         },
         {
@@ -133,6 +138,7 @@ const SidePanelApplicationItems = () => {
             overrides: {
                 component: Link,
                 to: `/documentation/application/${currentApplicationId}/overview`,
+                selected: location.pathname.includes('/documentation'),
             },
         },
     ];
@@ -149,6 +155,7 @@ const SidePanelIntegrationItems = () => {
             overrides: {
                 component: Link,
                 to: '/integrations/connections',
+                selected: location.pathname.includes('/integrations'),
             },
         },
     ];

--- a/Source/SelfService/Web/context/globalContext.tsx
+++ b/Source/SelfService/Web/context/globalContext.tsx
@@ -23,10 +23,12 @@ export type GlobalContextType = {
     lastError: any;
     hasOneCustomer: boolean;
     currentApplicationId: string;
+    currentEnvironment: string;
     setError: (obj: any) => void;
     setNotification: (message: string, level: string) => void;
     clearNotification: () => void;
     setCurrentApplicationId: (applicationId: string) => void;
+    setCurrentEnvironment: (environment: string) => void;
     clearGlobalState: () => void;
 };
 
@@ -44,10 +46,12 @@ export const GlobalContext = createContext<GlobalContextType>({
     lastError: undefined,
     hasOneCustomer: false,
     currentApplicationId: '',
+    currentEnvironment: '',
     setError: (obj) => console.warn('setError function not set'),
     setNotification: (message, level) => { console.log(message, level); },
     clearNotification: () => console.warn('clearNotification function not set'),
     setCurrentApplicationId: (applicationId: string) => console.warn('setCurrentApplicationId function not set'),
+    setCurrentEnvironment: (environment: string) => console.warn('setCurrentEnvironment function not set'),
     clearGlobalState: () => console.warn('clearGlobalState function not set'),
 });
 
@@ -74,6 +78,7 @@ export const GlobalContextProvider = ({ children }: GlobalContextProviderProps) 
 
     const initErrors = getFromLocalStorage('errors', []);
     const initCurrentApplicationId = getFromLocalStorage('currentApplicationId', '');
+    const initCurrentEnvironment = getFromLocalStorage('currentEnvironment', '');
 
     const [messages, setMessages] = useState([] as any[]);
     const [errors, setErrors] = useState(initErrors as any[]);
@@ -81,6 +86,7 @@ export const GlobalContextProvider = ({ children }: GlobalContextProviderProps) 
     const [lastError, setLastError] = useState({} as any);
     const [hasOneCustomer, setHasOneCustomer] = useState(false);
     const [currentApplicationId, _setCurrentApplicationId] = useState(initCurrentApplicationId);
+    const [currentEnvironment, _setCurrentEnvironment] = useState(initCurrentEnvironment);
 
     useEffect(() => {
         getAllCustomers().then(customers =>
@@ -112,6 +118,11 @@ export const GlobalContextProvider = ({ children }: GlobalContextProviderProps) 
         _setCurrentApplicationId(newApplicationId);
     };
 
+    const setCurrentEnvironment = (newEnvironment) => {
+        saveToLocalStorage('currentEnvironment', newEnvironment);
+        _setCurrentEnvironment(newEnvironment);
+    };
+
     const clearNotification = () => {
         const n = newNotification('', '');
         setMessages([]);
@@ -122,6 +133,7 @@ export const GlobalContextProvider = ({ children }: GlobalContextProviderProps) 
         _errors = [];
         _messages = [];
         setCurrentApplicationId('');
+        setCurrentEnvironment('');
         setErrors(_errors);
         setMessages(_messages);
     };
@@ -134,10 +146,12 @@ export const GlobalContextProvider = ({ children }: GlobalContextProviderProps) 
             lastError,
             hasOneCustomer,
             currentApplicationId,
+            currentEnvironment,
             setError,
             setNotification,
             clearNotification,
             setCurrentApplicationId,
+            setCurrentEnvironment,
             clearGlobalState,
         }}>
             {children}

--- a/Source/SelfService/Web/home/homeScreen.tsx
+++ b/Source/SelfService/Web/home/homeScreen.tsx
@@ -5,7 +5,7 @@ import React from 'react';
 
 import { Typography } from '@mui/material';
 
-import { WorkSpaceLayout } from '../components/layout/workSpaceLayout/workSpaceLayout';
+import { WorkSpaceLayout } from '../components/layout/workSpaceLayout';
 import { HomeScreenCardGridItems } from './homeScreenCardGridItems';
 
 export const HomeScreen = () =>

--- a/Source/SelfService/Web/integrations/index.tsx
+++ b/Source/SelfService/Web/integrations/index.tsx
@@ -3,30 +3,27 @@
 
 import React from 'react';
 
-import { useLocation, useRoutes } from 'react-router-dom';
+import { useRoutes } from 'react-router-dom';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 
+import { Box } from '@mui/material';
+
 import { buildQueryClient } from '../apis/integrations/queryClient';
 
-import { integrationsBreadcrumbsNameMap, routes } from './routes';
+import { routes } from './routes';
 
 import { WorkSpaceLayoutWithSidePanel } from '../components/layout/workSpaceLayout';
 import { DebugRouter } from '../components/debugRouter';
 
 export const IntegrationsIndex = () => {
-    const location = useLocation();
     const queryClient = buildQueryClient();
     const routesElement = useRoutes(routes);
 
     return (
-        <WorkSpaceLayoutWithSidePanel
-            pageTitle='Integrations'
-        // breadcrumbs={{
-        //     currentPath: location.pathname,
-        //     breadcrumbsNameMap: integrationsBreadcrumbsNameMap,
-        // }}
-        >
+        <WorkSpaceLayoutWithSidePanel pageTitle='Integrations'>
+            {/* Temporary replacement for breadcrumbs */}
+            <Box sx={{ minHeight: 16 }} />
             <QueryClientProvider client={queryClient}>
                 <DebugRouter>
                     {routesElement}

--- a/Source/SelfService/Web/integrations/index.tsx
+++ b/Source/SelfService/Web/integrations/index.tsx
@@ -11,7 +11,7 @@ import { buildQueryClient } from '../apis/integrations/queryClient';
 
 import { integrationsBreadcrumbsNameMap, routes } from './routes';
 
-import { WorkSpaceLayoutWithSidePanel } from '../components/layout/workSpaceLayout/workSpaceLayout';
+import { WorkSpaceLayoutWithSidePanel } from '../components/layout/workSpaceLayout';
 import { DebugRouter } from '../components/debugRouter';
 
 export const IntegrationsIndex = () => {

--- a/Source/SelfService/Web/utils/helpers/connectionStatuses.ts
+++ b/Source/SelfService/Web/utils/helpers/connectionStatuses.ts
@@ -24,7 +24,7 @@ export const getConnectionStatus = (status: string): StatusIndicatorStatus => {
         };
     }
 
-    return { status: 'unknown' };
+    return { status: 'unknown', label: 'unknown' };
 };
 
 export const getConnectionsStatus = (status?: string): StatusIndicatorStatus => {
@@ -47,7 +47,7 @@ export const getConnectionsStatus = (status?: string): StatusIndicatorStatus => 
             };
         }
     }
-    return { status: 'unknown' };
+    return { status: 'unknown', label: 'unknown' };
 };
 
 export const getPodHealthStatus = (status?: string): StatusIndicatorStatus => {
@@ -71,7 +71,7 @@ export const getPodHealthStatus = (status?: string): StatusIndicatorStatus => {
         }
     }
 
-    return { status: 'unknown' };
+    return { status: 'unknown', label: 'unknown' };
 };
 
 export const getContainerStatus = (status: string[]): StatusIndicatorStatus => {
@@ -94,5 +94,5 @@ export const getContainerStatus = (status: string[]): StatusIndicatorStatus => {
         };
     }
 
-    return { status: 'unknown' };
+    return { status: 'unknown', label: 'unknown' };
 };


### PR DESCRIPTION
## Summary

Replaced Layout with new WorkSpaceLayout.

<img width="1387" alt="Screenshot 2023-08-17 at 19 40 34" src="https://github.com/dolittle/Studio/assets/19160439/062f0776-4835-4f41-868e-3c7b05655e28">

### Added

- Current environment to GlobalContext to be used at the moment in Backups page.
- 'Div' around MicroserviceDetails so content is not in Flex Container.
- 'selected' prop to SidePanel navigation that shows active panel.
- A temporary spacing on the Integrations page that takes 'breadcrumbs' place.

### Changed

- Error handling in pages, when data is not found. Removed navigation to a 'problem' page.
- Link to Setup page in new layout.
- Style improvements for new layout.

### Fixed

- Link to Backups list view.

### Removed

- Breadcrumbs as they were not consistant and useful.

