### PR TITLE
Add 'word-break' styles to LogLine text

### DIFF
--- a/Source/SelfService/Web/applications/logging/logLine.tsx
+++ b/Source/SelfService/Web/applications/logging/logLine.tsx
@@ -2,13 +2,15 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 import React from 'react';
+
 import { Box, Skeleton } from '@mui/material';
+
+import { Button } from '@dolittle/design-system';
+
 import { format } from 'date-fns';
 
 import { ColoredLine, ColoredLineSection, TerminalColor } from './lineParsing';
 import { DataLabels } from './loki/types';
-
-import { Button } from '@dolittle/design-system';
 
 const styles = {
     showCell: {
@@ -33,6 +35,14 @@ const styles = {
         flexShrink: 0,
         textOverflow: 'ellipsis',
         overflow: 'hidden',
+    },
+    textCell: {
+        display: 'flex',
+        alignItems: 'center',
+        flexGrow: 1,
+        wordWrap: 'break-word',
+        whiteSpace: 'pre-wrap',
+        wordBreak: 'break-word',
     },
 };
 
@@ -157,7 +167,7 @@ export const LogLine = ({ line, showContextButton, loading, onClickShowLineConte
                 </SkeletonWhenLoading>
             </Box>
 
-            <Box sx={{ display: 'flex', alignItems: 'center', flexGrow: 1 }}
+            <Box sx={styles.textCell}
                 style={
                     leadingWhitespace > 0 ? {
                         paddingLeft: leadingEmSpace,


### PR DESCRIPTION
## Summary

Fixed log line text that overflowed if long text has no spaces.

<img width="1471" alt="Screenshot 2023-08-22 at 18 27 17" src="https://github.com/dolittle/Studio/assets/19160439/5faea2c1-d450-4628-9428-4d0e46e5b7e1">

