### PR TITLE
Fix switch to hide unselected rows in the message mapping table

### DIFF
--- a/Source/DesignSystem/atoms/Forms/Switch.stories.tsx
+++ b/Source/DesignSystem/atoms/Forms/Switch.stories.tsx
@@ -9,9 +9,9 @@ import { Form, Switch } from './';
 const { metadata, createStory } = componentStories(Switch, {
     actions: { onChange: 'Changed' },
     decorator: (Story) => (
-        <Form<{ default: string }>
+        <Form<{ default: boolean }>
             initialValues={{
-                default: '',
+                default: false,
             }}
         >
             {Story()}
@@ -43,3 +43,14 @@ metadata.args = {
 export default metadata;
 
 export const Default = createStory();
+
+export const DefaultOn = createStory();
+DefaultOn.decorators = [(Story) => (
+    <Form<{ default: boolean }>
+        initialValues={{
+            default: true,
+        }}
+    >
+        {Story()}
+    </Form>
+)];

--- a/Source/DesignSystem/atoms/Switch/Switch.stories.tsx
+++ b/Source/DesignSystem/atoms/Switch/Switch.stories.tsx
@@ -29,3 +29,8 @@ metadata.args = {
 export default metadata;
 
 export const Default = createStory();
+
+export const DefaultOn = createStory({
+    label: 'Default on switch',
+    checked: true,
+});

--- a/Source/DesignSystem/atoms/Switch/Switch.tsx
+++ b/Source/DesignSystem/atoms/Switch/Switch.tsx
@@ -37,5 +37,5 @@ export type SwitchProps = {
  * @param {SwitchProps} props - The {@link SwitchProps}.
  * @returns A {@link NewSwitch} component.
  */
-export const NewSwitch = ({ label, size, isDisabled, onChange }: SwitchProps) =>
-    <FormControlLabel label={label} control={<MuiSwitch size={size ? size : 'small'} disabled={isDisabled} onChange={onChange} />} />;
+export const NewSwitch = ({ label, size, isDisabled, onChange, ...switchProps }: SwitchProps) =>
+    <FormControlLabel label={label} control={<MuiSwitch size={size ? size : 'small'} disabled={isDisabled} onChange={onChange} {...switchProps} />} />;

--- a/Source/SelfService/Web/integrations/connection/connectionDetails/messages/changeMessage/components/TableSection.tsx
+++ b/Source/SelfService/Web/integrations/connection/connectionDetails/messages/changeMessage/components/TableSection.tsx
@@ -143,7 +143,7 @@ export const TableSection = ({ selectedTableName, initialSelectedFields, onBackT
                                 onSelectedIdsChanged={setSelectedRowIds}
                                 onFieldMapped={updateMappedFieldsAndUpdateFormValue}
                                 quickFilterValue={fieldSearchTerm}
-                                showOnlySelected={!hideUnselectedRows}
+                                showOnlySelected={hideUnselectedRows}
                             />
                         </>
                     )}


### PR DESCRIPTION
## Summary
- Fix wrongly inverted boolean being passed into the switch to hide unselected rows in the message mapping table
- [DesignSystem]/NewSwitch] - Fix 'NewSwitch" and pass the props to the component - alternatively, we should pass in only 'checked.'

