### PR TITLE
Switched service listings to use new endpoint with pod status included

### DIFF
--- a/Source/SelfService/Web/apis/solutions/api.ts
+++ b/Source/SelfService/Web/apis/solutions/api.ts
@@ -39,7 +39,7 @@ export type MicroserviceObject = {
     name: string;
     kind: string;
     environment: string;
-    live: MicroserviceInfo;
+    live: MicroserviceInfoWithPods;
     edit: MicroserviceSimple;
 };
 

--- a/Source/SelfService/Web/applications/logging/index.tsx
+++ b/Source/SelfService/Web/applications/logging/index.tsx
@@ -8,7 +8,11 @@ import { useSnackbar } from 'notistack';
 
 import { Box, Typography } from '@mui/material';
 
-import { HttpResponseMicroservices, getMicroservices } from '../../apis/solutions/api';
+import {
+    HttpResponseMicroservices,
+    getMicroservices,
+    HttpResponseMicroservicesWithPods, getMicroservicesWithPods
+} from '../../apis/solutions/api';
 import { HttpResponseApplication, getApplication } from '../../apis/solutions/application';
 
 import { mergeMicroservicesFromGit, mergeMicroservicesFromK8s } from '../stores/microservice';
@@ -59,7 +63,7 @@ export const LogsIndex = withRouteApplicationState(({ routeApplicationParams }) 
 
         Promise.all([
             getApplication(currentApplicationId),
-            getMicroservices(currentApplicationId),
+            getMicroservicesWithPods(currentApplicationId),
         ]).then(values => {
             const applicationData = values[0];
 
@@ -72,7 +76,7 @@ export const LogsIndex = withRouteApplicationState(({ routeApplicationParams }) 
             setApplication(applicationData);
             mergeMicroservicesFromGit(applicationData.microservices);
 
-            const microservicesData = values[1] as HttpResponseMicroservices;
+            const microservicesData = values[1] as HttpResponseMicroservicesWithPods;
 
             mergeMicroservicesFromK8s(microservicesData.microservices);
             setIsLoaded(true);

--- a/Source/SelfService/Web/applications/microservice/index.tsx
+++ b/Source/SelfService/Web/applications/microservice/index.tsx
@@ -10,7 +10,7 @@ import { Typography } from '@mui/material';
 
 import { mergeMicroservicesFromGit, mergeMicroservicesFromK8s } from '../stores/microservice';
 
-import { getMicroservices } from '../../apis/solutions/api';
+import { getMicroservices, getMicroservicesWithPods } from '../../apis/solutions/api';
 import { getApplication, HttpResponseApplication } from '../../apis/solutions/application';
 
 import { WorkSpaceLayoutWithSidePanel } from '../../layout/workSpaceLayout';
@@ -39,7 +39,7 @@ export const MicroservicesIndex = withRouteApplicationState(({ routeApplicationP
 
         Promise.all([
             getApplication(currentApplicationId),
-            getMicroservices(currentApplicationId),
+            getMicroservicesWithPods(currentApplicationId),
         ]).then(values => {
             const applicationData = values[0];
 

--- a/Source/SelfService/Web/applications/microservice/microserviceDetails/index.tsx
+++ b/Source/SelfService/Web/applications/microservice/microserviceDetails/index.tsx
@@ -10,9 +10,10 @@ import { Typography } from '@mui/material';
 
 import { HttpResponseApplication } from '../../../apis/solutions/application';
 
-import { microservices, MicroserviceStore } from '../../stores/microservice';
+import { microservices } from '../../stores/microservice';
 
 import { MicroserviceViewIndex } from './microserviceView';
+import { MicroserviceObject } from '../../../apis/solutions/api';
 
 export type MicroserviceDetailsIndexProps = {
     application: HttpResponseApplication;
@@ -23,7 +24,7 @@ export const MicroserviceDetailsIndex = ({ application }: MicroserviceDetailsInd
     const $microservices = useReadable(microservices) as any;
     const { microserviceId, environment } = useParams() as any;
 
-    const currentMicroservice: MicroserviceStore = $microservices.find((microservice: MicroserviceStore) =>
+    const currentMicroservice: MicroserviceObject = $microservices.find((microservice: MicroserviceObject) =>
         microservice.id === microserviceId && microservice.environment === environment
     );
 
@@ -53,7 +54,7 @@ export const MicroserviceDetailsIndex = ({ application }: MicroserviceDetailsInd
     }
 };
 
-function whichSubView(currentMicroservice: MicroserviceStore): string {
+function whichSubView(currentMicroservice: MicroserviceObject): string {
     // Today we try and map subviews based on kind, its not perfect
     let kind = currentMicroservice.kind;
 

--- a/Source/SelfService/Web/applications/microservice/microserviceDetails/microserviceView/configuration/Configurations.tsx
+++ b/Source/SelfService/Web/applications/microservice/microserviceDetails/microserviceView/configuration/Configurations.tsx
@@ -10,10 +10,10 @@ import { Box } from '@mui/material';
 
 import { AlertDialog, Button, Form, LoadingSpinnerFullPage } from '@dolittle/design-system';
 
-import { canDeleteMicroservice, deleteMicroserviceWithStore, editMicroserviceWithStore, MicroserviceStore } from '../../../../stores/microservice';
+import { canDeleteMicroservice, deleteMicroserviceWithStore, editMicroserviceWithStore } from '../../../../stores/microservice';
 
 import { HttpResponseApplication } from '../../../../../apis/solutions/application';
-import { InputEditMicroservice } from '../../../../../apis/solutions/api';
+import { InputEditMicroservice, MicroserviceObject } from '../../../../../apis/solutions/api';
 import { MicroserviceFormParameters } from '../../../../../apis/solutions/index';
 
 import { ContainerImageFields } from '../../../components/form/containerImageFields';
@@ -26,7 +26,7 @@ import { getMicroserviceInfo } from '../../../utils/getMicroserviceInfo';
 
 export type ConfigurationsIndexProps = {
     application: HttpResponseApplication;
-    currentMicroservice: MicroserviceStore;
+    currentMicroservice: MicroserviceObject;
 };
 
 export const ConfigurationsIndex = ({ application, currentMicroservice }: ConfigurationsIndexProps) => {

--- a/Source/SelfService/Web/applications/microservice/microserviceDetails/microserviceView/configuration/configurationFiles/index.tsx
+++ b/Source/SelfService/Web/applications/microservice/microserviceDetails/microserviceView/configuration/configurationFiles/index.tsx
@@ -9,9 +9,14 @@ import { GridSelectionModel } from '@mui/x-data-grid-pro';
 
 import { Accordion, FileUploadForm, FileUploadFormRef } from '@dolittle/design-system';
 
-import { MicroserviceStore } from '../../../../../stores/microservice';
 
-import { getConfigFilesNamesList, getServerUrlPrefix, updateConfigFile, deleteConfigFile } from '../../../../../../apis/solutions/api';
+import {
+    getConfigFilesNamesList,
+    getServerUrlPrefix,
+    updateConfigFile,
+    deleteConfigFile,
+    MicroserviceObject
+} from '../../../../../../apis/solutions/api';
 
 import { isAlphaNumeric } from '../../../../../../utils/helpers';
 
@@ -28,7 +33,7 @@ const MAX_CONFIGMAP_ENTRY_SIZE = 3145728;
 
 export type ConfigurationFilesIndexProps = {
     applicationId: string;
-    currentMicroservice: MicroserviceStore;
+    currentMicroservice: MicroserviceObject;
 };
 
 export const ConfigurationFilesIndex = ({ applicationId, currentMicroservice }: ConfigurationFilesIndexProps) => {

--- a/Source/SelfService/Web/applications/microservice/microserviceDetails/microserviceView/configuration/environmentVariable/index.tsx
+++ b/Source/SelfService/Web/applications/microservice/microserviceDetails/microserviceView/configuration/environmentVariable/index.tsx
@@ -5,14 +5,18 @@ import React, { useEffect, useState } from 'react';
 
 import { useSnackbar } from 'notistack';
 
-import { MicroserviceStore } from '../../../../../stores/microservice';
-
 import { GridRowId, GridRowModesModel, GridRowModes, GridRowModel } from '@mui/x-data-grid-pro';
 import { Box } from '@mui/material';
 
 import { Accordion, Button } from '@dolittle/design-system';
 
-import { getEnvironmentVariables, getServerUrlPrefix, InputEnvironmentVariable, updateEnvironmentVariables } from '../../../../../../apis/solutions/api';
+import {
+    getEnvironmentVariables,
+    getServerUrlPrefix,
+    InputEnvironmentVariable,
+    MicroserviceObject,
+    updateEnvironmentVariables
+} from '../../../../../../apis/solutions/api';
 
 import { EmptyDataTable } from '../../../../components/emptyDataTable';
 import { DataGrid, EnvironmentVariableTableRowParams } from './DataGrid';
@@ -30,7 +34,7 @@ const styles = {
 
 export type EnvironmentVariableIndexProps = {
     applicationId: string;
-    currentMicroservice: MicroserviceStore;
+    currentMicroservice: MicroserviceObject;
 };
 
 export const EnvironmentVariableIndex = ({ applicationId, currentMicroservice }: EnvironmentVariableIndexProps) => {

--- a/Source/SelfService/Web/applications/microservice/microserviceDetails/microserviceView/configuration/index.tsx
+++ b/Source/SelfService/Web/applications/microservice/microserviceDetails/microserviceView/configuration/index.tsx
@@ -5,15 +5,15 @@ import React from 'react';
 
 import { HttpResponseApplication } from '../../../../../apis/solutions/application';
 
-import { MicroserviceStore } from '../../../../stores/microservice';
 
 import { ConfigurationsIndex } from './Configurations';
 import { ConfigurationFilesIndex } from './configurationFiles';
 import { EnvironmentVariableIndex } from './environmentVariable';
+import { MicroserviceObject } from '../../../../../apis/solutions/api';
 
 export type ConfigurationIndexProps = {
     application: HttpResponseApplication;
-    currentMicroservice: MicroserviceStore;
+    currentMicroservice: MicroserviceObject;
 };
 
 export const ConfigurationIndex = ({ application, currentMicroservice }: ConfigurationIndexProps) => (

--- a/Source/SelfService/Web/applications/microservice/microserviceDetails/microserviceView/healthStatus/index.tsx
+++ b/Source/SelfService/Web/applications/microservice/microserviceDetails/microserviceView/healthStatus/index.tsx
@@ -3,11 +3,10 @@
 
 import React, { useMemo, useState } from 'react';
 
-import { MicroserviceStore } from '../../../../stores/microservice';
 
 import { AlertBox, AlertBoxErrorMessage, Button, Graph } from '@dolittle/design-system';
 
-import { ContainerStatusInfo, HttpResponsePodStatus } from '../../../../../apis/solutions/api';
+import { ContainerStatusInfo, HttpResponsePodStatus, MicroserviceObject } from '../../../../../apis/solutions/api';
 
 import { Metric, useMetricsFromLast } from '../../../../metrics/useMetrics';
 import { HealthStatusDataGrid, HealthStatusTableStats } from './HealthStatusDataGrid';
@@ -25,7 +24,7 @@ const computeStats = (metric: Metric | undefined, scale: number): HealthStatusTa
 
 export type HealthStatusIndexProps = {
     applicationId: string;
-    currentMicroservice: MicroserviceStore;
+    currentMicroservice: MicroserviceObject;
 };
 
 export const HealthStatusIndex = ({ applicationId, currentMicroservice }: HealthStatusIndexProps) => {

--- a/Source/SelfService/Web/applications/microservice/microserviceDetails/microserviceView/healthStatus/index.tsx
+++ b/Source/SelfService/Web/applications/microservice/microserviceDetails/microserviceView/healthStatus/index.tsx
@@ -26,10 +26,9 @@ const computeStats = (metric: Metric | undefined, scale: number): HealthStatusTa
 export type HealthStatusIndexProps = {
     applicationId: string;
     currentMicroservice: MicroserviceStore;
-    data: HttpResponsePodStatus;
 };
 
-export const HealthStatusIndex = ({ applicationId, currentMicroservice, data }: HealthStatusIndexProps) => {
+export const HealthStatusIndex = ({ applicationId, currentMicroservice }: HealthStatusIndexProps) => {
     const [restartDialogIsOpen, setRestartDialogIsOpen] = useState(false);
 
     const microserviceId = currentMicroservice.id;
@@ -39,7 +38,7 @@ export const HealthStatusIndex = ({ applicationId, currentMicroservice, data }: 
     const cpu = useMetricsFromLast(`microservice:container_cpu_usage_seconds:rate_max{application_id="${applicationId}", environment="${microserviceEnvironment}", microservice_id="${microserviceId}"}`, 86_400, 60);
     const memory = useMetricsFromLast(`microservice:container_memory_working_set_bytes:max{application_id="${applicationId}", environment="${microserviceEnvironment}", microservice_id="${microserviceId}"}`, 86_400, 60);
 
-    const containerTables = data.pods?.map(pod => {
+    const containerTables = currentMicroservice.live.pods?.map(pod => {
         const rows = pod.containers.map((container: ContainerStatusInfo) => {
             const containerCPU = cpu.metrics.find(_ => _.labels.container === container.name);
             const containerMemory = memory.metrics.find(_ => _.labels.container === container.name);

--- a/Source/SelfService/Web/applications/microservice/microserviceDetails/microserviceView/index.tsx
+++ b/Source/SelfService/Web/applications/microservice/microserviceDetails/microserviceView/index.tsx
@@ -1,13 +1,11 @@
 // Copyright (c) Aigonix. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 
 import { Tabs } from '@dolittle/design-system';
 
-import { MicroserviceStore } from '../../../stores/microservice';
-
-import { getPodStatus, HttpResponsePodStatus } from '../../../../apis/solutions/api';
+import { getPodStatus, HttpResponsePodStatus, MicroserviceObject } from '../../../../apis/solutions/api';
 import { HttpResponseApplication } from '../../../../apis/solutions/application';
 
 import { PageTitle } from '../../../../layout/PageTitle';
@@ -29,21 +27,15 @@ const initialPodsData: HttpResponsePodStatus = {
 
 export type MicroserviceViewIndexProps = {
     application: HttpResponseApplication;
-    currentMicroservice: MicroserviceStore;
+    currentMicroservice: MicroserviceObject;
 };
 
 export const MicroserviceViewIndex = ({ application, currentMicroservice }: MicroserviceViewIndexProps) => {
-    // const [podsData, setPodsData] = useState(initialPodsData);
 
     const applicationId = application.id;
     const microserviceId = currentMicroservice.id;
     const microserviceEnvironment = currentMicroservice.environment;
     const microserviceName = currentMicroservice.name;
-
-    // useEffect(() => {
-    //     Promise.all([getPodStatus(applicationId, microserviceEnvironment, microserviceId)])
-    //         .then(values => setPodsData(values[0]));
-    // }, []);
 
     const getLastOpenTab = parseInt(sessionStorage.getItem('microservice-details-tabs') || '0');
     const podsStatuses = () => currentMicroservice.live.pods.flatMap(pod => pod.containers.map(container => container.state));

--- a/Source/SelfService/Web/applications/microservice/microserviceDetails/microserviceView/index.tsx
+++ b/Source/SelfService/Web/applications/microservice/microserviceDetails/microserviceView/index.tsx
@@ -33,20 +33,20 @@ export type MicroserviceViewIndexProps = {
 };
 
 export const MicroserviceViewIndex = ({ application, currentMicroservice }: MicroserviceViewIndexProps) => {
-    const [podsData, setPodsData] = useState(initialPodsData);
+    // const [podsData, setPodsData] = useState(initialPodsData);
 
     const applicationId = application.id;
     const microserviceId = currentMicroservice.id;
     const microserviceEnvironment = currentMicroservice.environment;
     const microserviceName = currentMicroservice.name;
 
-    useEffect(() => {
-        Promise.all([getPodStatus(applicationId, microserviceEnvironment, microserviceId)])
-            .then(values => setPodsData(values[0]));
-    }, []);
+    // useEffect(() => {
+    //     Promise.all([getPodStatus(applicationId, microserviceEnvironment, microserviceId)])
+    //         .then(values => setPodsData(values[0]));
+    // }, []);
 
     const getLastOpenTab = parseInt(sessionStorage.getItem('microservice-details-tabs') || '0');
-    const podsStatuses = () => podsData.pods.flatMap(pod => pod.containers.map(container => container.state));
+    const podsStatuses = () => currentMicroservice.live.pods.flatMap(pod => pod.containers.map(container => container.state));
     const microserviceHealthStatus = getContainerStatus(podsStatuses());
 
     const tabs = [
@@ -56,7 +56,7 @@ export const MicroserviceViewIndex = ({ application, currentMicroservice }: Micr
         },
         {
             label: 'Health Status',
-            render: () => <HealthStatusIndex applicationId={applicationId} currentMicroservice={currentMicroservice} data={podsData} />
+            render: () => <HealthStatusIndex applicationId={applicationId} currentMicroservice={currentMicroservice} />
         },
     ];
 

--- a/Source/SelfService/Web/applications/microservice/microservicesOverview/microservicesList/MicroservicesList.tsx
+++ b/Source/SelfService/Web/applications/microservice/microservicesOverview/microservicesList/MicroservicesList.tsx
@@ -11,11 +11,10 @@ import { MicroserviceObject } from '../../../../apis/solutions/api';
 import { HttpResponseApplication } from '../../../../apis/solutions/application';
 
 import { MicroservicesDataGrid } from './microservicesDataGrid';
-import { MicroserviceStore } from '../../../stores/microservice';
 
 export type MicroservicesViewProps = {
     application: HttpResponseApplication;
-    microservices: MicroserviceStore[];
+    microservices: MicroserviceObject[];
 };
 
 export const MicroservicesList = ({ application, microservices }: MicroservicesViewProps) => {

--- a/Source/SelfService/Web/applications/microservice/microservicesOverview/microservicesList/MicroservicesList.tsx
+++ b/Source/SelfService/Web/applications/microservice/microservicesOverview/microservicesList/MicroservicesList.tsx
@@ -11,10 +11,11 @@ import { MicroserviceObject } from '../../../../apis/solutions/api';
 import { HttpResponseApplication } from '../../../../apis/solutions/application';
 
 import { MicroservicesDataGrid } from './microservicesDataGrid';
+import { MicroserviceStore } from '../../../stores/microservice';
 
 export type MicroservicesViewProps = {
     application: HttpResponseApplication;
-    microservices: MicroserviceObject[];
+    microservices: MicroserviceStore[];
 };
 
 export const MicroservicesList = ({ application, microservices }: MicroservicesViewProps) => {

--- a/Source/SelfService/Web/applications/microservice/microservicesOverview/microservicesList/microservicesDataGrid.tsx
+++ b/Source/SelfService/Web/applications/microservice/microservicesOverview/microservicesList/microservicesDataGrid.tsx
@@ -15,10 +15,11 @@ import { HttpResponseApplication } from '../../../../apis/solutions/application'
 import { microservicesDataGridColumns } from './microservicesDataGridColumns';
 
 import { getMicroserviceInfo } from '../../utils/getMicroserviceInfo';
+import { MicroserviceStore } from '../../../stores/microservice';
 
 export type MicroservicesDataGridProps = {
     application: HttpResponseApplication;
-    microservices: MicroserviceObject[];
+    microservices: MicroserviceStore[];
 };
 
 export const MicroservicesDataGrid = ({ application, microservices }: MicroservicesDataGridProps) => {
@@ -32,12 +33,12 @@ export const MicroservicesDataGrid = ({ application, microservices }: Microservi
 
         Promise.all(microservices.map(async microservice => {
             const microserviceInfo = getMicroserviceInfo(application, microservice);
-            const status = await getMicroserviceStatus(microservice.id, microservice.environment);
+            // const status = await getMicroserviceStatus(microservice.id, microservice.environment);
 
             return {
                 ...microservice,
                 edit: microserviceInfo,
-                phase: status[0]?.phase,
+                phase: microservice.live.phase,
             } as MicroserviceObject;
         })).then(setMicroserviceRows)
             .finally(() => setIsLoading(false));

--- a/Source/SelfService/Web/applications/microservice/microservicesOverview/microservicesList/microservicesDataGrid.tsx
+++ b/Source/SelfService/Web/applications/microservice/microservicesOverview/microservicesList/microservicesDataGrid.tsx
@@ -15,11 +15,10 @@ import { HttpResponseApplication } from '../../../../apis/solutions/application'
 import { microservicesDataGridColumns } from './microservicesDataGridColumns';
 
 import { getMicroserviceInfo } from '../../utils/getMicroserviceInfo';
-import { MicroserviceStore } from '../../../stores/microservice';
 
 export type MicroservicesDataGridProps = {
     application: HttpResponseApplication;
-    microservices: MicroserviceStore[];
+    microservices: MicroserviceObject[];
 };
 
 export const MicroservicesDataGrid = ({ application, microservices }: MicroservicesDataGridProps) => {

--- a/Source/SelfService/Web/applications/microservice/utils/getMicroserviceInfo.ts
+++ b/Source/SelfService/Web/applications/microservice/utils/getMicroserviceInfo.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Aigonix. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-import { canEditMicroservice, MicroserviceStore } from '../../stores/microservice';
+import { canEditMicroservice } from '../../stores/microservice';
 
 import { MicroserviceSimple } from '../../../apis/solutions/index';
 import { HttpResponseApplication } from '../../../apis/solutions/application';

--- a/Source/SelfService/Web/applications/microservice/utils/getMicroserviceInfo.ts
+++ b/Source/SelfService/Web/applications/microservice/utils/getMicroserviceInfo.ts
@@ -5,9 +5,10 @@ import { canEditMicroservice, MicroserviceStore } from '../../stores/microservic
 
 import { MicroserviceSimple } from '../../../apis/solutions/index';
 import { HttpResponseApplication } from '../../../apis/solutions/application';
+import { MicroserviceObject } from '../../../apis/solutions/api';
 
 // Check if there is microservice.edit data. If not, use microservice.live data.
-export const getMicroserviceInfo = (application: HttpResponseApplication, microservice: MicroserviceStore): MicroserviceSimple => {
+export const getMicroserviceInfo = (application: HttpResponseApplication, microservice: MicroserviceObject): MicroserviceSimple => {
     const canEdit = canEditMicroservice(application.environments, microservice.environment, microservice.id);
 
     if (canEdit) {

--- a/Source/SelfService/Web/applications/stores/microservice.ts
+++ b/Source/SelfService/Web/applications/stores/microservice.ts
@@ -4,7 +4,16 @@
 import { get, writable } from 'use-svelte-store';
 
 import { MicroserviceDolittle, MicroserviceSimple } from '../../apis/solutions/index';
-import { deleteMicroservice, editMicroservice, getMicroservices, HttpResponseMicroservices, InputEditMicroservice, MicroserviceInfo, saveMicroservice } from '../../apis/solutions/api';
+import {
+    deleteMicroservice,
+    editMicroservice,
+    getMicroservices, getMicroservicesWithPods,
+    HttpResponseMicroservices, HttpResponseMicroservicesWithPods,
+    InputEditMicroservice,
+    MicroserviceInfo,
+    MicroserviceInfoWithPods,
+    saveMicroservice
+} from '../../apis/solutions/api';
 import { getApplication, HttpResponseApplication, HttpInputApplicationEnvironment } from '../../apis/solutions/application';
 
 export type MicroserviceStore = {
@@ -12,12 +21,12 @@ export type MicroserviceStore = {
     name: string;
     kind: string;
     environment: string;
-    live: MicroserviceInfo;
+    live: MicroserviceInfoWithPods;
     edit: MicroserviceSimple;
 };
 
 const data = {
-    microservices: [] as MicroserviceInfo[],
+    microservices: [] as MicroserviceInfoWithPods[],
     isLoaded: false,
 };
 
@@ -31,7 +40,7 @@ export const loadMicroservices = (applicationId: string) => {
             const applicationData = values[0];
             mergeMicroservicesFromGit(applicationData.microservices);
 
-            const microservicesData = values[1] as HttpResponseMicroservices;
+            const microservicesData = values[1] as HttpResponseMicroservicesWithPods;
             mergeMicroservicesFromK8s(microservicesData.microservices);
 
             isLoaded.set(true);
@@ -74,7 +83,7 @@ export const mergeMicroservicesFromGit = (items: MicroserviceSimple[]) => {
     microservices.set(data);
 };
 
-export const mergeMicroservicesFromK8s = (items: MicroserviceInfo[]) => {
+export const mergeMicroservicesFromK8s = (items: MicroserviceInfoWithPods[]) => {
     let data = get(microservices);
 
     items.forEach(element => {
@@ -118,7 +127,7 @@ const saveMicroserviceWithStore = async (kind: string, input: MicroserviceSimple
     if (!response) return response;
 
     mergeMicroservicesFromGit(application.microservices);
-    const liveMicroservices = await getMicroservices(application.id);
+    const liveMicroservices = await getMicroservicesWithPods(application.id);
     mergeMicroservicesFromK8s(liveMicroservices.microservices);
 
     return response;

--- a/Source/SelfService/Web/applications/stores/microservice.ts
+++ b/Source/SelfService/Web/applications/stores/microservice.ts
@@ -11,19 +11,11 @@ import {
     HttpResponseMicroservices, HttpResponseMicroservicesWithPods,
     InputEditMicroservice,
     MicroserviceInfo,
-    MicroserviceInfoWithPods,
+    MicroserviceInfoWithPods, MicroserviceObject,
     saveMicroservice
 } from '../../apis/solutions/api';
 import { getApplication, HttpResponseApplication, HttpInputApplicationEnvironment } from '../../apis/solutions/application';
 
-export type MicroserviceStore = {
-    id: string;
-    name: string;
-    kind: string;
-    environment: string;
-    live: MicroserviceInfoWithPods;
-    edit: MicroserviceSimple;
-};
 
 const data = {
     microservices: [] as MicroserviceInfoWithPods[],
@@ -122,7 +114,7 @@ const saveMicroserviceWithStore = async (kind: string, input: MicroserviceSimple
         default:
             alert(`Saving via store failed. Kind: ${kind} not supported.`);
             return false;
-    };
+    }
 
     if (!response) return response;
 
@@ -139,7 +131,7 @@ export const saveSimpleMicroserviceWithStore = (input: MicroserviceSimple, appli
 export const canEditMicroservices = (environments: HttpInputApplicationEnvironment[], environment: string): boolean =>
     environments.some(info => info.name === environment && info.automationEnabled);
 
-export const findCurrentMicroservice = (microserviceId: string): MicroserviceStore => {
+export const findCurrentMicroservice = (microserviceId: string): MicroserviceObject => {
     const data = get(microservices);
     return data.find(ms => ms.id === microserviceId);
 };
@@ -147,7 +139,7 @@ export const findCurrentMicroservice = (microserviceId: string): MicroserviceSto
 export const canEditMicroservice = (environments: HttpInputApplicationEnvironment[], environment: string, microserviceId: string): boolean => {
     if (!canDeleteMicroservice(environments, environment, microserviceId)) return false;
 
-    const currentMicroservice: MicroserviceStore = findCurrentMicroservice(microserviceId);
+    const currentMicroservice: MicroserviceObject = findCurrentMicroservice(microserviceId);
     if (!currentMicroservice || !currentMicroservice?.edit?.dolittle) return false;
 
     const { id, kind } = currentMicroservice;
@@ -167,7 +159,7 @@ export const editMicroserviceWithStore = async (applicationId: string, environme
 };
 
 export const canDeleteMicroservice = (environments: HttpInputApplicationEnvironment[], environment: string, microserviceId: string): boolean => {
-    const currentMicroservice: MicroserviceStore = findCurrentMicroservice(microserviceId);
+    const currentMicroservice: MicroserviceObject = findCurrentMicroservice(microserviceId);
     if (!currentMicroservice) return false;
 
     return canEditMicroservices(environments, environment);
@@ -184,4 +176,4 @@ export async function deleteMicroserviceWithStore(applicationId: string, environ
     microservices.set(data);
 
     return response;
-};
+}


### PR DESCRIPTION
## Summary

Changed microservices to use the new endpoints which include pod status when listing services. This means each service does not need to individually call getpodstatus, and can render faster.

The new endpoint also uses the images which are actually used by the running pod, which means there will no longer be a stale runtime version.