### PR TITLE
Quick filter fields in message mapping table

### DIFF
--- a/Source/DesignSystem/atoms/TextField/TextField.tsx
+++ b/Source/DesignSystem/atoms/TextField/TextField.tsx
@@ -3,7 +3,7 @@
 
 import React from 'react';
 
-import { InputAdornment, SxProps, TextField as MuiTextField } from '@mui/material';
+import { InputAdornment, SxProps, TextField as MuiTextField, TextFieldProps as MuiTextFieldProps } from '@mui/material';
 
 import { Icon, IconProps, SvgIconsDefinition } from '@dolittle/design-system';
 
@@ -84,12 +84,18 @@ export type TextFieldProps = {
     onValueChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
 
     /**
+     * The variant of the `TextField`.
+     * @default 'outlined
+     */
+    variant?: MuiTextFieldProps['variant'];
+
+    /**
      * The sx prop lets you add custom styles to the component, overriding the styles defined by Material-UI.
      */
     sx?: SxProps;
 };
 
-export const TextField = ({ label, value, size = 'small', placeholder, helperText, isDisabled, isFullWidth, startIcon, endIcon, iconColor, onValueChange, sx }: TextFieldProps) =>
+export const TextField = ({ label, value, size = 'small', placeholder, helperText, isDisabled, isFullWidth, startIcon, endIcon, iconColor, onValueChange, variant = 'outlined', sx }: TextFieldProps) =>
     <MuiTextField
         label={label}
         value={value}
@@ -105,7 +111,7 @@ export const TextField = ({ label, value, size = 'small', placeholder, helperTex
                 <TextFieldAdornment position='end' icon={endIcon} color={iconColor ?? 'inherit'} size={size} />
         }}
         onChange={onValueChange}
-        variant='outlined'
+        variant={variant}
         type='text'
         autoComplete='off'
         sx={{ '.MuiOutlinedInput-root': { fontSize: 'inherit' }, ...sx }}

--- a/Source/SelfService/Web/integrations/connection/connectionDetails/messages/changeMessage/components/MessageMappingTable.tsx
+++ b/Source/SelfService/Web/integrations/connection/connectionDetails/messages/changeMessage/components/MessageMappingTable.tsx
@@ -26,6 +26,7 @@ export type MessageMappingTableProps = {
     isLoading: boolean;
     hideUnselectedRows?: boolean;
     onFieldMapped: (m3Field: string, mappedFieldName) => void;
+    quickFilterValue?: string;
 };
 
 export const MessageMappingTable = ({
@@ -35,6 +36,7 @@ export const MessageMappingTable = ({
     disabledRows,
     isLoading,
     onFieldMapped,
+    quickFilterValue
 }: MessageMappingTableProps) => {
     const columns: GridColDef<DataGridTableListingEntry>[] = useMemo(() => [
         {
@@ -168,10 +170,12 @@ export const MessageMappingTable = ({
                 processRowUpdate={processRowUpdate}
                 onProcessRowUpdateError={error => console.log(error)}
                 experimentalFeatures={{ newEditingApi: true }}
+                filterModel={{ items: [], quickFilterValues: [quickFilterValue] }}
                 disableColumnReorder
                 disableColumnResize
                 disableColumnSelector
                 disableSelectionOnClick
+                keepNonExistentRowsSelected
             />
         </Paper>
     );

--- a/Source/SelfService/Web/integrations/connection/connectionDetails/messages/changeMessage/components/MessageMappingTable.tsx
+++ b/Source/SelfService/Web/integrations/connection/connectionDetails/messages/changeMessage/components/MessageMappingTable.tsx
@@ -4,7 +4,7 @@
 import React, { useMemo } from 'react';
 
 import { Box, Paper, Tooltip } from '@mui/material';
-import { DataGridPro, GridColDef, GridSelectionModel, GridRowId, useGridApiRef, GRID_CHECKBOX_SELECTION_COL_DEF } from '@mui/x-data-grid-pro';
+import { DataGridPro, GridColDef, GridSelectionModel, GridRowId, useGridApiRef, GRID_CHECKBOX_SELECTION_FIELD, GRID_CHECKBOX_SELECTION_COL_DEF } from '@mui/x-data-grid-pro';
 
 import { EditCell, EditTextFieldCell } from '@dolittle/design-system';
 
@@ -24,7 +24,7 @@ export type MessageMappingTableProps = {
     onSelectedIdsChanged: (newSelectedIds: GridSelectionModel) => void;
     disabledRows?: GridRowId[];
     isLoading: boolean;
-    hideUnselectedRows?: boolean;
+    showOnlySelected?: boolean;
     onFieldMapped: (m3Field: string, mappedFieldName) => void;
     quickFilterValue?: string;
 };
@@ -36,6 +36,7 @@ export const MessageMappingTable = ({
     disabledRows,
     isLoading,
     onFieldMapped,
+    showOnlySelected,
     quickFilterValue
 }: MessageMappingTableProps) => {
     const columns: GridColDef<DataGridTableListingEntry>[] = useMemo(() => [
@@ -73,6 +74,19 @@ export const MessageMappingTable = ({
             renderEditCell: EditTextFieldCell,
         },
     ], [disabledRows]);
+
+    const gridFilters = useMemo(() => {
+        return {
+            items: showOnlySelected ? [
+                {
+                    columnField: GRID_CHECKBOX_SELECTION_FIELD,
+                    operatorValue: 'is',
+                    value: 'true',
+                }
+            ] : [],
+            quickFilterValues: [quickFilterValue?.trim() || undefined]
+        };
+    }, [quickFilterValue, showOnlySelected]);
 
     const gridApiRef = useGridApiRef();
 
@@ -170,7 +184,7 @@ export const MessageMappingTable = ({
                 processRowUpdate={processRowUpdate}
                 onProcessRowUpdateError={error => console.log(error)}
                 experimentalFeatures={{ newEditingApi: true }}
-                filterModel={{ items: [], quickFilterValues: [quickFilterValue] }}
+                filterModel={gridFilters}
                 disableColumnReorder
                 disableColumnResize
                 disableColumnSelector

--- a/Source/SelfService/Web/integrations/connection/connectionDetails/messages/changeMessage/components/TableSection.tsx
+++ b/Source/SelfService/Web/integrations/connection/connectionDetails/messages/changeMessage/components/TableSection.tsx
@@ -6,7 +6,7 @@ import React, { useState, useMemo, useEffect } from 'react';
 import { Grid, LinearProgress, Box } from '@mui/material';
 import { GridSelectionModel } from '@mui/x-data-grid-pro';
 
-import { AlertBox, Button, ContentSection, NewSwitch, Switch, TextField } from '@dolittle/design-system/';
+import { AlertBox, Button, ContentSection, NewSwitch, TextField } from '@dolittle/design-system/';
 
 import { FieldMapping, MappedField } from '../../../../../../apis/integrations/generated';
 import { useConnectionsIdMessageMappingsTablesTableGet } from '../../../../../../apis/integrations/mappableTablesApi.hooks';
@@ -75,11 +75,6 @@ export const TableSection = ({ selectedTableName, initialSelectedFields, onBackT
         [allMappableTableColumns, mappedFields]
     );
 
-    const selectedTableColumns = useMemo(
-        () => gridMappableTableColumns.filter(column => selectedIds.includes(column.m3ColumnName)),
-        [gridMappableTableColumns, selectedIds]
-    );
-
     const updateMappedFieldsAndUpdateFormValue = (m3Field: string, mappedFieldName: any) => {
         setMappedFields(prevMappedFields => {
             const newMappedFields = new Map(prevMappedFields);
@@ -140,13 +135,14 @@ export const TableSection = ({ selectedTableName, initialSelectedFields, onBackT
                                 />
                             </Grid>
                             <MessageMappingTable
-                                dataGridListing={hideUnselectedRows ? selectedTableColumns : gridMappableTableColumns}
+                                dataGridListing={gridMappableTableColumns}
                                 isLoading={isLoading}
                                 selectedIds={selectedIds}
                                 disabledRows={requiredTableColumnIds}
                                 onSelectedIdsChanged={setSelectedRowIds}
                                 onFieldMapped={updateMappedFieldsAndUpdateFormValue}
                                 quickFilterValue={fieldSearchTerm}
+                                showOnlySelected={!hideUnselectedRows}
                             />
                         </>
                     )}

--- a/Source/SelfService/Web/integrations/connection/connectionDetails/messages/changeMessage/components/TableSection.tsx
+++ b/Source/SelfService/Web/integrations/connection/connectionDetails/messages/changeMessage/components/TableSection.tsx
@@ -126,6 +126,7 @@ export const TableSection = ({ selectedTableName, initialSelectedFields, onBackT
                                     variant='outlined'
                                     placeholder='Search fields'
                                     onValueChange={(event) => setFieldSearchTerm(event.target.value)}
+                                    sx={{ flexGrow: 1 }}
                                 />
                                 <NewSwitch
                                     id='hideUnselectedRows'

--- a/Source/SelfService/Web/integrations/connection/connectionDetails/messages/changeMessage/components/TableSection.tsx
+++ b/Source/SelfService/Web/integrations/connection/connectionDetails/messages/changeMessage/components/TableSection.tsx
@@ -6,7 +6,7 @@ import React, { useState, useMemo, useEffect } from 'react';
 import { Grid, LinearProgress, Box } from '@mui/material';
 import { GridSelectionModel } from '@mui/x-data-grid-pro';
 
-import { AlertBox, Button, ContentSection, Switch } from '@dolittle/design-system/';
+import { AlertBox, Button, ContentSection, NewSwitch, Switch, TextField } from '@dolittle/design-system/';
 
 import { FieldMapping, MappedField } from '../../../../../../apis/integrations/generated';
 import { useConnectionsIdMessageMappingsTablesTableGet } from '../../../../../../apis/integrations/mappableTablesApi.hooks';
@@ -125,7 +125,7 @@ export const TableSection = ({ selectedTableName, initialSelectedFields, onBackT
                                 You can remap the M3 Description by adding a remapped name that makes sense for your organization’s business logic. `}
                             </Box>
                             <Grid container gap={2} sx={{ py: 3, justifyContent: 'flex-end', alignContent: 'flex-end' }}>
-                                <Switch.UI
+                                <NewSwitch
                                     id='hideUnselectedRows'
                                     label='Hide Unselected Rows'
                                     checked={hideUnselectedRows}

--- a/Source/SelfService/Web/integrations/connection/connectionDetails/messages/changeMessage/components/TableSection.tsx
+++ b/Source/SelfService/Web/integrations/connection/connectionDetails/messages/changeMessage/components/TableSection.tsx
@@ -26,6 +26,7 @@ export type TableSectionProps = ViewModeProps & {
 export const TableSection = ({ selectedTableName, initialSelectedFields, onBackToSearchResultsClicked, mode }: TableSectionProps) => {
     const connectionId = useConnectionIdFromRoute();
     const setMappedFieldsInForm = useUpdateMappedFieldsInForm();
+    const [fieldSearchTerm, setFieldSearchTerm] = useState('');
 
     if (!selectedTableName) return <AlertBox />;
 
@@ -124,7 +125,13 @@ export const TableSection = ({ selectedTableName, initialSelectedFields, onBackT
                                 {`This displays all the M3 fields available for this table. Primary fields are necessary for the message type and have already been selected.
                                 You can remap the M3 Description by adding a remapped name that makes sense for your organization’s business logic. `}
                             </Box>
-                            <Grid container gap={2} sx={{ py: 3, justifyContent: 'flex-end', alignContent: 'flex-end' }}>
+                            <Grid container gap={4} sx={{ py: 3, justifyContent: 'flex-end', justifyItems: 'center', }}>
+                                <TextField
+                                    startIcon='Search'
+                                    variant='standard'
+                                    placeholder='Search fields'
+                                    onValueChange={(event) => setFieldSearchTerm(event.target.value)}
+                                />
                                 <NewSwitch
                                     id='hideUnselectedRows'
                                     label='Hide Unselected Rows'
@@ -139,6 +146,7 @@ export const TableSection = ({ selectedTableName, initialSelectedFields, onBackT
                                 disabledRows={requiredTableColumnIds}
                                 onSelectedIdsChanged={setSelectedRowIds}
                                 onFieldMapped={updateMappedFieldsAndUpdateFormValue}
+                                quickFilterValue={fieldSearchTerm}
                             />
                         </>
                     )}

--- a/Source/SelfService/Web/integrations/connection/connectionDetails/messages/changeMessage/components/TableSection.tsx
+++ b/Source/SelfService/Web/integrations/connection/connectionDetails/messages/changeMessage/components/TableSection.tsx
@@ -125,10 +125,10 @@ export const TableSection = ({ selectedTableName, initialSelectedFields, onBackT
                                 {`This displays all the M3 fields available for this table. Primary fields are necessary for the message type and have already been selected.
                                 You can remap the M3 Description by adding a remapped name that makes sense for your organization’s business logic. `}
                             </Box>
-                            <Grid container gap={4} sx={{ py: 3, justifyContent: 'flex-end', justifyItems: 'center', }}>
+                            <Grid container gap={4} sx={{ py: 3, justifyContent: 'space-between', justifyItems: 'center', }}>
                                 <TextField
                                     startIcon='Search'
-                                    variant='standard'
+                                    variant='outlined'
                                     placeholder='Search fields'
                                     onValueChange={(event) => setFieldSearchTerm(event.target.value)}
                                 />


### PR DESCRIPTION
## Summary
- Add support for quick filtering of the table fields
- Move responsibility of filtering selected to the grid itself to trigger item count correctly
